### PR TITLE
chore: Bump version to 0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "snowflake-semantic-tools"
-version = "0.1.0"
+version = "0.1.1"
 description = "dbt extension for managing Snowflake Semantic Views and Cortex Analyst semantic models"
 readme = "README.md"
 authors = ["Matt Luizzi <matthew.luizzi@whoop.com>"]

--- a/snowflake_semantic_tools/_version.py
+++ b/snowflake_semantic_tools/_version.py
@@ -1,3 +1,3 @@
 """Version information for snowflake-semantic-tools."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"


### PR DESCRIPTION
## Description

Bump version from 0.1.0 to 0.1.1 in preparation for the next PyPI release.

## Type of Change

- [x] Other (version bump for release)

## Changes Made

- Updated `version = "0.1.1"` in `pyproject.toml`
- Updated `__version__ = "0.1.1"` in `snowflake_semantic_tools/_version.py`

This ensures that:
- `sst --version` displays the correct version
- PyPI package metadata matches the release tag
- The GitHub Actions workflow validation passes (checks that tag version matches pyproject.toml)

## Testing

- [x] Version string updated in both locations
- [x] No functional changes (version bump only)

## Checklist

### Code Quality
- [x] Code follows the project's style guidelines
- [x] No linting errors (version bump only)

### Documentation & Compatibility
- [x] No breaking changes
- [x] Version bump only, no functional changes

## Additional Notes

This PR should be merged before creating the `v0.1.1` release tag. After merging, the release workflow will:
1. Verify tag version matches `pyproject.toml` version ✅
2. Build and publish to PyPI automatically
