### PR TITLE
fix: use universally available Cortex model and fail loudly on invalid config (#18)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -160,8 +160,8 @@ Control LLM behavior in `sst_config.yaml`:
 
 ```yaml
 enrichment:
-  # LLM model for synonym generation
-  synonym_model: 'openai-gpt-4.1'  # Options: openai-gpt-4.1, mistral-large, etc.
+  # LLM model for synonym generation (mistral-large2 is universally available)
+  synonym_model: 'mistral-large2'  # Options: mistral-large2, llama3.1-70b, etc.
   
   # Maximum synonyms per table/column
   synonym_max_count: 4

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -106,8 +106,11 @@ validation:
 enrichment:
   distinct_limit: 25                    # Distinct values to fetch
   sample_values_display_limit: 10       # Sample values to show
-  synonym_model: 'openai-gpt-4.1'       # LLM for synonyms
+  synonym_model: 'mistral-large2'       # LLM for synonyms (universally available)
   synonym_max_count: 4                  # Max synonyms per field
+  
+  # Alternative models: llama3.1-70b, mixtral-8x7b, claude-3-5-sonnet
+  # OpenAI models require Azure or cross-region inference enabled
 ```
 
 **Required fields:**
@@ -435,6 +438,32 @@ con = snowflake.connector.connect(insecure_mode=True)
 ```
 
 **Note:** Snowflake is actively working on a permanent fix. Monitor [status.snowflake.com](https://status.snowflake.com/) for updates.
+
+### "Model unavailable" during synonym generation
+
+**Problem:** Cortex model not available error when running `sst enrich --synonyms`:
+```
+Model "openai-gpt-4.1" is unavailable
+```
+
+**Cause:** OpenAI models (gpt-4.1, gpt-5, etc.) are only available on Snowflake accounts hosted on Azure, or require cross-region inference to be enabled.
+
+**Solution 1 (Recommended):** Use a universally available model in `sst_config.yml`:
+```yaml
+enrichment:
+  synonym_model: 'mistral-large2'  # Works on AWS, Azure, GCP
+```
+
+Other universally available models:
+- `llama3.1-70b`, `llama3.1-8b` (Meta open models)
+- `mixtral-8x7b`, `mistral-7b` (fast, lower cost)
+
+**Solution 2:** Enable cross-region inference (requires ACCOUNTADMIN):
+```sql
+ALTER ACCOUNT SET CORTEX_ENABLED_CROSS_REGION = 'AZURE_US';
+```
+
+**See:** [Snowflake Cortex Model Availability](https://docs.snowflake.com/en/user-guide/snowflake-cortex/llm-functions#availability) for models available in your region.
 
 ---
 

--- a/snowflake_semantic_tools/shared/config.py
+++ b/snowflake_semantic_tools/shared/config.py
@@ -94,7 +94,7 @@ class Config:
                 "distinct_limit": 25,  # Number of distinct values to fetch (accounts for null)
                 "sample_values_display_limit": 10,  # Number of sample values to display in YAML
                 "generate_synonyms": False,  # Auto-generate synonyms using Cortex LLM
-                "synonym_model": "mistral-large",  # LLM model for synonym generation
+                "synonym_model": "mistral-large2",  # LLM model (universally available on AWS/Azure/GCP)
                 "synonym_max_count": 4,  # Maximum synonyms per table/column
                 "generate_column_synonyms": True,  # Also generate column-level synonyms
             },
@@ -220,8 +220,8 @@ class Config:
         return self.get("enrichment.sample_values_display_limit", 10)
 
     def get_synonym_model(self) -> str:
-        """Get LLM model for synonym generation (default: openai-gpt-4.1)."""
-        return self.get("enrichment.synonym_model", "openai-gpt-4.1")
+        """Get LLM model for synonym generation (default: mistral-large2)."""
+        return self.get("enrichment.synonym_model", "mistral-large2")
 
     def get_synonym_max_count(self) -> int:
         """Get maximum number of synonyms to generate (default: 4)."""

--- a/snowflake_semantic_tools/shared/config_utils.py
+++ b/snowflake_semantic_tools/shared/config_utils.py
@@ -99,7 +99,7 @@ def get_synonym_config() -> Dict[str, Any]:
     Get synonym generation configuration from config.
 
     Returns dictionary with:
-    - model: LLM model to use (e.g., 'openai-gpt-4.1', 'claude-4-sonnet')
+    - model: LLM model to use (e.g., 'mistral-large2', 'llama3.1-70b')
     - max_count: Maximum synonyms per table/column
 
     Uses config values with sensible defaults.
@@ -110,7 +110,7 @@ def get_synonym_config() -> Dict[str, Any]:
     Example:
         >>> config = get_synonym_config()
         >>> config['model']
-        'openai-gpt-4.1'
+        'mistral-large2'
         >>> config['max_count']
         4
     """
@@ -118,7 +118,7 @@ def get_synonym_config() -> Dict[str, Any]:
     enrichment_config = config.get("enrichment", {})
 
     return {
-        "model": enrichment_config.get("synonym_model", "openai-gpt-4.1"),
+        "model": enrichment_config.get("synonym_model", "mistral-large2"),
         "max_count": enrichment_config.get("synonym_max_count", 4),
     }
 

--- a/snowflake_semantic_tools/shared/config_validator.py
+++ b/snowflake_semantic_tools/shared/config_validator.py
@@ -76,7 +76,7 @@ def validate_config(
         ("validation.exclude_dirs", "Recommended: List of directories to exclude from validation", []),
         ("enrichment.distinct_limit", "Optional: Number of distinct values to fetch during enrichment", 25),
         ("enrichment.sample_values_display_limit", "Optional: Number of sample values to show in YAML files", 10),
-        ("enrichment.synonym_model", "Optional: LLM model for synonym generation", "openai-gpt-5"),
+        ("enrichment.synonym_model", "Optional: LLM model for synonym generation", "mistral-large2"),
         ("enrichment.synonym_max_count", "Optional: Maximum synonyms per table/column", 4),
     ]
 

--- a/sst_config.yml.example
+++ b/sst_config.yml.example
@@ -25,5 +25,9 @@ validation:
 enrichment:
   distinct_limit: 25                                # Distinct values to fetch from Snowflake
   sample_values_display_limit: 10                   # Sample values to show in YAML files
-  synonym_model: 'openai-gpt-5'                     # LLM model for synonym generation (openai-gpt-5, claude-4-sonnet, etc.)
   synonym_max_count: 4                              # Maximum synonyms per table/column
+  synonym_model: 'mistral-large2'                   # Snowflake Cortex LLM model for synonym generation      
+  # Default: mistral-large2 (universally available on AWS, Azure, GCP)
+  #
+  # Check model availability for your region:
+  #   https://docs.snowflake.com/en/user-guide/snowflake-cortex/llm-functions#availability

--- a/tests/unit/core/enrichment/test_cortex_synonym_generator.py
+++ b/tests/unit/core/enrichment/test_cortex_synonym_generator.py
@@ -21,236 +21,196 @@ def mock_snowflake_client():
 @pytest.fixture
 def synonym_generator(mock_snowflake_client):
     """Create a CortexSynonymGenerator instance."""
-    return CortexSynonymGenerator(
-        snowflake_client=mock_snowflake_client,
-        model='gpt-4o',
-        max_synonyms=4
-    )
+    return CortexSynonymGenerator(snowflake_client=mock_snowflake_client, model="gpt-4o", max_synonyms=4)
 
 
 class TestCortexSynonymGenerator:
     """Test suite for CortexSynonymGenerator."""
-    
+
     def test_init(self, mock_snowflake_client):
         """Test initialization with default parameters."""
-        generator = CortexSynonymGenerator(
-            snowflake_client=mock_snowflake_client,
-            model='gpt-4o',
-            max_synonyms=4
-        )
-        
+        generator = CortexSynonymGenerator(snowflake_client=mock_snowflake_client, model="gpt-4o", max_synonyms=4)
+
         assert generator.snowflake_client == mock_snowflake_client
-        assert generator.model == 'gpt-4o'
+        assert generator.model == "gpt-4o"
         assert generator.max_synonyms == 4
-    
+
     def test_init_custom_model(self, mock_snowflake_client):
         """Test initialization with custom model."""
         generator = CortexSynonymGenerator(
-            snowflake_client=mock_snowflake_client,
-            model='mistral-large',
-            max_synonyms=3
+            snowflake_client=mock_snowflake_client, model="mistral-large", max_synonyms=3
         )
-        
-        assert generator.model == 'mistral-large'
+
+        assert generator.model == "mistral-large"
         assert generator.max_synonyms == 3
-    
+
     def test_generate_table_synonyms_skips_existing(self, synonym_generator):
         """Test that existing synonyms are preserved."""
-        existing = ['existing synonym', 'another one']
-        
+        existing = ["existing synonym", "another one"]
+
         result = synonym_generator.generate_table_synonyms(
-            table_name='test_table',
-            description='Test description',
-            column_info=[],
-            existing_synonyms=existing
+            table_name="test_table", description="Test description", column_info=[], existing_synonyms=existing
         )
-        
+
         assert result == existing
-    
+
     def test_generate_table_synonyms_success(self, synonym_generator, mock_snowflake_client):
         """Test successful synonym generation with structured output."""
         # Mock Cortex structured response
-        mock_df = pd.DataFrame({
-            'RESPONSE': ['{"synonyms": ["member analytics", "subscription data", "user metrics"]}']
-        })
-        mock_snowflake_client.execute_query.return_value = mock_df
-        
-        result = synonym_generator.generate_table_synonyms(
-            table_name='churn_details',
-            description='Member churn analysis',
-            column_info=[
-                {'name': 'user_id', 'description': 'User identifier'},
-                {'name': 'churn_date', 'description': 'Date of churn'}
-            ]
+        mock_df = pd.DataFrame(
+            {"RESPONSE": ['{"synonyms": ["member analytics", "subscription data", "user metrics"]}']}
         )
-        
+        mock_snowflake_client.execute_query.return_value = mock_df
+
+        result = synonym_generator.generate_table_synonyms(
+            table_name="churn_details",
+            description="Member churn analysis",
+            column_info=[
+                {"name": "user_id", "description": "User identifier"},
+                {"name": "churn_date", "description": "Date of churn"},
+            ],
+        )
+
         assert len(result) == 3
-        assert 'member analytics' in result
-        assert 'subscription data' in result
-        assert 'user metrics' in result
-    
+        assert "member analytics" in result
+        assert "subscription data" in result
+        assert "user metrics" in result
+
     def test_cortex_invalid_json_returns_empty(self, synonym_generator, mock_snowflake_client):
         """Test that invalid JSON returns empty list (no fallback)."""
         # Mock invalid JSON response (shouldn't happen with structured outputs)
-        mock_df = pd.DataFrame({
-            'RESPONSE': ['Invalid response']
-        })
+        mock_df = pd.DataFrame({"RESPONSE": ["Invalid response"]})
         mock_snowflake_client.execute_query.return_value = mock_df
-        
-        result = synonym_generator.generate_table_synonyms(
-            table_name='test_table',
-            description='Test',
-            column_info=[]
-        )
-        
+
+        result = synonym_generator.generate_table_synonyms(table_name="test_table", description="Test", column_info=[])
+
         # Should return empty (no fallback)
         assert result == []
-    
-    def test_cortex_empty_response_returns_empty(self, synonym_generator, mock_snowflake_client):
-        """Test that empty Cortex response returns empty list (no fallback)."""
+
+    def test_cortex_empty_response_raises_error(self, synonym_generator, mock_snowflake_client):
+        """Test that empty Cortex response raises RuntimeError (fail loudly)."""
         mock_df = pd.DataFrame()
         mock_snowflake_client.execute_query.return_value = mock_df
-        
-        result = synonym_generator.generate_table_synonyms(
-            table_name='test_table',
-            description='Test',
-            column_info=[]
-        )
-        
-        # Should return empty (no fallback)
-        assert result == []
-    
-    def test_cortex_exception_returns_empty(self, synonym_generator, mock_snowflake_client):
-        """Test that Cortex exceptions return empty list (no fallback)."""
+
+        with pytest.raises(RuntimeError) as exc_info:
+            synonym_generator.generate_table_synonyms(table_name="test_table", description="Test", column_info=[])
+
+        # Should fail loudly with clear error
+        assert "empty response" in str(exc_info.value).lower()
+
+    def test_cortex_exception_raises_error(self, synonym_generator, mock_snowflake_client):
+        """Test that Cortex exceptions are raised (fail loudly)."""
         mock_snowflake_client.execute_query.side_effect = Exception("Cortex error")
-        
-        result = synonym_generator.generate_table_synonyms(
-            table_name='error_table',
-            description='Test',
-            column_info=[]
-        )
-        
-        # Should return empty (no fallback)
-        assert result == []
-    
+
+        with pytest.raises(RuntimeError) as exc_info:
+            synonym_generator.generate_table_synonyms(table_name="error_table", description="Test", column_info=[])
+
+        # Should fail loudly
+        assert "error_table" in str(exc_info.value) or "Cortex error" in str(exc_info.value)
+
     def test_build_table_synonym_prompt(self, synonym_generator):
         """Test table synonym prompt construction."""
         column_info = [
-            {'name': 'user_id', 'description': 'User ID', 'sample_values': [1, 2, 3]},
-            {'name': 'date', 'description': 'Date', 'sample_values': ['2024-01-01']}
+            {"name": "user_id", "description": "User ID", "sample_values": [1, 2, 3]},
+            {"name": "date", "description": "Date", "sample_values": ["2024-01-01"]},
         ]
-        
+
         prompt = synonym_generator._build_table_synonym_prompt(
-            'churn_details',
-            'Member churn tracking',
-            synonym_generator._build_column_context(column_info)
+            "churn_details", "Member churn tracking", synonym_generator._build_column_context(column_info)
         )
-        
-        assert 'churn_details' in prompt
-        assert 'Member churn tracking' in prompt
-        assert 'user_id' in prompt
-        assert 'synonyms' in prompt  # References the array in structured output
-    
+
+        assert "churn_details" in prompt
+        assert "Member churn tracking" in prompt
+        assert "user_id" in prompt
+        assert "synonyms" in prompt  # References the array in structured output
+
     def test_build_batch_column_synonym_prompt(self, synonym_generator):
         """Test batch column synonym prompt construction."""
         columns = [
-            {'name': 'user_id', 'description': 'User ID', 'meta': {'sst': {'data_type': 'NUMBER', 'sample_values': [1, 2, 3]}}},
-            {'name': 'email', 'description': 'Email address', 'meta': {'sst': {'data_type': 'VARCHAR', 'sample_values': ['a@b.com']}}}
+            {
+                "name": "user_id",
+                "description": "User ID",
+                "meta": {"sst": {"data_type": "NUMBER", "sample_values": [1, 2, 3]}},
+            },
+            {
+                "name": "email",
+                "description": "Email address",
+                "meta": {"sst": {"data_type": "VARCHAR", "sample_values": ["a@b.com"]}},
+            },
         ]
-        
-        prompt = synonym_generator._build_batch_column_synonym_prompt(
-            'users',
-            columns,
-            'User table'
-        )
-        
-        assert 'user_id' in prompt
-        assert 'email' in prompt
-        assert 'JSON object' in prompt
-        assert 'EACH column' in prompt
-    
+
+        prompt = synonym_generator._build_batch_column_synonym_prompt("users", columns, "User table")
+
+        assert "user_id" in prompt
+        assert "email" in prompt
+        assert "JSON object" in prompt
+        assert "EACH column" in prompt
+
     def test_synonym_count_limit(self, synonym_generator, mock_snowflake_client):
         """Test that synonyms are limited to max_synonyms via JSON schema."""
         # Mock structured response - schema should enforce max
-        mock_df = pd.DataFrame({
-            'RESPONSE': ['{"synonyms": ["syn1", "syn2", "syn3", "syn4"]}']
-        })
+        mock_df = pd.DataFrame({"RESPONSE": ['{"synonyms": ["syn1", "syn2", "syn3", "syn4"]}']})
         mock_snowflake_client.execute_query.return_value = mock_df
-        
-        result = synonym_generator.generate_table_synonyms(
-            table_name='test',
-            description='Test',
-            column_info=[]
-        )
-        
+
+        result = synonym_generator.generate_table_synonyms(table_name="test", description="Test", column_info=[])
+
         # Should be limited to max_synonyms (4)
         assert len(result) <= 4
-    
+
     def test_sql_escaping(self, synonym_generator, mock_snowflake_client):
         """Test that single quotes are properly escaped in prompts."""
-        mock_df = pd.DataFrame({'RESPONSE': ['["test"]']})
+        mock_df = pd.DataFrame({"RESPONSE": ['["test"]']})
         mock_snowflake_client.execute_query.return_value = mock_df
-        
+
         # Description with single quotes
         synonym_generator.generate_table_synonyms(
-            table_name='test',
-            description="User's membership data",
-            column_info=[]
+            table_name="test", description="User's membership data", column_info=[]
         )
-        
+
         # Check that query was called with escaped quotes
         called_query = mock_snowflake_client.execute_query.call_args[0][0]
         assert "''" in called_query  # Should have escaped quotes
         assert "User''s" in called_query
 
-
     def test_batch_column_synonyms_success(self, synonym_generator, mock_snowflake_client):
         """Test batch column synonym generation."""
         # Mock batch response
-        mock_df = pd.DataFrame({
-            'RESPONSE': ['{"col1": ["synonym 1", "synonym 2"], "col2": ["synonym a", "synonym b"]}']
-        })
-        mock_snowflake_client.execute_query.return_value = mock_df
-        
-        columns = [
-            {'name': 'col1', 'description': 'Column 1', 'meta': {'sst': {'data_type': 'VARCHAR'}}},
-            {'name': 'col2', 'description': 'Column 2', 'meta': {'sst': {'data_type': 'NUMBER'}}}
-        ]
-        
-        result = synonym_generator.generate_column_synonyms_batch(
-            table_name='test_table',
-            columns=columns
+        mock_df = pd.DataFrame(
+            {"RESPONSE": ['{"col1": ["synonym 1", "synonym 2"], "col2": ["synonym a", "synonym b"]}']}
         )
-        
-        assert 'col1' in result
-        assert 'col2' in result
-        assert len(result['col1']) == 2
-        assert len(result['col2']) == 2
-        assert 'synonym 1' in result['col1']
+        mock_snowflake_client.execute_query.return_value = mock_df
+
+        columns = [
+            {"name": "col1", "description": "Column 1", "meta": {"sst": {"data_type": "VARCHAR"}}},
+            {"name": "col2", "description": "Column 2", "meta": {"sst": {"data_type": "NUMBER"}}},
+        ]
+
+        result = synonym_generator.generate_column_synonyms_batch(table_name="test_table", columns=columns)
+
+        assert "col1" in result
+        assert "col2" in result
+        assert len(result["col1"]) == 2
+        assert len(result["col2"]) == 2
+        assert "synonym 1" in result["col1"]
 
     def test_batch_column_synonyms_markdown_fence(self, synonym_generator, mock_snowflake_client):
         """Test that markdown code fences are stripped from Cortex response."""
         # Mock response with markdown code fence (common Cortex behavior)
-        mock_df = pd.DataFrame({
-            'RESPONSE': ['```json\n{"col1": ["synonym 1"], "col2": ["synonym 2"]}\n```']
-        })
+        mock_df = pd.DataFrame({"RESPONSE": ['```json\n{"col1": ["synonym 1"], "col2": ["synonym 2"]}\n```']})
         mock_snowflake_client.execute_query.return_value = mock_df
-        
+
         columns = [
-            {'name': 'col1', 'description': 'Column 1', 'meta': {'sst': {'data_type': 'VARCHAR'}}},
-            {'name': 'col2', 'description': 'Column 2', 'meta': {'sst': {'data_type': 'NUMBER'}}}
+            {"name": "col1", "description": "Column 1", "meta": {"sst": {"data_type": "VARCHAR"}}},
+            {"name": "col2", "description": "Column 2", "meta": {"sst": {"data_type": "NUMBER"}}},
         ]
-        
-        result = synonym_generator.generate_column_synonyms_batch(
-            table_name='test_table',
-            columns=columns
-        )
-        
+
+        result = synonym_generator.generate_column_synonyms_batch(table_name="test_table", columns=columns)
+
         # Should successfully parse despite markdown fence
-        assert 'col1' in result
-        assert 'col2' in result
-        assert result['col1'] == ['synonym 1']
-        assert result['col2'] == ['synonym 2']
+        assert "col1" in result
+        assert "col2" in result
+        assert result["col1"] == ["synonym 1"]
+        assert result["col2"] == ["synonym 2"]
 
     def test_extract_json_with_preamble_text(self, synonym_generator):
         """Test JSON extraction when LLM adds preamble text."""
@@ -278,89 +238,155 @@ class TestCortexSynonymGenerator:
 
 class TestCortexVerification:
     """Test Cortex access verification and error handling."""
-    
+
     @pytest.fixture
     def mock_snowflake_client(self):
         """Create a mock Snowflake client."""
         client = Mock()
         return client
-    
+
     def test_verify_cortex_access_success(self, mock_snowflake_client):
         """Test successful Cortex verification."""
-        mock_df = pd.DataFrame({'RESPONSE': ['Hello!']})
+        mock_df = pd.DataFrame({"RESPONSE": ["Hello!"]})
         mock_snowflake_client.execute_query.return_value = mock_df
-        
+
         generator = CortexSynonymGenerator(mock_snowflake_client)
         assert generator._cortex_verified is False
-        
+
         # Trigger verification via _execute_cortex
         generator._execute_cortex("test prompt")
-        
+
         assert generator._cortex_verified is True
-    
+
     def test_verify_cortex_access_permission_error(self, mock_snowflake_client):
         """Test Cortex permission error provides helpful message."""
         mock_snowflake_client.execute_query.side_effect = Exception("access denied to function")
-        
+
         generator = CortexSynonymGenerator(mock_snowflake_client)
-        
+
         with pytest.raises(RuntimeError) as exc_info:
             generator._verify_cortex_access()
-        
+
         error_msg = str(exc_info.value)
         assert "permission error" in error_msg.lower()
         assert "CORTEX_USER" in error_msg
-    
+
     def test_verify_cortex_access_model_not_found(self, mock_snowflake_client):
         """Test Cortex model not found error provides helpful message."""
         mock_snowflake_client.execute_query.side_effect = Exception("model not found")
-        
+
         generator = CortexSynonymGenerator(mock_snowflake_client)
-        
+
         with pytest.raises(RuntimeError) as exc_info:
             generator._verify_cortex_access()
-        
+
         error_msg = str(exc_info.value)
         assert "not available" in error_msg.lower()
-        assert "openai-gpt-4.1" in error_msg  # Default model
-    
+        assert "mistral-large2" in error_msg  # Default model
+        assert "docs.snowflake.com" in error_msg  # Link to availability docs
+
     def test_verify_cortex_access_generic_error(self, mock_snowflake_client):
         """Test Cortex generic error provides connection guidance."""
         mock_snowflake_client.execute_query.side_effect = Exception("some other error")
-        
+
         generator = CortexSynonymGenerator(mock_snowflake_client)
-        
+
         with pytest.raises(RuntimeError) as exc_info:
             generator._verify_cortex_access()
-        
+
         error_msg = str(exc_info.value)
         assert "connection failed" in error_msg.lower()
-    
+
     def test_verify_cortex_access_only_called_once(self, mock_snowflake_client):
         """Test Cortex verification is only performed once."""
-        mock_df = pd.DataFrame({'RESPONSE': ['Hello!']})
+        mock_df = pd.DataFrame({"RESPONSE": ["Hello!"]})
         mock_snowflake_client.execute_query.return_value = mock_df
-        
+
         generator = CortexSynonymGenerator(mock_snowflake_client)
         generator._verify_cortex_access()
         generator._verify_cortex_access()
         generator._verify_cortex_access()
-        
+
         # Should only have called execute_query once for verification
         # (subsequent calls skip because _cortex_verified is True)
         assert mock_snowflake_client.execute_query.call_count == 1
-    
-    def test_generate_synonyms_returns_empty_on_cortex_error(self, mock_snowflake_client):
-        """Test that synonym generation gracefully returns empty on Cortex error."""
+
+    def test_generate_synonyms_raises_on_cortex_error(self, mock_snowflake_client):
+        """Test that synonym generation fails loudly on Cortex error."""
         mock_snowflake_client.execute_query.side_effect = Exception("access denied")
-        
+
         generator = CortexSynonymGenerator(mock_snowflake_client)
-        
-        # Should return empty list, not raise
-        result = generator.generate_table_synonyms(
-            table_name='test',
-            description='Test table',
-            column_info=[]
-        )
-        
-        assert result == []
+
+        # Should raise RuntimeError, not silently return empty
+        with pytest.raises(RuntimeError) as exc_info:
+            generator.generate_table_synonyms(table_name="test", description="Test table", column_info=[])
+
+        # Error should contain helpful information
+        error_msg = str(exc_info.value)
+        assert "permission error" in error_msg.lower() or "access" in error_msg.lower()
+
+    def test_verify_cortex_model_unavailable_error(self, mock_snowflake_client):
+        """Test that 'unavailable' error provides helpful cross-region guidance."""
+        mock_snowflake_client.execute_query.side_effect = Exception('Model "openai-gpt-4.1" is unavailable')
+
+        # Test with an OpenAI model to trigger cross-region guidance
+        generator = CortexSynonymGenerator(mock_snowflake_client, model="openai-gpt-4.1")
+
+        with pytest.raises(RuntimeError) as exc_info:
+            generator._verify_cortex_access()
+
+        error_msg = str(exc_info.value)
+        # Should include model name
+        assert "openai-gpt-4.1" in error_msg
+        # Should include cross-region inference guidance for OpenAI models
+        assert "cross-region" in error_msg.lower()
+        assert "CORTEX_ENABLED_CROSS_REGION" in error_msg
+        # Should suggest universally available models
+        assert "mistral-large2" in error_msg
+        # Should include link to availability docs
+        assert "docs.snowflake.com" in error_msg
+        assert "availability" in error_msg.lower()
+
+    def test_verify_cortex_non_openai_model_unavailable(self, mock_snowflake_client):
+        """Test that non-OpenAI model unavailable error doesn't mention cross-region."""
+        mock_snowflake_client.execute_query.side_effect = Exception('Model "some-custom-model" is unavailable')
+
+        generator = CortexSynonymGenerator(mock_snowflake_client, model="some-custom-model")
+
+        with pytest.raises(RuntimeError) as exc_info:
+            generator._verify_cortex_access()
+
+        error_msg = str(exc_info.value)
+        # Should include model name
+        assert "some-custom-model" in error_msg
+        # Should NOT include cross-region guidance (not an OpenAI model)
+        assert "CORTEX_ENABLED_CROSS_REGION" not in error_msg
+        # Should still suggest universally available models
+        assert "mistral-large2" in error_msg
+
+    def test_default_model_is_mistral_large2(self, mock_snowflake_client):
+        """Test that the default model is mistral-large2 (universally available)."""
+        generator = CortexSynonymGenerator(mock_snowflake_client)
+        assert generator.model == "mistral-large2"
+
+    def test_build_model_unavailable_error_openai_model(self, mock_snowflake_client):
+        """Test _build_model_unavailable_error for OpenAI models includes cross-region info."""
+        generator = CortexSynonymGenerator(mock_snowflake_client, model="gpt-4.1")
+
+        error_msg = generator._build_model_unavailable_error("test error")
+
+        assert "gpt-4.1" in error_msg
+        assert "cross-region" in error_msg.lower()
+        assert "AZURE_US" in error_msg
+
+    def test_build_model_unavailable_error_non_openai_model(self, mock_snowflake_client):
+        """Test _build_model_unavailable_error for non-OpenAI models excludes cross-region info."""
+        generator = CortexSynonymGenerator(mock_snowflake_client, model="llama3.1-70b")
+
+        error_msg = generator._build_model_unavailable_error("test error")
+
+        assert "llama3.1-70b" in error_msg
+        # Should not include cross-region for non-OpenAI models
+        assert "CORTEX_ENABLED_CROSS_REGION" not in error_msg
+        # But should still suggest alternatives
+        assert "mistral-large2" in error_msg

--- a/tests/unit/shared/test_config_utils.py
+++ b/tests/unit/shared/test_config_utils.py
@@ -15,230 +15,223 @@ from snowflake_semantic_tools.shared.config_utils import (
     get_synonym_config,
     get_project_paths,
     is_strict_mode,
-    get_exclusion_summary
+    get_exclusion_summary,
 )
 
 
 class TestGetExclusionPatterns:
     """Test exclusion pattern retrieval and merging."""
-    
-    @patch('snowflake_semantic_tools.shared.config_utils.get_config')
+
+    @patch("snowflake_semantic_tools.shared.config_utils.get_config")
     def test_no_exclusions(self, mock_get_config):
         """Test when no exclusions configured."""
         mock_config = Mock()
         mock_config.get_exclude_dirs.return_value = None
         mock_get_config.return_value = mock_config
-        
+
         result = get_exclusion_patterns()
         assert result is None
-    
-    @patch('snowflake_semantic_tools.shared.config_utils.get_config')
+
+    @patch("snowflake_semantic_tools.shared.config_utils.get_config")
     def test_config_exclusions_only(self, mock_get_config):
         """Test with only config file exclusions."""
         mock_config = Mock()
-        mock_config.get_exclude_dirs.return_value = ['models/amplitude/*', 'models/analytics_mart/*']
+        mock_config.get_exclude_dirs.return_value = ["models/amplitude/*", "models/analytics_mart/*"]
         mock_get_config.return_value = mock_config
-        
+
         result = get_exclusion_patterns()
-        assert result == ['models/amplitude/*', 'models/analytics_mart/*']
-    
-    @patch('snowflake_semantic_tools.shared.config_utils.get_config')
+        assert result == ["models/amplitude/*", "models/analytics_mart/*"]
+
+    @patch("snowflake_semantic_tools.shared.config_utils.get_config")
     def test_cli_exclusions_only(self, mock_get_config):
         """Test with only CLI exclusions."""
         mock_config = Mock()
         mock_config.get_exclude_dirs.return_value = None
         mock_get_config.return_value = mock_config
-        
+
         result = get_exclusion_patterns(cli_exclude="temp,backup")
-        assert result == ['temp', 'backup']
-    
-    @patch('snowflake_semantic_tools.shared.config_utils.get_config')
+        assert result == ["temp", "backup"]
+
+    @patch("snowflake_semantic_tools.shared.config_utils.get_config")
     def test_merged_exclusions(self, mock_get_config):
         """Test merging config and CLI exclusions."""
         mock_config = Mock()
-        mock_config.get_exclude_dirs.return_value = ['models/amplitude/*']
+        mock_config.get_exclude_dirs.return_value = ["models/amplitude/*"]
         mock_get_config.return_value = mock_config
-        
+
         result = get_exclusion_patterns(cli_exclude="temp,experimental")
-        assert result == ['models/amplitude/*', 'temp', 'experimental']
-    
-    @patch('snowflake_semantic_tools.shared.config_utils.get_config')
+        assert result == ["models/amplitude/*", "temp", "experimental"]
+
+    @patch("snowflake_semantic_tools.shared.config_utils.get_config")
     def test_deduplication(self, mock_get_config):
         """Test that duplicates are removed."""
         mock_config = Mock()
-        mock_config.get_exclude_dirs.return_value = ['temp', 'backup']
+        mock_config.get_exclude_dirs.return_value = ["temp", "backup"]
         mock_get_config.return_value = mock_config
-        
+
         result = get_exclusion_patterns(cli_exclude="temp,staging")
-        assert result == ['temp', 'backup', 'staging']  # 'temp' only appears once
-    
-    @patch('snowflake_semantic_tools.shared.config_utils.get_config')
+        assert result == ["temp", "backup", "staging"]  # 'temp' only appears once
+
+    @patch("snowflake_semantic_tools.shared.config_utils.get_config")
     def test_order_preservation(self, mock_get_config):
         """Test that order is preserved (config first, then CLI)."""
         mock_config = Mock()
-        mock_config.get_exclude_dirs.return_value = ['a', 'b']
+        mock_config.get_exclude_dirs.return_value = ["a", "b"]
         mock_get_config.return_value = mock_config
-        
+
         result = get_exclusion_patterns(cli_exclude="c,d")
-        assert result == ['a', 'b', 'c', 'd']
-    
-    @patch('snowflake_semantic_tools.shared.config_utils.get_config')
+        assert result == ["a", "b", "c", "d"]
+
+    @patch("snowflake_semantic_tools.shared.config_utils.get_config")
     def test_whitespace_handling(self, mock_get_config):
         """Test that whitespace in CLI input is trimmed."""
         mock_config = Mock()
         mock_config.get_exclude_dirs.return_value = []
         mock_get_config.return_value = mock_config
-        
+
         result = get_exclusion_patterns(cli_exclude=" temp , backup , staging ")
-        assert result == ['temp', 'backup', 'staging']
+        assert result == ["temp", "backup", "staging"]
 
 
 class TestGetEnrichmentLimits:
     """Test enrichment limit retrieval."""
-    
-    @patch('snowflake_semantic_tools.shared.config_utils.get_config')
+
+    @patch("snowflake_semantic_tools.shared.config_utils.get_config")
     def test_default_limits(self, mock_get_config):
         """Test default limits when not configured."""
         mock_config = Mock()
         mock_config.get.return_value = {}
         mock_get_config.return_value = mock_config
-        
+
         result = get_enrichment_limits()
-        assert result['distinct_limit'] == 25
-        assert result['sample_values_display_limit'] == 10
-    
-    @patch('snowflake_semantic_tools.shared.config_utils.get_config')
+        assert result["distinct_limit"] == 25
+        assert result["sample_values_display_limit"] == 10
+
+    @patch("snowflake_semantic_tools.shared.config_utils.get_config")
     def test_custom_limits(self, mock_get_config):
         """Test custom limits from config."""
         mock_config = Mock()
-        mock_config.get.return_value = {
-            'distinct_limit': 50,
-            'sample_values_display_limit': 20
-        }
+        mock_config.get.return_value = {"distinct_limit": 50, "sample_values_display_limit": 20}
         mock_get_config.return_value = mock_config
-        
+
         result = get_enrichment_limits()
-        assert result['distinct_limit'] == 50
-        assert result['sample_values_display_limit'] == 20
+        assert result["distinct_limit"] == 50
+        assert result["sample_values_display_limit"] == 20
 
 
 class TestGetSynonymConfig:
     """Test synonym configuration retrieval."""
-    
-    @patch('snowflake_semantic_tools.shared.config_utils.get_config')
+
+    @patch("snowflake_semantic_tools.shared.config_utils.get_config")
     def test_default_synonym_config(self, mock_get_config):
         """Test default synonym config."""
         mock_config = Mock()
         mock_config.get.return_value = {}
         mock_get_config.return_value = mock_config
-        
+
         result = get_synonym_config()
-        assert result['model'] == 'openai-gpt-4.1'
-        assert result['max_count'] == 4
-    
-    @patch('snowflake_semantic_tools.shared.config_utils.get_config')
+        assert result["model"] == "mistral-large2"  # Universal default
+        assert result["max_count"] == 4
+
+    @patch("snowflake_semantic_tools.shared.config_utils.get_config")
     def test_custom_synonym_config(self, mock_get_config):
         """Test custom synonym config."""
         mock_config = Mock()
-        mock_config.get.return_value = {
-            'synonym_model': 'claude-4-sonnet',
-            'synonym_max_count': 6
-        }
+        mock_config.get.return_value = {"synonym_model": "claude-4-sonnet", "synonym_max_count": 6}
         mock_get_config.return_value = mock_config
-        
+
         result = get_synonym_config()
-        assert result['model'] == 'claude-4-sonnet'
-        assert result['max_count'] == 6
+        assert result["model"] == "claude-4-sonnet"
+        assert result["max_count"] == 6
 
 
 class TestGetProjectPaths:
     """Test project path resolution."""
-    
-    @patch('snowflake_semantic_tools.shared.config_utils.get_config')
-    @patch('snowflake_semantic_tools.shared.config_utils.Path.cwd')
+
+    @patch("snowflake_semantic_tools.shared.config_utils.get_config")
+    @patch("snowflake_semantic_tools.shared.config_utils.Path.cwd")
     def test_default_paths(self, mock_cwd, mock_get_config):
         """Test default project paths."""
-        mock_cwd.return_value = Path('/project')
+        mock_cwd.return_value = Path("/project")
         mock_config = Mock()
         mock_config.get.return_value = {}
         mock_get_config.return_value = mock_config
-        
+
         result = get_project_paths()
-        assert result['dbt_models_dir'] == Path('/project/models')
-        assert result['semantic_models_dir'] == Path('/project/snowflake_semantic_models')
-        assert result['manifest_path'] == Path('/project/target/manifest.json')
-    
-    @patch('snowflake_semantic_tools.shared.config_utils.get_config')
-    @patch('snowflake_semantic_tools.shared.config_utils.Path.cwd')
+        assert result["dbt_models_dir"] == Path("/project/models")
+        assert result["semantic_models_dir"] == Path("/project/snowflake_semantic_models")
+        assert result["manifest_path"] == Path("/project/target/manifest.json")
+
+    @patch("snowflake_semantic_tools.shared.config_utils.get_config")
+    @patch("snowflake_semantic_tools.shared.config_utils.Path.cwd")
     def test_custom_paths(self, mock_cwd, mock_get_config):
         """Test custom project paths from config."""
-        mock_cwd.return_value = Path('/project')
+        mock_cwd.return_value = Path("/project")
         mock_config = Mock()
         mock_config.get.return_value = {
-            'dbt_models_dir': 'my_models',
-            'semantic_models_dir': 'my_semantics',
-            'manifest_path': 'custom/manifest.json'
+            "dbt_models_dir": "my_models",
+            "semantic_models_dir": "my_semantics",
+            "manifest_path": "custom/manifest.json",
         }
         mock_get_config.return_value = mock_config
-        
+
         result = get_project_paths()
-        assert result['dbt_models_dir'] == Path('/project/my_models')
-        assert result['semantic_models_dir'] == Path('/project/my_semantics')
-        assert result['manifest_path'] == Path('/project/custom/manifest.json')
+        assert result["dbt_models_dir"] == Path("/project/my_models")
+        assert result["semantic_models_dir"] == Path("/project/my_semantics")
+        assert result["manifest_path"] == Path("/project/custom/manifest.json")
 
 
 class TestIsStrictMode:
     """Test strict mode detection."""
-    
-    @patch('snowflake_semantic_tools.shared.config_utils.get_config')
+
+    @patch("snowflake_semantic_tools.shared.config_utils.get_config")
     def test_strict_mode_false_default(self, mock_get_config):
         """Test strict mode defaults to false."""
         mock_config = Mock()
         mock_config.get.return_value = {}
         mock_get_config.return_value = mock_config
-        
+
         assert is_strict_mode() is False
-    
-    @patch('snowflake_semantic_tools.shared.config_utils.get_config')
+
+    @patch("snowflake_semantic_tools.shared.config_utils.get_config")
     def test_strict_mode_enabled(self, mock_get_config):
         """Test strict mode when enabled in config."""
         mock_config = Mock()
-        mock_config.get.return_value = {'strict': True}
+        mock_config.get.return_value = {"strict": True}
         mock_get_config.return_value = mock_config
-        
+
         assert is_strict_mode() is True
 
 
 class TestGetExclusionSummary:
     """Test exclusion summary generation."""
-    
-    @patch('snowflake_semantic_tools.shared.config_utils.get_config')
+
+    @patch("snowflake_semantic_tools.shared.config_utils.get_config")
     def test_summary_with_both(self, mock_get_config):
         """Test summary with both config and CLI exclusions."""
         mock_config = Mock()
-        mock_config.get_exclude_dirs.return_value = ['models/amplitude/*']
+        mock_config.get_exclude_dirs.return_value = ["models/amplitude/*"]
         mock_get_config.return_value = mock_config
-        
+
         result = get_exclusion_summary(cli_exclude="temp,backup")
-        
-        assert result['config_patterns'] == ['models/amplitude/*']
-        assert result['cli_patterns'] == ['temp', 'backup']
-        assert result['total_patterns'] == ['models/amplitude/*', 'temp', 'backup']
-        assert result['has_exclusions'] is True
-        assert result['total_count'] == 3
-    
-    @patch('snowflake_semantic_tools.shared.config_utils.get_config')
+
+        assert result["config_patterns"] == ["models/amplitude/*"]
+        assert result["cli_patterns"] == ["temp", "backup"]
+        assert result["total_patterns"] == ["models/amplitude/*", "temp", "backup"]
+        assert result["has_exclusions"] is True
+        assert result["total_count"] == 3
+
+    @patch("snowflake_semantic_tools.shared.config_utils.get_config")
     def test_summary_no_exclusions(self, mock_get_config):
         """Test summary with no exclusions."""
         mock_config = Mock()
         mock_config.get_exclude_dirs.return_value = None
         mock_get_config.return_value = mock_config
-        
-        result = get_exclusion_summary()
-        
-        assert result['config_patterns'] == []
-        assert result['cli_patterns'] == []
-        assert result['total_patterns'] == []
-        assert result['has_exclusions'] is False
-        assert result['total_count'] == 0
 
+        result = get_exclusion_summary()
+
+        assert result["config_patterns"] == []
+        assert result["cli_patterns"] == []
+        assert result["total_patterns"] == []
+        assert result["has_exclusions"] is False
+        assert result["total_count"] == 0

--- a/tests/unit/shared/test_config_validator.py
+++ b/tests/unit/shared/test_config_validator.py
@@ -19,95 +19,68 @@ from snowflake_semantic_tools.shared.events import setup_events
 # Fixtures: Complete Configurations
 # ============================================================================
 
+
 @pytest.fixture
 def valid_complete_config() -> Dict[str, Any]:
     """Complete valid configuration with all fields."""
     return {
-        "project": {
-            "semantic_models_dir": "snowflake_semantic_models",
-            "dbt_models_dir": "models"
-        },
-        "validation": {
-            "strict": False,
-            "exclude_dirs": ["_intermediate", "staging"]
-        },
+        "project": {"semantic_models_dir": "snowflake_semantic_models", "dbt_models_dir": "models"},
+        "validation": {"strict": False, "exclude_dirs": ["_intermediate", "staging"]},
         "enrichment": {
             "distinct_limit": 25,
             "sample_values_display_limit": 10,
-            "synonym_model": "openai-gpt-5",
-            "synonym_max_count": 4
-        }
+            "synonym_model": "mistral-large2",
+            "synonym_max_count": 4,
+        },
     }
 
 
 @pytest.fixture
 def valid_minimal_config() -> Dict[str, Any]:
     """Minimal valid configuration with only required fields."""
-    return {
-        "project": {
-            "semantic_models_dir": "semantic_models",
-            "dbt_models_dir": "models"
-        }
-    }
+    return {"project": {"semantic_models_dir": "semantic_models", "dbt_models_dir": "models"}}
 
 
 # ============================================================================
 # Fixtures: Missing Required Fields
 # ============================================================================
 
+
 @pytest.fixture
 def config_missing_semantic_models_dir() -> Dict[str, Any]:
     """Config missing project.semantic_models_dir."""
-    return {
-        "project": {
-            "dbt_models_dir": "models"
-        }
-    }
+    return {"project": {"dbt_models_dir": "models"}}
 
 
 @pytest.fixture
 def config_missing_dbt_models_dir() -> Dict[str, Any]:
     """Config missing project.dbt_models_dir."""
-    return {
-        "project": {
-            "semantic_models_dir": "semantic_models"
-        }
-    }
+    return {"project": {"semantic_models_dir": "semantic_models"}}
 
 
 @pytest.fixture
 def config_missing_project_section() -> Dict[str, Any]:
     """Config with project section completely missing."""
-    return {
-        "validation": {
-            "strict": False
-        }
-    }
+    return {"validation": {"strict": False}}
 
 
 @pytest.fixture
 def config_empty_project_section() -> Dict[str, Any]:
     """Config with empty project section."""
-    return {
-        "project": {}
-    }
+    return {"project": {}}
 
 
 # ============================================================================
 # Fixtures: Missing Optional Fields
 # ============================================================================
 
+
 @pytest.fixture
 def config_missing_validation_strict() -> Dict[str, Any]:
     """Config missing validation.strict."""
     return {
-        "project": {
-            "semantic_models_dir": "semantic_models",
-            "dbt_models_dir": "models"
-        },
-        "validation": {
-            "exclude_dirs": ["_intermediate"]
-        }
+        "project": {"semantic_models_dir": "semantic_models", "dbt_models_dir": "models"},
+        "validation": {"exclude_dirs": ["_intermediate"]},
     }
 
 
@@ -115,13 +88,8 @@ def config_missing_validation_strict() -> Dict[str, Any]:
 def config_missing_validation_exclude_dirs() -> Dict[str, Any]:
     """Config missing validation.exclude_dirs."""
     return {
-        "project": {
-            "semantic_models_dir": "semantic_models",
-            "dbt_models_dir": "models"
-        },
-        "validation": {
-            "strict": False
-        }
+        "project": {"semantic_models_dir": "semantic_models", "dbt_models_dir": "models"},
+        "validation": {"strict": False},
     }
 
 
@@ -129,15 +97,8 @@ def config_missing_validation_exclude_dirs() -> Dict[str, Any]:
 def config_missing_enrichment_distinct_limit() -> Dict[str, Any]:
     """Config missing enrichment.distinct_limit."""
     return {
-        "project": {
-            "semantic_models_dir": "semantic_models",
-            "dbt_models_dir": "models"
-        },
-        "enrichment": {
-            "sample_values_display_limit": 10,
-            "synonym_model": "openai-gpt-5",
-            "synonym_max_count": 4
-        }
+        "project": {"semantic_models_dir": "semantic_models", "dbt_models_dir": "models"},
+        "enrichment": {"sample_values_display_limit": 10, "synonym_model": "mistral-large2", "synonym_max_count": 4},
     }
 
 
@@ -145,15 +106,8 @@ def config_missing_enrichment_distinct_limit() -> Dict[str, Any]:
 def config_missing_enrichment_sample_values_display_limit() -> Dict[str, Any]:
     """Config missing enrichment.sample_values_display_limit."""
     return {
-        "project": {
-            "semantic_models_dir": "semantic_models",
-            "dbt_models_dir": "models"
-        },
-        "enrichment": {
-            "distinct_limit": 25,
-            "synonym_model": "openai-gpt-5",
-            "synonym_max_count": 4
-        }
+        "project": {"semantic_models_dir": "semantic_models", "dbt_models_dir": "models"},
+        "enrichment": {"distinct_limit": 25, "synonym_model": "mistral-large2", "synonym_max_count": 4},
     }
 
 
@@ -161,15 +115,8 @@ def config_missing_enrichment_sample_values_display_limit() -> Dict[str, Any]:
 def config_missing_enrichment_synonym_model() -> Dict[str, Any]:
     """Config missing enrichment.synonym_model."""
     return {
-        "project": {
-            "semantic_models_dir": "semantic_models",
-            "dbt_models_dir": "models"
-        },
-        "enrichment": {
-            "distinct_limit": 25,
-            "sample_values_display_limit": 10,
-            "synonym_max_count": 4
-        }
+        "project": {"semantic_models_dir": "semantic_models", "dbt_models_dir": "models"},
+        "enrichment": {"distinct_limit": 25, "sample_values_display_limit": 10, "synonym_max_count": 4},
     }
 
 
@@ -177,43 +124,32 @@ def config_missing_enrichment_synonym_model() -> Dict[str, Any]:
 def config_missing_enrichment_synonym_max_count() -> Dict[str, Any]:
     """Config missing enrichment.synonym_max_count."""
     return {
-        "project": {
-            "semantic_models_dir": "semantic_models",
-            "dbt_models_dir": "models"
-        },
-        "enrichment": {
-            "distinct_limit": 25,
-            "sample_values_display_limit": 10,
-            "synonym_model": "openai-gpt-5"
-        }
+        "project": {"semantic_models_dir": "semantic_models", "dbt_models_dir": "models"},
+        "enrichment": {"distinct_limit": 25, "sample_values_display_limit": 10, "synonym_model": "mistral-large2"},
     }
 
 
 @pytest.fixture
 def config_missing_all_optional_fields() -> Dict[str, Any]:
     """Config missing all optional fields."""
-    return {
-        "project": {
-            "semantic_models_dir": "semantic_models",
-            "dbt_models_dir": "models"
-        }
-    }
+    return {"project": {"semantic_models_dir": "semantic_models", "dbt_models_dir": "models"}}
 
 
 # ============================================================================
 # Tests: validate_config - Required Fields
 # ============================================================================
 
+
 class TestValidateConfigRequiredFields:
     """Test validation of required configuration fields."""
-    
+
     def test_valid_complete_config(self, valid_complete_config):
         """Valid complete config should pass validation."""
         is_valid, missing_required, missing_optional = validate_config(valid_complete_config)
         assert is_valid is True
         assert len(missing_required) == 0
         assert len(missing_optional) == 0
-    
+
     def test_valid_minimal_config(self, valid_minimal_config):
         """Valid minimal config (only required fields) should pass."""
         is_valid, missing_required, missing_optional = validate_config(valid_minimal_config)
@@ -221,21 +157,21 @@ class TestValidateConfigRequiredFields:
         assert len(missing_required) == 0
         # Should identify missing optional fields
         assert len(missing_optional) > 0
-    
+
     def test_missing_semantic_models_dir(self, config_missing_semantic_models_dir):
         """Missing project.semantic_models_dir should fail validation."""
         is_valid, missing_required, _ = validate_config(config_missing_semantic_models_dir)
         assert is_valid is False
         assert "project.semantic_models_dir" in missing_required
         assert len(missing_required) == 1
-    
+
     def test_missing_dbt_models_dir(self, config_missing_dbt_models_dir):
         """Missing project.dbt_models_dir should fail validation."""
         is_valid, missing_required, _ = validate_config(config_missing_dbt_models_dir)
         assert is_valid is False
         assert "project.dbt_models_dir" in missing_required
         assert len(missing_required) == 1
-    
+
     def test_missing_both_required_fields(self):
         """Missing both required fields should fail validation."""
         config = {"project": {}}
@@ -244,14 +180,14 @@ class TestValidateConfigRequiredFields:
         assert "project.semantic_models_dir" in missing_required
         assert "project.dbt_models_dir" in missing_required
         assert len(missing_required) == 2
-    
+
     def test_missing_project_section(self, config_missing_project_section):
         """Missing project section entirely should fail validation."""
         is_valid, missing_required, _ = validate_config(config_missing_project_section)
         assert is_valid is False
         assert "project.semantic_models_dir" in missing_required
         assert "project.dbt_models_dir" in missing_required
-    
+
     def test_empty_project_section(self, config_empty_project_section):
         """Empty project section should fail validation."""
         is_valid, missing_required, _ = validate_config(config_empty_project_section)
@@ -264,9 +200,10 @@ class TestValidateConfigRequiredFields:
 # Tests: validate_config - Optional Fields
 # ============================================================================
 
+
 class TestValidateConfigOptionalFields:
     """Test validation of optional configuration fields."""
-    
+
     def test_missing_validation_strict(self, config_missing_validation_strict):
         """Missing validation.strict should be identified but not fail validation."""
         is_valid, missing_required, missing_optional = validate_config(config_missing_validation_strict)
@@ -274,7 +211,7 @@ class TestValidateConfigOptionalFields:
         assert len(missing_required) == 0
         optional_fields = [field[0] for field in missing_optional]
         assert "validation.strict" in optional_fields
-    
+
     def test_missing_validation_exclude_dirs(self, config_missing_validation_exclude_dirs):
         """Missing validation.exclude_dirs should be identified but not fail validation."""
         is_valid, missing_required, missing_optional = validate_config(config_missing_validation_exclude_dirs)
@@ -282,7 +219,7 @@ class TestValidateConfigOptionalFields:
         assert len(missing_required) == 0
         optional_fields = [field[0] for field in missing_optional]
         assert "validation.exclude_dirs" in optional_fields
-    
+
     def test_missing_enrichment_distinct_limit(self, config_missing_enrichment_distinct_limit):
         """Missing enrichment.distinct_limit should be identified but not fail validation."""
         is_valid, missing_required, missing_optional = validate_config(config_missing_enrichment_distinct_limit)
@@ -290,15 +227,19 @@ class TestValidateConfigOptionalFields:
         assert len(missing_required) == 0
         optional_fields = [field[0] for field in missing_optional]
         assert "enrichment.distinct_limit" in optional_fields
-    
-    def test_missing_enrichment_sample_values_display_limit(self, config_missing_enrichment_sample_values_display_limit):
+
+    def test_missing_enrichment_sample_values_display_limit(
+        self, config_missing_enrichment_sample_values_display_limit
+    ):
         """Missing enrichment.sample_values_display_limit should be identified."""
-        is_valid, missing_required, missing_optional = validate_config(config_missing_enrichment_sample_values_display_limit)
+        is_valid, missing_required, missing_optional = validate_config(
+            config_missing_enrichment_sample_values_display_limit
+        )
         assert is_valid is True
         assert len(missing_required) == 0
         optional_fields = [field[0] for field in missing_optional]
         assert "enrichment.sample_values_display_limit" in optional_fields
-    
+
     def test_missing_enrichment_synonym_model(self, config_missing_enrichment_synonym_model):
         """Missing enrichment.synonym_model should be identified."""
         is_valid, missing_required, missing_optional = validate_config(config_missing_enrichment_synonym_model)
@@ -306,7 +247,7 @@ class TestValidateConfigOptionalFields:
         assert len(missing_required) == 0
         optional_fields = [field[0] for field in missing_optional]
         assert "enrichment.synonym_model" in optional_fields
-    
+
     def test_missing_enrichment_synonym_max_count(self, config_missing_enrichment_synonym_max_count):
         """Missing enrichment.synonym_max_count should be identified."""
         is_valid, missing_required, missing_optional = validate_config(config_missing_enrichment_synonym_max_count)
@@ -314,7 +255,7 @@ class TestValidateConfigOptionalFields:
         assert len(missing_required) == 0
         optional_fields = [field[0] for field in missing_optional]
         assert "enrichment.synonym_max_count" in optional_fields
-    
+
     def test_missing_all_optional_fields(self, config_missing_all_optional_fields):
         """Config missing all optional fields should pass but identify all missing."""
         is_valid, missing_required, missing_optional = validate_config(config_missing_all_optional_fields)
@@ -335,46 +276,40 @@ class TestValidateConfigOptionalFields:
 # Tests: validate_and_report_config - Event Firing
 # ============================================================================
 
+
 class TestValidateAndReportConfig:
     """Test validate_and_report_config event firing and error handling."""
-    
+
     def setup_method(self):
         """Setup events system for each test."""
         setup_events(verbose=False, show_timestamps=False)
-    
+
     def test_valid_config_returns_true(self, valid_complete_config):
         """Valid config should return True."""
         result = validate_and_report_config(valid_complete_config, fail_on_errors=False)
         assert result is True
-    
+
     def test_invalid_config_returns_false_when_not_failing(self, config_missing_semantic_models_dir):
         """Invalid config should return False when fail_on_errors=False."""
         result = validate_and_report_config(config_missing_semantic_models_dir, fail_on_errors=False)
         assert result is False
-    
+
     def test_invalid_config_raises_systemexit_when_failing(self, config_missing_semantic_models_dir):
         """Invalid config should raise SystemExit when fail_on_errors=True."""
         with pytest.raises(SystemExit):
             validate_and_report_config(config_missing_semantic_models_dir, fail_on_errors=True)
-    
+
     def test_valid_config_with_missing_optional_returns_true(self, config_missing_all_optional_fields):
         """Config missing only optional fields should return True."""
         result = validate_and_report_config(config_missing_all_optional_fields, fail_on_errors=False)
         assert result is True  # Still valid since required fields are present
-    
+
     def test_nested_field_handling(self):
         """Test that nested field paths are handled correctly."""
         # Config with deeply nested structure (future-proofing)
         config = {
-            "project": {
-                "semantic_models_dir": "semantic_models",
-                "dbt_models_dir": "models"
-            },
-            "nested": {
-                "deep": {
-                    "value": "test"  # Not validated, but shouldn't break
-                }
-            }
+            "project": {"semantic_models_dir": "semantic_models", "dbt_models_dir": "models"},
+            "nested": {"deep": {"value": "test"}},  # Not validated, but shouldn't break
         }
         is_valid, missing_required, _ = validate_config(config)
         assert is_valid is True
@@ -385,62 +320,50 @@ class TestValidateAndReportConfig:
 # Tests: Edge Cases
 # ============================================================================
 
+
 class TestConfigValidatorEdgeCases:
     """Test edge cases and boundary conditions."""
-    
+
     def test_empty_config_dict(self):
         """Empty config dict should fail validation."""
         config = {}
         is_valid, missing_required, _ = validate_config(config)
         assert is_valid is False
         assert len(missing_required) == 2  # Both required fields missing
-    
+
     def test_none_values(self):
         """Config with None values should fail validation."""
-        config = {
-            "project": {
-                "semantic_models_dir": None,
-                "dbt_models_dir": None
-            }
-        }
+        config = {"project": {"semantic_models_dir": None, "dbt_models_dir": None}}
         is_valid, missing_required, _ = validate_config(config)
         assert is_valid is False
         assert "project.semantic_models_dir" in missing_required
         assert "project.dbt_models_dir" in missing_required
-    
+
     def test_empty_string_values(self):
         """Config with empty string values should be considered present."""
         # Note: Empty strings are technically present, so validation passes
         # The code checks for key existence, not value truthiness
-        config = {
-            "project": {
-                "semantic_models_dir": "",
-                "dbt_models_dir": ""
-            }
-        }
+        config = {"project": {"semantic_models_dir": "", "dbt_models_dir": ""}}
         # Empty strings are present (validation only checks existence, not value)
         is_valid, missing_required, _ = validate_config(config)
         assert is_valid is True  # Keys exist, even if values are empty
-    
+
     def test_config_path_logging(self, tmp_path, valid_minimal_config):
         """Config path should be used for logging context."""
         config_path = tmp_path / "sst_config.yml"
         is_valid, _, _ = validate_config(valid_minimal_config, config_path=config_path)
         assert is_valid is True  # Should still validate correctly
-    
+
     def test_non_dict_project_section(self):
         """Config with project as non-dict should fail gracefully."""
-        config = {
-            "project": "not_a_dict"
-        }
+        config = {"project": "not_a_dict"}
         is_valid, missing_required, _ = validate_config(config)
         assert is_valid is False
         assert len(missing_required) == 2  # Can't navigate into non-dict
-    
+
     def test_extra_unrecognized_fields(self, valid_complete_config):
         """Config with extra unrecognized fields should still validate."""
         config = valid_complete_config.copy()
         config["unknown_section"] = {"unknown_field": "value"}
         is_valid, missing_required, _ = validate_config(config)
         assert is_valid is True  # Unrecognized fields don't affect validation
-


### PR DESCRIPTION
## Description

This PR fixes the default Cortex model configuration to use a universally available model (`mistral-large2`) instead of OpenAI models that require Azure or cross-region inference. It also adds proper error handling to fail loudly when an invalid model is configured, rather than silently returning no synonyms.

## Related Issue

closes #18

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [x] Test improvements
- [ ] Other (please describe):

## Changes Made

### Default Model Configuration
- Changed default model from `openai-gpt-4.1`/`openai-gpt-5` to `mistral-large2` (universally available on AWS, Azure, GCP)
- Updated in: `sst_config.yml.example`, `cortex_synonym_generator.py`, `config.py`, `config_utils.py`, `config_validator.py`

### Error Handling - Fail Loudly
- Modified `generate_table_synonyms()` and `generate_column_synonyms_batch()` to raise `RuntimeError` instead of silently returning empty results
- Added `_build_model_unavailable_error()` method that provides actionable guidance including:
  - List of universally available models
  - Cross-region inference instructions for OpenAI models
  - Link to Snowflake documentation

### Documentation
- Updated `docs/getting-started.md` with new default and troubleshooting section for model unavailability
- Updated `docs/cli-reference.md` with new default model

### Tests
- Updated existing tests to expect new default model (`mistral-large2`)
- Added new tests for error handling behavior:
  - `test_cortex_empty_response_raises_error`
  - `test_cortex_exception_raises_error`
  - `test_generate_synonyms_raises_on_cortex_error`
  - `test_verify_cortex_model_unavailable_error`
  - `test_verify_cortex_non_openai_model_unavailable`
  - `test_default_model_is_mistral_large2`
  - `test_build_model_unavailable_error_openai_model`
  - `test_build_model_unavailable_error_non_openai_model`

## Testing

- [x] Unit tests pass (`pytest tests/unit/`)
- [x] All existing tests pass
- [x] New tests added for new functionality
- [ ] Tested locally with Python 3.9-3.11
- [x] Manual testing completed (if applicable)
- [x] Test coverage maintained or improved (target: >90%)

### Test Results

```
======================== 694 passed, 8 skipped in 1.74s ========================
```

### Manual Testing

Verified synonym generation works on sst-jaffle-shop project with the new `mistral-large2` default model:
- Table-level synonyms generated successfully
- Column-level synonyms generated successfully
- Model correctly identified as `mistral-large2`

## Checklist

### Code Quality
- [x] Code follows the project's style guidelines (Black, line length 120)
- [x] Imports sorted with isort (black profile)
- [x] Type hints added for new code (`mypy snowflake_semantic_tools/` passes)
- [x] Docstrings added for public functions/classes
- [x] No linting errors
- [ ] Pre-commit hooks pass (if using pre-commit)

### Testing & Validation
- [x] All tests pass (`pytest tests/unit/`)
- [x] New functionality has test coverage
- [x] Test results included above

### Documentation & Compatibility
- [x] Documentation updated (if needed)
- [x] Backward compatibility maintained (if applicable)
- [x] Breaking changes discussed with maintainer first (see CONTRIBUTING.md)

### Performance
- [x] Performance impact considered
- [x] No significant performance regressions

## Screenshots / Examples

### Error Message for Invalid Model

When a user configures an unavailable model (e.g., `openai-gpt-4.1` on AWS), they now see:

```
Cortex model 'openai-gpt-4.1' is not available in your Snowflake account.

Original error: Model "openai-gpt-4.1" is unavailable

OpenAI models (gpt-4.1, gpt-5, etc.) are only available on Azure
or require cross-region inference to be enabled.

To enable cross-region inference (requires ACCOUNTADMIN):
  ALTER ACCOUNT SET CORTEX_ENABLED_CROSS_REGION = 'AZURE_US';

Solutions:

1. Use a universally available model in sst_config.yml:
   enrichment:
     synonym_model: 'mistral-large2'  # Recommended (128K context)

   Other options: llama3.1-70b, llama3.1-8b, mixtral-8x7b, mistral-7b

2. Check model availability for your region:
   https://docs.snowflake.com/en/user-guide/snowflake-cortex/llm-functions#availability
```

## Additional Notes

- The `mistral-large2` model was chosen as the new default because it is available across all Snowflake cloud providers (AWS, Azure, GCP) without requiring cross-region inference
- OpenAI models are still fully supported but now have clear documentation about their Azure/cross-region requirements
- The "fail loudly" behavior ensures users are immediately aware of configuration issues rather than silently getting no synonyms

