### PR TITLE
fix: don't show error if enrichment via sst enrich succeeds

### DIFF
--- a/snowflake_semantic_tools/interfaces/cli/commands/enrich.py
+++ b/snowflake_semantic_tools/interfaces/cli/commands/enrich.py
@@ -353,9 +353,9 @@ def enrich(
 
         # Show dbt-style done line
         output.blank_line()
-        success_count = result.models_enriched if hasattr(result, "models_enriched") else 0
-        failed_count = len(result.failed_models) if hasattr(result, "failed_models") else 0
-        total_count = success_count + failed_count
+        success_count = result.processed
+        failed_count = len(result.errors)
+        total_count = result.total
 
         output.done_line(passed=success_count, errored=failed_count, total=total_count)
 

--- a/tests/integration/end_to_end/test_enrich_status_issue_83.py
+++ b/tests/integration/end_to_end/test_enrich_status_issue_83.py
@@ -134,8 +134,9 @@ models:
             # Create a result with "complete" status (what service actually returns)
             mock_result = Mock()
             mock_result.status = "complete"  # This is the key - service returns "complete"
-            mock_result.models_enriched = 1
-            mock_result.failed_models = []
+            mock_result.processed = 1
+            mock_result.errors = []
+            mock_result.total = 1
             mock_result.print_summary = Mock()
 
             mock_instance.enrich = Mock(return_value=mock_result)
@@ -184,8 +185,9 @@ models:
             # Create a result with "partial" status (some succeeded, some failed)
             mock_result = Mock()
             mock_result.status = "partial"
-            mock_result.models_enriched = 1
-            mock_result.failed_models = ["models/orders.yml"]
+            mock_result.processed = 1
+            mock_result.errors = [{"model": "models/orders.yml"}]
+            mock_result.total = 2
             mock_result.print_summary = Mock()
 
             mock_instance.enrich = Mock(return_value=mock_result)
@@ -236,8 +238,9 @@ models:
             # Create a result with "failed" status (all failed)
             mock_result = Mock()
             mock_result.status = "failed"
-            mock_result.models_enriched = 0
-            mock_result.failed_models = ["models/customers.yml"]
+            mock_result.processed = 0
+            mock_result.errors = [{"model": "models/customers.yml"}]
+            mock_result.total = 1
             mock_result.print_summary = Mock()
 
             mock_instance.enrich = Mock(return_value=mock_result)

--- a/tests/unit/interfaces/cli/test_enrich_models_option.py
+++ b/tests/unit/interfaces/cli/test_enrich_models_option.py
@@ -156,8 +156,9 @@ class TestEnrichCLIModelsOption:
             mock_instance.enrich = Mock(
                 return_value=Mock(
                     status="complete",  # Service returns "complete", not "success"
-                    models_enriched=1,
-                    failed_models=[],
+                    processed=1,
+                    errors=[],
+                    total=1,
                     print_summary=Mock(),
                 )
             )
@@ -213,8 +214,9 @@ class TestEnrichCLIModelsOption:
             mock_instance.enrich = Mock(
                 return_value=Mock(
                     status="complete",  # Service returns "complete", not "success"
-                    models_enriched=2,
-                    failed_models=[],
+                    processed=2,
+                    errors=[],
+                    total=2,
                     print_summary=Mock(),
                 )
             )
@@ -242,8 +244,9 @@ class TestEnrichCLIModelsOption:
             mock_instance.enrich = Mock(
                 return_value=Mock(
                     status="complete",  # Service returns "complete", not "success"
-                    models_enriched=1,
-                    failed_models=[],
+                    processed=1,
+                    errors=[],
+                    total=1,
                     print_summary=Mock(),
                 )
             )

--- a/tests/unit/interfaces/cli/test_enrich_status_handling.py
+++ b/tests/unit/interfaces/cli/test_enrich_status_handling.py
@@ -29,8 +29,9 @@ class TestEnrichmentStatusHandling:
             mock_instance.enrich = Mock(
                 return_value=Mock(
                     status="complete",  # Service returns "complete", not "success"
-                    models_enriched=1,
-                    failed_models=[],
+                    processed=1,
+                    errors=[],
+                    total=1,
                     print_summary=Mock(),
                 )
             )
@@ -60,8 +61,9 @@ class TestEnrichmentStatusHandling:
             mock_instance.enrich = Mock(
                 return_value=Mock(
                     status="partial",
-                    models_enriched=1,
-                    failed_models=["models/orders.sql"],
+                    processed=1,
+                    errors=[{"model": "models/orders.sql"}],
+                    total=2,
                     print_summary=Mock(),
                 )
             )
@@ -88,8 +90,9 @@ class TestEnrichmentStatusHandling:
             mock_instance.enrich = Mock(
                 return_value=Mock(
                     status="failed",
-                    models_enriched=0,
-                    failed_models=["models/customers.sql"],
+                    processed=0,
+                    errors=[{"model": "models/customers.sql"}],
+                    total=1,
                     print_summary=Mock(),
                 )
             )
@@ -147,8 +150,9 @@ class TestEnrichmentStatusRegression:
             mock_instance.connect = Mock()
             mock_result = Mock()
             mock_result.status = "complete"  # This is what service actually returns
-            mock_result.models_enriched = 1
-            mock_result.failed_models = []
+            mock_result.processed = 1
+            mock_result.errors = []
+            mock_result.total = 1
             mock_result.print_summary = Mock()
 
             mock_instance.enrich = Mock(return_value=mock_result)
@@ -167,3 +171,42 @@ class TestEnrichmentStatusRegression:
             assert (
                 "Enrichment failed" not in result.output
             ), f"Should not show 'failed' for successful enrichment. Output: {result.output}"
+
+    def test_done_line_shows_correct_counts(self):
+        """
+        Regression test for count display bug discovered during Issue #83 testing.
+
+        Before fix: CLI looked for non-existent attributes (models_enriched, failed_models)
+                    and always fell back to 0, showing PASS=0 TOTAL=0 even on success
+        After fix: CLI uses correct attributes (processed, errors, total) from EnrichmentResult
+
+        This test ensures the Done line displays accurate enrichment counts.
+        """
+        runner = CliRunner()
+
+        with patch("snowflake_semantic_tools.interfaces.cli.commands.enrich.setup_command"), patch(
+            "snowflake_semantic_tools.interfaces.cli.commands.enrich.MetadataEnrichmentService"
+        ) as mock_service:
+            # Service returns result with 1 model enriched
+            mock_instance = Mock()
+            mock_instance.connect = Mock()
+            mock_result = Mock()
+            mock_result.status = "complete"
+            mock_result.processed = 1  # 1 model enriched
+            mock_result.errors = []  # No errors
+            mock_result.total = 1  # Total of 1 model
+            mock_result.print_summary = Mock()
+
+            mock_instance.enrich = Mock(return_value=mock_result)
+            mock_instance.close = Mock()
+            mock_service.return_value = mock_instance
+
+            with patch("snowflake_semantic_tools.interfaces.cli.commands.enrich._resolve_model_names") as mock_resolve:
+                mock_resolve.return_value = ["models/customers.sql"]
+                result = runner.invoke(enrich, ["--models", "customers"])
+
+            # Before fix: Shows "Done. PASS=0 WARN=0 ERROR=0 SKIP=0 TOTAL=0"
+            # After fix: Shows "Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1"
+            assert result.exit_code == 0
+            assert "PASS=1" in result.output, f"Expected PASS=1 but got: {result.output}"
+            assert "TOTAL=1" in result.output, f"Expected TOTAL=1 but got: {result.output}"


### PR DESCRIPTION
## Description
This PR fixes a status value mismatch between the CLI and service layers that caused successful enrichment operations to display "Enrichment failed [ERROR]" even when enrichment via the `sst enrich` command completed successfully.

## Related Issue

Closes #83 

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test improvements
- [ ] Other (please describe):

## Changes Made

### Core fix
**File:** `snowflake_semantic_tools/interfaces/cli/commands/enrich.py`
- Line 344: Changed `if result.status == "success":` to `if result.status == "complete"`
- Aligns CLI status check with the actual status value returned by service

### Tests
- Updated existing tests to use new mock status values ( `"success"` to `"complete"` ). This ensures existing tests use correct service contract
- New unit test `tests/unit/interfaces/cli/test_enrich_status_handling.py` which includes comprehensive unit tests for all three status values:
  - `"complete"` - Shows "Enrichment completed"
  - `"partial"` - Shows "Enrichment completed with errors"  
  - `"failed"` - Shows "Enrichment failed"
- New integration test `tests/integration/end_to_end/test_enrich_status_issue_83.py`:
  - End-to-end tests with jaffle_shop-style dbt project setup
  - Tests full enrichment workflow through actual CLI
  - Validates all three status scenarios in realistic conditions

## Testing

Changes have been tested via new testing scripts listed above, as well as with a local test dataset of jaffle shop data. 

- [x] Unit tests pass (`pytest tests/unit/`)
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Tested locally with Python 3.11
- [x] Manual testing completed (if applicable)
- [x] Test coverage maintained or improved (target: >90%)

### Test Results

**Updated Existing Tests:**
```bash
$ pytest tests/unit/interfaces/cli/test_enrich_models_option.py
======================== test session starts =========================
... (all 15 tests pass)
========================== 15 passed in 0.55s ==========================
```

**New Unit Tests:**
```bash
$ pytest tests/unit/interfaces/cli/test_enrich_status_handling.py -v
======================== test session starts =========================
tests/unit/interfaces/cli/test_enrich_status_handling.py::TestEnrichmentStatusHandling::test_complete_status_shows_success PASSED [ 20%]
tests/unit/interfaces/cli/test_enrich_status_handling.py::TestEnrichmentStatusHandling::test_partial_status_shows_warning PASSED [ 40%]
tests/unit/interfaces/cli/test_enrich_status_handling.py::TestEnrichmentStatusHandling::test_failed_status_shows_error PASSED [ 60%]
tests/unit/interfaces/cli/test_enrich_status_handling.py::TestEnrichmentStatusHandling::test_status_values_match_service_contract PASSED [ 80%]
tests/unit/interfaces/cli/test_enrich_status_handling.py::TestEnrichmentStatusRegression::test_successful_enrichment_does_not_show_error PASSED [100%]

========================== 5 passed in 1.77s ==========================
```

**New Integration Tests:**
```bash
$ pytest tests/integration/end_to_end/test_enrich_status_issue_83.py -v
======================== test session starts =========================
tests/integration/end_to_end/test_enrich_status_issue_83.py::TestEnrichmentStatusIntegration::test_successful_enrichment_shows_complete_message PASSED [ 20%]
tests/integration/end_to_end/test_enrich_status_issue_83.py::TestEnrichmentStatusIntegration::test_partial_enrichment_shows_warning PASSED [ 40%]
tests/integration/end_to_end/test_enrich_status_issue_83.py::TestEnrichmentStatusIntegration::test_complete_failure_shows_error PASSED [ 60%]
tests/integration/end_to_end/test_enrich_status_issue_83.py::TestEnrichmentStatusRegression::test_status_value_alignment PASSED [ 80%]
tests/integration/end_to_end/test_enrich_status_issue_83.py::TestEnrichmentStatusRegression::test_issue_83_scenario PASSED [100%]

========================== 5 passed in 0.57s ==========================
```

## Checklist

### Code Quality
- [X] Code follows the project's style guidelines (Black, line length 120)
- [X] Imports sorted with isort (black profile)
- [ ] Type hints added for new code (`mypy snowflake_semantic_tools/` passes)
- [X] Docstrings added for public functions/classes
- [X] No linting errors
- [ ] Pre-commit hooks pass (if using pre-commit)

### Testing & Validation
- [X] All tests pass (`pytest tests/unit/`)
- [X] New functionality has test coverage
- [X] Test results included above

### Documentation & Compatibility
- [ ] Documentation updated (if needed)
- [X] Backward compatibility maintained (if applicable)
- [ ] Breaking changes discussed with maintainer first (see CONTRIBUTING.md)

### Performance
- [X] Performance impact considered
- [X] No significant performance regressions

## Screenshots / Examples

```
================================================================================
TEST: Issue #83 - Enrichment Status Display
================================================================================
1. OLD BEHAVIOR (BUGGY - checking for 'success')
--------------------------------------------------------------------------------
Service returns:  status='complete'
CLI checks:       if status == 'success'
Match:            False (mismatch!)
Display:          ✗ Enrichment failed [ERROR]

PROBLEM: Success shows as failure!
--------------------------------------------------------------------------------

2. NEW BEHAVIOR (FIXED - checking for 'complete')
--------------------------------------------------------------------------------
Service returns:  status='complete'
CLI checks:       if status == 'complete'
Match:            True ✓
Display:          ✓ Enrichment completed [SUCCESS]

FIXED: Success shows as success!
--------------------------------------------------------------------------------

3. ACTUAL CLI COMMAND TEST
--------------------------------------------------------------------------------
Command output:
15:40:04  Running with sst=0.2.0
15:40:04  Resolving 1 model name(s)...
15:40:04  Resolved 1 model(s) [OK]

15:40:04  Connecting to Snowflake...
15:40:04  Connected to Snowflake [OK in 0.0s]


15:40:04  Enrichment completed in 0.0s [OK]


15:40:04  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1

--------------------------------------------------------------------------------
✓ Shows 'Enrichment completed'
✓ Does not show 'Enrichment failed' for success

================================================================================
SUMMARY
================================================================================
✓ Issue #83 is FIXED!

The fix changes line 344 in enrich.py:
  OLD: if result.status == 'success':
  NEW: if result.status == 'complete':

Now the CLI correctly displays success when the service
returns status='complete' (successful enrichment).
```

## Additional Notes

None at this time. 
