### PR TITLE
fix: Add description field at model/column level for new files (#85)

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -117,7 +117,7 @@ sst enrich --models customers --exclude experimental
 ### What Gets Preserved
 
 Enrichment NEVER overwrites:
-- Existing descriptions
+- Existing descriptions (including empty strings and null values)
 - Existing synonyms
 - Existing primary_key
 - Existing unique_keys
@@ -126,6 +126,9 @@ Enrichment NEVER overwrites:
 Enrichment ALWAYS updates:
 - sample_values (fresh data)
 - is_enum (current cardinality)
+
+Enrichment ADDS if missing:
+- `description: ''` placeholder (model and column level) for new items only
 
 **Safe to run multiple times.**
 


### PR DESCRIPTION
## Description

When running `sst enrich` on a model without an existing YAML file, the `description` field was not being added at the model level (though column-level descriptions were added). This fix ensures both model-level and column-level descriptions get an empty placeholder when the key is missing, while never overwriting existing values.

## Related Issue

Closes #85

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [x] Test improvements
- [ ] Other (please describe):

## Changes Made

### Code Changes (`metadata_enricher.py`)
1. **Model-level**: Added description handling in `_process_model_metadata()` - only adds `description: ''` if key is completely missing
2. **Column-level**: Added same handling in `_process_single_column()` for consistency
3. **Preservation rule**: Never overwrites existing values (including empty strings and `None`)

### Test Changes (`test_metadata_enricher.py`)
Added 8 new unit tests:
- `TestProcessModelMetadataDescription` (4 tests): new model, None preserved, existing preserved, empty string preserved
- `TestProcessSingleColumnDescription` (4 tests): new column, existing preserved, None preserved, missing key gets placeholder

### Documentation Updates
- `docs/user-guide.md`: Clarified preservation rules and added "Adds if missing" section
- Module docstring: Updated to reflect description behavior

## Testing

- [x] Unit tests pass (`pytest tests/unit/`)
- [x] All existing tests pass
- [x] New tests added for new functionality
- [ ] Tested locally with Python 3.9-3.11
- [x] Manual testing completed (if applicable)
- [x] Test coverage maintained or improved (target: >90%)

### Test Results

```
pytest tests/unit/ --tb=short
=================== 1008 passed, 25 subtests passed in 1.76s ===================
```

## Checklist

### Code Quality
- [x] Code follows the project's style guidelines (Black, line length 120)
- [x] Imports sorted with isort (black profile)
- [x] Type hints added for new code (`mypy snowflake_semantic_tools/` passes)
- [x] Docstrings added for public functions/classes
- [x] No linting errors
- [ ] Pre-commit hooks pass (if using pre-commit)

### Testing & Validation
- [x] All tests pass (`pytest tests/unit/`)
- [x] New functionality has test coverage
- [x] Test results included above

### Documentation & Compatibility
- [x] Documentation updated (if needed)
- [x] Backward compatibility maintained (if applicable)
- [ ] Breaking changes discussed with maintainer first (see CONTRIBUTING.md)

### Performance
- [x] Performance impact considered
- [x] No significant performance regressions

## Screenshots / Examples

**Before (new model YAML):**
```yaml
models:
  - name: customers
    config:           # <-- No description!
      meta:
        sst:
          ...
```

**After (new model YAML):**
```yaml
models:
  - name: customers
    description: ''   # <-- Now added
    config:
      meta:
        sst:
          ...
```

## Additional Notes

- The fix is conservative: only adds description when the key is completely missing
- Existing descriptions are never modified, even if they are `None` or empty string
- This aligns with the documented preservation rules ("Never overwrite descriptions")

