### PR TITLE
feat: Auto-detect dbt model paths from dbt_project.yml

### DIFF
--- a/snowflake_semantic_tools/services/init_wizard.py
+++ b/snowflake_semantic_tools/services/init_wizard.py
@@ -55,7 +55,6 @@ class WizardConfig:
     """Configuration gathered during the wizard."""
 
     semantic_models_dir: str = "snowflake_semantic_models"
-    dbt_models_dir: str = "models"
     create_examples: bool = True
     test_connection: bool = False
 
@@ -417,9 +416,7 @@ class InitWizard:
         config = WizardConfig()
 
         if self.skip_prompts:
-            # Use defaults, detect models dir from dbt_project.yml
-            if self.dbt_project and self.dbt_project.model_paths:
-                config.dbt_models_dir = self.dbt_project.model_paths[0]
+            # Use defaults
             return config
 
         console.print()
@@ -445,11 +442,10 @@ class InitWizard:
 
         config.semantic_models_dir = semantic_dir
 
-        # dbt models directory (auto-detect from dbt_project.yml)
-        default_models_dir = "models"
+        # Note: dbt model paths are auto-detected from dbt_project.yml (no config needed)
         if self.dbt_project and self.dbt_project.model_paths:
-            default_models_dir = self.dbt_project.model_paths[0]
-        config.dbt_models_dir = default_models_dir
+            model_paths_str = ", ".join(self.dbt_project.model_paths)
+            console.print(f"[dim]  dbt model paths (from dbt_project.yml): {model_paths_str}[/dim]")
 
         # Create examples?
         create_examples = questionary.select(
@@ -571,16 +567,15 @@ class InitWizard:
                 template = f.read()
 
             content = template.replace("{{ semantic_models_dir }}", config.semantic_models_dir)
-            content = content.replace("{{ dbt_models_dir }}", config.dbt_models_dir)
 
             with open(output_path, "w", encoding="utf-8") as f:
                 f.write(content)
         else:
             # Fallback: create basic config
+            # Note: dbt_models_dir is no longer needed - auto-detected from dbt_project.yml
             config_content = {
                 "project": {
                     "semantic_models_dir": config.semantic_models_dir,
-                    "dbt_models_dir": config.dbt_models_dir,
                 },
                 "validation": {"strict": False, "exclude_dirs": ["_intermediate", "staging"]},
                 "enrichment": {

--- a/snowflake_semantic_tools/shared/config.py
+++ b/snowflake_semantic_tools/shared/config.py
@@ -60,7 +60,7 @@ class Config:
             },
             "project": {
                 "semantic_models_dir": None,  # Required - must be in sst_config.yml
-                "dbt_models_dir": None,  # Required - must be in sst_config.yml
+                # Note: dbt_models_dir removed - now auto-detected from dbt_project.yml
             },
             "validation": {"exclude_dirs": [], "strict": False, "verbose": False},
             "enrichment": {

--- a/snowflake_semantic_tools/shared/config_utils.py
+++ b/snowflake_semantic_tools/shared/config_utils.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from snowflake_semantic_tools.shared.config import get_config
+from snowflake_semantic_tools.shared.utils.file_utils import get_dbt_model_paths
 
 
 def get_exclusion_patterns(cli_exclude: Optional[str] = None) -> Optional[List[str]]:
@@ -123,12 +124,12 @@ def get_synonym_config() -> Dict[str, Any]:
     }
 
 
-def get_project_paths() -> Dict[str, Path]:
+def get_project_paths() -> Dict[str, Any]:
     """
-    Get project directory paths from config.
+    Get project directory paths from config and dbt_project.yml.
 
     Returns dictionary with:
-    - dbt_models_dir: Path to dbt models directory
+    - dbt_models_dirs: List of paths to dbt models directories (from dbt_project.yml)
     - semantic_models_dir: Path to semantic models directory
     - manifest_path: Path to manifest.json (optional)
 
@@ -139,8 +140,8 @@ def get_project_paths() -> Dict[str, Path]:
 
     Example:
         >>> paths = get_project_paths()
-        >>> paths['dbt_models_dir']
-        PosixPath('/Users/.../analytics-dbt/models')
+        >>> paths['dbt_models_dirs']
+        [PosixPath('/Users/.../analytics-dbt/models')]
         >>> paths['semantic_models_dir']
         PosixPath('/Users/.../analytics-dbt/snowflake_semantic_models')
     """
@@ -149,8 +150,8 @@ def get_project_paths() -> Dict[str, Path]:
 
     cwd = Path.cwd()
 
-    paths = {
-        "dbt_models_dir": cwd / project_config.get("dbt_models_dir", "models"),
+    paths: Dict[str, Any] = {
+        "dbt_models_dirs": get_dbt_model_paths(),  # Now a list from dbt_project.yml
         "semantic_models_dir": cwd / project_config.get("semantic_models_dir", "snowflake_semantic_models"),
     }
 

--- a/snowflake_semantic_tools/shared/config_validator.py
+++ b/snowflake_semantic_tools/shared/config_validator.py
@@ -58,12 +58,12 @@ def validate_config(
     missing_optional = []
 
     # Required fields (error if missing)
+    # Note: dbt_models_dir is no longer required - it's auto-detected from dbt_project.yml
     required_checks = [
         (
             "project.semantic_models_dir",
             "Required: Directory containing semantic model YAML files (metrics, relationships)",
         ),
-        ("project.dbt_models_dir", "Required: Directory containing dbt model YAML files"),
     ]
 
     for field_path, message in required_checks:
@@ -219,7 +219,6 @@ def _get_field_message(field_path: str) -> str:
     """
     messages = {
         "project.semantic_models_dir": "Directory containing semantic model YAML files (metrics, relationships)",
-        "project.dbt_models_dir": "Directory containing dbt model YAML files",
         "validation.strict": "Set to true in CI/CD to block deployments on warnings",
         "validation.exclude_dirs": "List of directories to exclude from validation",
         "enrichment.distinct_limit": "Number of distinct values to fetch during enrichment",
@@ -256,8 +255,6 @@ def _build_helpful_error_message(missing_fields: List[str], config_path: Optiona
         message += "project:\n"
         if "project.semantic_models_dir" in project_fields:
             message += '  semantic_models_dir: "snowflake_semantic_models"  # Required\n'
-        if "project.dbt_models_dir" in project_fields:
-            message += '  dbt_models_dir: "models"  # Required\n'
         message += "\n"
 
     return message

--- a/snowflake_semantic_tools/templates/sst_config.yaml.j2
+++ b/snowflake_semantic_tools/templates/sst_config.yaml.j2
@@ -7,7 +7,6 @@
 # ============================================================================
 project:
   semantic_models_dir: "{{ semantic_models_dir }}"  # Where semantic layer YAML files live
-  dbt_models_dir: "{{ dbt_models_dir }}"            # Where dbt models live
 
 # ============================================================================
 # VALIDATION (Optional)

--- a/tests/unit/services/test_init_wizard.py
+++ b/tests/unit/services/test_init_wizard.py
@@ -10,6 +10,9 @@ import yaml
 
 from snowflake_semantic_tools.services.init_wizard import DbtProjectInfo, InitWizard, ProfileInfo, WizardConfig
 
+# Note: WizardConfig no longer has dbt_models_dir field - dbt model paths
+# are now auto-detected from dbt_project.yml
+
 # =============================================================================
 # Fixtures
 # =============================================================================
@@ -176,7 +179,6 @@ class TestCreateSstConfig:
         wizard = InitWizard(project_dir=temp_dbt_project, skip_prompts=True)
         config = WizardConfig(
             semantic_models_dir="snowflake_semantic_models",
-            dbt_models_dir="models",
         )
 
         wizard._create_sst_config(config)
@@ -187,7 +189,8 @@ class TestCreateSstConfig:
         with open(config_path) as f:
             content = f.read()
         assert "snowflake_semantic_models" in content
-        assert "models" in content
+        # dbt_models_dir should NOT be in the config anymore
+        assert "dbt_models_dir" not in content or "# Note:" in content
 
     def test_create_sst_config_overwrite(self, temp_dbt_project):
         """Test overwriting existing sst_config.yaml."""
@@ -198,7 +201,6 @@ class TestCreateSstConfig:
         wizard = InitWizard(project_dir=temp_dbt_project, skip_prompts=True)
         config = WizardConfig(
             semantic_models_dir="semantic_models",
-            dbt_models_dir="models",
         )
 
         wizard._create_sst_config(config)

--- a/tests/unit/shared/test_config_edge_cases.py
+++ b/tests/unit/shared/test_config_edge_cases.py
@@ -48,20 +48,20 @@ class TestConfigFileEdgeCases:
         config_dict = {
             "validation": {"strict": False}  # Python boolean, not YAML
             # Missing project.semantic_models_dir
-            # Missing project.dbt_models_dir
+            # Note: dbt_models_dir is no longer required - auto-detected from dbt_project.yml
         }
 
         is_valid, missing, _ = validate_config(config_dict)
         assert not is_valid
         assert "project.semantic_models_dir" in missing
-        assert "project.dbt_models_dir" in missing
+        assert len(missing) == 1  # Only semantic_models_dir is required now
 
     def test_invalid_path_references(self):
         """Test config with non-existent directory paths."""
+        # Note: dbt_models_dir removed - now auto-detected from dbt_project.yml
         config_dict = {
             "project": {
                 "semantic_models_dir": "/nonexistent/path/to/semantic_models",
-                "dbt_models_dir": "/nonexistent/path/to/models",
             }
         }
 
@@ -74,7 +74,6 @@ class TestConfigFileEdgeCases:
         config_dict = {
             "project": {
                 "semantic_models_dir": "snowflake_semantic_models",  # Relative
-                "dbt_models_dir": "/abs/path/to/models",  # Absolute
             }
         }
 
@@ -86,7 +85,6 @@ class TestConfigFileEdgeCases:
         config_dict = {
             "project": {
                 "semantic_models_dir": "snowflake_semantic_models/",  # Trailing slash
-                "dbt_models_dir": "models",  # No trailing slash
             }
         }
 
@@ -95,9 +93,7 @@ class TestConfigFileEdgeCases:
 
     def test_special_chars_in_paths(self):
         """Test paths with spaces and unicode."""
-        config_dict = {
-            "project": {"semantic_models_dir": "semantic models", "dbt_models_dir": "modèles"}  # Space  # Unicode
-        }
+        config_dict = {"project": {"semantic_models_dir": "semantic models"}}  # Space
 
         is_valid, missing, _ = validate_config(config_dict)
         assert is_valid
@@ -206,12 +202,12 @@ class TestEnrichmentConfigDefaults:
     def test_default_enrichment_config(self, tmp_path):
         """Test that default enrichment config values are correct."""
         # Create a minimal config to avoid relying on existing files
+        # Note: dbt_models_dir is no longer needed - auto-detected from dbt_project.yml
         config_file = tmp_path / "sst_config.yml"
         config_file.write_text(
             """
 project:
   semantic_models_dir: "snowflake_semantic_models"
-  dbt_models_dir: "models"
 """
         )
 
@@ -236,7 +232,6 @@ project:
             """
 project:
   semantic_models_dir: "snowflake_semantic_models"
-  dbt_models_dir: "models"
 
 enrichment:
   distinct_limit: 50
@@ -264,7 +259,6 @@ enrichment:
             """
 project:
   semantic_models_dir: "snowflake_semantic_models"
-  dbt_models_dir: "models"
 
 enrichment:
   distinct_limit: 100
@@ -291,7 +285,6 @@ enrichment:
             """
 project:
   semantic_models_dir: "snowflake_semantic_models"
-  dbt_models_dir: "models"
 
 enrichment:
   distinct_limit: 30
@@ -319,7 +312,6 @@ enrichment:
             """
 project:
   semantic_models_dir: "snowflake_semantic_models"
-  dbt_models_dir: "models"
 # enrichment section omitted - should use defaults
 """
         )

--- a/tests/unit/shared/test_config_validator.py
+++ b/tests/unit/shared/test_config_validator.py
@@ -21,7 +21,7 @@ from snowflake_semantic_tools.shared.events import setup_events
 def valid_complete_config() -> Dict[str, Any]:
     """Complete valid configuration with all fields."""
     return {
-        "project": {"semantic_models_dir": "snowflake_semantic_models", "dbt_models_dir": "models"},
+        "project": {"semantic_models_dir": "snowflake_semantic_models"},
         "validation": {"strict": False, "exclude_dirs": ["_intermediate", "staging"]},
         "enrichment": {
             "distinct_limit": 25,
@@ -35,7 +35,8 @@ def valid_complete_config() -> Dict[str, Any]:
 @pytest.fixture
 def valid_minimal_config() -> Dict[str, Any]:
     """Minimal valid configuration with only required fields."""
-    return {"project": {"semantic_models_dir": "semantic_models", "dbt_models_dir": "models"}}
+    # Note: dbt_models_dir is no longer required - it's auto-detected from dbt_project.yml
+    return {"project": {"semantic_models_dir": "semantic_models"}}
 
 
 # ============================================================================
@@ -46,13 +47,8 @@ def valid_minimal_config() -> Dict[str, Any]:
 @pytest.fixture
 def config_missing_semantic_models_dir() -> Dict[str, Any]:
     """Config missing project.semantic_models_dir."""
-    return {"project": {"dbt_models_dir": "models"}}
-
-
-@pytest.fixture
-def config_missing_dbt_models_dir() -> Dict[str, Any]:
-    """Config missing project.dbt_models_dir."""
-    return {"project": {"semantic_models_dir": "semantic_models"}}
+    # Note: dbt_models_dir is no longer required - auto-detected from dbt_project.yml
+    return {"project": {}}
 
 
 @pytest.fixture
@@ -76,7 +72,7 @@ def config_empty_project_section() -> Dict[str, Any]:
 def config_missing_validation_strict() -> Dict[str, Any]:
     """Config missing validation.strict."""
     return {
-        "project": {"semantic_models_dir": "semantic_models", "dbt_models_dir": "models"},
+        "project": {"semantic_models_dir": "semantic_models"},
         "validation": {"exclude_dirs": ["_intermediate"]},
     }
 
@@ -85,7 +81,7 @@ def config_missing_validation_strict() -> Dict[str, Any]:
 def config_missing_validation_exclude_dirs() -> Dict[str, Any]:
     """Config missing validation.exclude_dirs."""
     return {
-        "project": {"semantic_models_dir": "semantic_models", "dbt_models_dir": "models"},
+        "project": {"semantic_models_dir": "semantic_models"},
         "validation": {"strict": False},
     }
 
@@ -94,7 +90,7 @@ def config_missing_validation_exclude_dirs() -> Dict[str, Any]:
 def config_missing_enrichment_distinct_limit() -> Dict[str, Any]:
     """Config missing enrichment.distinct_limit."""
     return {
-        "project": {"semantic_models_dir": "semantic_models", "dbt_models_dir": "models"},
+        "project": {"semantic_models_dir": "semantic_models"},
         "enrichment": {"sample_values_display_limit": 10, "synonym_model": "mistral-large2", "synonym_max_count": 4},
     }
 
@@ -103,7 +99,7 @@ def config_missing_enrichment_distinct_limit() -> Dict[str, Any]:
 def config_missing_enrichment_sample_values_display_limit() -> Dict[str, Any]:
     """Config missing enrichment.sample_values_display_limit."""
     return {
-        "project": {"semantic_models_dir": "semantic_models", "dbt_models_dir": "models"},
+        "project": {"semantic_models_dir": "semantic_models"},
         "enrichment": {"distinct_limit": 25, "synonym_model": "mistral-large2", "synonym_max_count": 4},
     }
 
@@ -112,7 +108,7 @@ def config_missing_enrichment_sample_values_display_limit() -> Dict[str, Any]:
 def config_missing_enrichment_synonym_model() -> Dict[str, Any]:
     """Config missing enrichment.synonym_model."""
     return {
-        "project": {"semantic_models_dir": "semantic_models", "dbt_models_dir": "models"},
+        "project": {"semantic_models_dir": "semantic_models"},
         "enrichment": {"distinct_limit": 25, "sample_values_display_limit": 10, "synonym_max_count": 4},
     }
 
@@ -121,7 +117,7 @@ def config_missing_enrichment_synonym_model() -> Dict[str, Any]:
 def config_missing_enrichment_synonym_max_count() -> Dict[str, Any]:
     """Config missing enrichment.synonym_max_count."""
     return {
-        "project": {"semantic_models_dir": "semantic_models", "dbt_models_dir": "models"},
+        "project": {"semantic_models_dir": "semantic_models"},
         "enrichment": {"distinct_limit": 25, "sample_values_display_limit": 10, "synonym_model": "mistral-large2"},
     }
 
@@ -129,7 +125,7 @@ def config_missing_enrichment_synonym_max_count() -> Dict[str, Any]:
 @pytest.fixture
 def config_missing_all_optional_fields() -> Dict[str, Any]:
     """Config missing all optional fields."""
-    return {"project": {"semantic_models_dir": "semantic_models", "dbt_models_dir": "models"}}
+    return {"project": {"semantic_models_dir": "semantic_models"}}
 
 
 # ============================================================================
@@ -162,35 +158,30 @@ class TestValidateConfigRequiredFields:
         assert "project.semantic_models_dir" in missing_required
         assert len(missing_required) == 1
 
-    def test_missing_dbt_models_dir(self, config_missing_dbt_models_dir):
-        """Missing project.dbt_models_dir should fail validation."""
-        is_valid, missing_required, _ = validate_config(config_missing_dbt_models_dir)
-        assert is_valid is False
-        assert "project.dbt_models_dir" in missing_required
-        assert len(missing_required) == 1
-
-    def test_missing_both_required_fields(self):
-        """Missing both required fields should fail validation."""
+    def test_missing_required_field(self):
+        """Missing required semantic_models_dir should fail validation."""
+        # Note: dbt_models_dir is no longer required - auto-detected from dbt_project.yml
         config = {"project": {}}
         is_valid, missing_required, _ = validate_config(config)
         assert is_valid is False
         assert "project.semantic_models_dir" in missing_required
-        assert "project.dbt_models_dir" in missing_required
-        assert len(missing_required) == 2
+        assert len(missing_required) == 1
 
     def test_missing_project_section(self, config_missing_project_section):
         """Missing project section entirely should fail validation."""
         is_valid, missing_required, _ = validate_config(config_missing_project_section)
         assert is_valid is False
         assert "project.semantic_models_dir" in missing_required
-        assert "project.dbt_models_dir" in missing_required
+        # Note: dbt_models_dir is no longer required
+        assert len(missing_required) == 1
 
     def test_empty_project_section(self, config_empty_project_section):
         """Empty project section should fail validation."""
         is_valid, missing_required, _ = validate_config(config_empty_project_section)
         assert is_valid is False
         assert "project.semantic_models_dir" in missing_required
-        assert "project.dbt_models_dir" in missing_required
+        # Note: dbt_models_dir is no longer required
+        assert len(missing_required) == 1
 
 
 # ============================================================================
@@ -305,7 +296,7 @@ class TestValidateAndReportConfig:
         """Test that nested field paths are handled correctly."""
         # Config with deeply nested structure (future-proofing)
         config = {
-            "project": {"semantic_models_dir": "semantic_models", "dbt_models_dir": "models"},
+            "project": {"semantic_models_dir": "semantic_models"},
             "nested": {"deep": {"value": "test"}},  # Not validated, but shouldn't break
         }
         is_valid, missing_required, _ = validate_config(config)
@@ -326,21 +317,21 @@ class TestConfigValidatorEdgeCases:
         config = {}
         is_valid, missing_required, _ = validate_config(config)
         assert is_valid is False
-        assert len(missing_required) == 2  # Both required fields missing
+        # Only semantic_models_dir is required now (dbt_models_dir auto-detected from dbt_project.yml)
+        assert len(missing_required) == 1
 
     def test_none_values(self):
         """Config with None values should fail validation."""
-        config = {"project": {"semantic_models_dir": None, "dbt_models_dir": None}}
+        config = {"project": {"semantic_models_dir": None}}
         is_valid, missing_required, _ = validate_config(config)
         assert is_valid is False
         assert "project.semantic_models_dir" in missing_required
-        assert "project.dbt_models_dir" in missing_required
 
     def test_empty_string_values(self):
         """Config with empty string values should be considered present."""
         # Note: Empty strings are technically present, so validation passes
         # The code checks for key existence, not value truthiness
-        config = {"project": {"semantic_models_dir": "", "dbt_models_dir": ""}}
+        config = {"project": {"semantic_models_dir": ""}}
         # Empty strings are present (validation only checks existence, not value)
         is_valid, missing_required, _ = validate_config(config)
         assert is_valid is True  # Keys exist, even if values are empty
@@ -356,7 +347,8 @@ class TestConfigValidatorEdgeCases:
         config = {"project": "not_a_dict"}
         is_valid, missing_required, _ = validate_config(config)
         assert is_valid is False
-        assert len(missing_required) == 2  # Can't navigate into non-dict
+        # Only semantic_models_dir is required now (dbt_models_dir auto-detected)
+        assert len(missing_required) == 1  # Can't navigate into non-dict
 
     def test_extra_unrecognized_fields(self, valid_complete_config):
         """Config with extra unrecognized fields should still validate."""

--- a/tests/unit/shared/test_file_utils.py
+++ b/tests/unit/shared/test_file_utils.py
@@ -1,0 +1,174 @@
+"""
+Tests for file_utils module.
+
+Tests the get_dbt_model_paths function that reads model paths from dbt_project.yml.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from snowflake_semantic_tools.shared.config import Config
+from snowflake_semantic_tools.shared.utils.file_utils import get_dbt_model_paths
+
+
+class TestGetDbtModelPaths:
+    """Test get_dbt_model_paths function."""
+
+    @pytest.fixture(autouse=True)
+    def setup_and_teardown(self):
+        """Save and restore cwd for each test."""
+        try:
+            original_cwd = Path.cwd()
+        except (FileNotFoundError, OSError):
+            import tempfile
+
+            temp_dir = tempfile.mkdtemp()
+            os.chdir(temp_dir)
+            original_cwd = Path(temp_dir)
+
+        yield
+
+        try:
+            if original_cwd.exists():
+                os.chdir(original_cwd)
+        except (FileNotFoundError, OSError):
+            pass
+        Config._instance = None
+
+    def test_reads_single_model_path(self, tmp_path):
+        """Test reading single model-paths value from dbt_project.yml."""
+        dbt_project = tmp_path / "dbt_project.yml"
+        dbt_project.write_text(
+            """
+name: 'test_project'
+profile: 'test'
+model-paths: ["models"]
+"""
+        )
+
+        os.chdir(tmp_path)
+        result = get_dbt_model_paths()
+
+        assert len(result) == 1
+        assert result[0] == tmp_path / "models"
+
+    def test_reads_multiple_model_paths(self, tmp_path):
+        """Test reading multiple model-paths values from dbt_project.yml."""
+        dbt_project = tmp_path / "dbt_project.yml"
+        dbt_project.write_text(
+            """
+name: 'test_project'
+profile: 'test'
+model-paths: ["models", "marts", "staging"]
+"""
+        )
+
+        os.chdir(tmp_path)
+        result = get_dbt_model_paths()
+
+        assert len(result) == 3
+        assert tmp_path / "models" in result
+        assert tmp_path / "marts" in result
+        assert tmp_path / "staging" in result
+
+    def test_custom_model_path(self, tmp_path):
+        """Test reading custom model path from dbt_project.yml."""
+        dbt_project = tmp_path / "dbt_project.yml"
+        dbt_project.write_text(
+            """
+name: 'test_project'
+profile: 'test'
+model-paths: ["dbt_models"]
+"""
+        )
+
+        os.chdir(tmp_path)
+        result = get_dbt_model_paths()
+
+        assert len(result) == 1
+        assert result[0] == tmp_path / "dbt_models"
+
+    def test_no_dbt_project_yml_fallback(self, tmp_path):
+        """Test fallback to default ["models"] when dbt_project.yml doesn't exist."""
+        os.chdir(tmp_path)
+        result = get_dbt_model_paths()
+
+        assert len(result) == 1
+        assert result[0] == tmp_path / "models"
+
+    def test_dbt_project_without_model_paths(self, tmp_path):
+        """Test fallback when dbt_project.yml exists but has no model-paths."""
+        dbt_project = tmp_path / "dbt_project.yml"
+        dbt_project.write_text(
+            """
+name: 'test_project'
+profile: 'test'
+"""
+        )
+
+        os.chdir(tmp_path)
+        result = get_dbt_model_paths()
+
+        assert len(result) == 1
+        assert result[0] == tmp_path / "models"
+
+    def test_invalid_yaml_fallback(self, tmp_path):
+        """Test fallback when dbt_project.yml has invalid YAML."""
+        dbt_project = tmp_path / "dbt_project.yml"
+        dbt_project.write_text("invalid: yaml: syntax:")
+
+        os.chdir(tmp_path)
+        result = get_dbt_model_paths()
+
+        # Should fall back to default
+        assert len(result) == 1
+        assert result[0] == tmp_path / "models"
+
+    def test_empty_dbt_project_yml(self, tmp_path):
+        """Test fallback when dbt_project.yml is empty."""
+        dbt_project = tmp_path / "dbt_project.yml"
+        dbt_project.write_text("")
+
+        os.chdir(tmp_path)
+        result = get_dbt_model_paths()
+
+        # Should fall back to default
+        assert len(result) == 1
+        assert result[0] == tmp_path / "models"
+
+    def test_returns_absolute_paths(self, tmp_path):
+        """Test that returned paths are absolute."""
+        dbt_project = tmp_path / "dbt_project.yml"
+        dbt_project.write_text(
+            """
+name: 'test_project'
+model-paths: ["models"]
+"""
+        )
+
+        os.chdir(tmp_path)
+        result = get_dbt_model_paths()
+
+        assert len(result) == 1
+        assert result[0].is_absolute()
+
+    def test_nested_model_paths(self, tmp_path):
+        """Test reading nested model paths from dbt_project.yml."""
+        dbt_project = tmp_path / "dbt_project.yml"
+        dbt_project.write_text(
+            """
+name: 'test_project'
+profile: 'test'
+model-paths: ["src/models", "src/marts"]
+"""
+        )
+
+        os.chdir(tmp_path)
+        result = get_dbt_model_paths()
+
+        assert len(result) == 2
+        assert tmp_path / "src/models" in result
+        assert tmp_path / "src/marts" in result


### PR DESCRIPTION
## Description

This PR removes the requirement for `dbt_models_dir` in `sst_config.yaml` by reading `model-paths` directly from `dbt_project.yml`. This eliminates configuration duplication and aligns with how SST already handles other dbt configurations (like profiles).

**Problem:** Users had to specify dbt models directory in two places, leading to configuration drift and DRY violations.

**Solution:** SST now auto-detects model paths from `dbt_project.yml`, with fallback to `["models"]` if not specified.

## Related Issue

Closes #94

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Test improvements
- [ ] Other (please describe):

## Changes Made

### Core Implementation

| File | Change |
|------|--------|
| `snowflake_semantic_tools/shared/utils/file_utils.py` | Added `get_dbt_model_paths()` function, updated `find_dbt_model_files()` to support multiple directories |
| `snowflake_semantic_tools/shared/config_validator.py` | Removed `project.dbt_models_dir` from required fields |
| `snowflake_semantic_tools/templates/sst_config.yaml.j2` | Removed `dbt_models_dir` line |
| `snowflake_semantic_tools/services/init_wizard.py` | Removed `dbt_models_dir` from `WizardConfig` and config output |
| `snowflake_semantic_tools/shared/config_utils.py` | Updated `get_project_paths()` to return `dbt_models_dirs` (list) |
| `snowflake_semantic_tools/shared/config.py` | Removed `dbt_models_dir` from defaults |

### Tests

| File | Change |
|------|--------|
| `tests/unit/shared/test_file_utils.py` | **New** - 9 tests for `get_dbt_model_paths()` |
| `tests/unit/shared/test_config_validator.py` | Updated to reflect single required field |
| `tests/unit/shared/test_config_utils.py` | Updated for `dbt_models_dirs` list return |
| `tests/unit/shared/test_config_edge_cases.py` | Removed `dbt_models_dir` references |
| `tests/unit/services/test_init_wizard.py` | Updated config creation tests |

## Testing

- [x] Unit tests pass (`pytest tests/unit/`)
- [x] All existing tests pass
- [x] New tests added for new functionality
- [ ] Tested locally with Python 3.9-3.11
- [x] Manual testing completed (if applicable)
- [x] Test coverage maintained or improved (target: >90%)

### Test Results

```
All 1023 unit tests pass ✅
Black formatting verified ✅
isort imports verified ✅
```

**New test coverage:**
- Single `model-paths` value
- Multiple `model-paths` values
- Custom model path names
- Missing `dbt_project.yml` (fallback to `["models"]`)
- Missing `model-paths` key (fallback to `["models"]`)
- Invalid YAML handling
- Empty file handling
- Absolute path resolution
- Nested paths (e.g., `src/models`)

## Checklist

### Code Quality
- [x] Code follows the project's style guidelines (Black, line length 120)
- [x] Imports sorted with isort (black profile)
- [ ] Type hints added for new code (`mypy snowflake_semantic_tools/` passes)
- [x] Docstrings added for public functions/classes
- [x] No linting errors
- [ ] Pre-commit hooks pass (if using pre-commit)

### Testing & Validation
- [x] All tests pass (`pytest tests/unit/`)
- [x] New functionality has test coverage
- [x] Test results included above

### Documentation & Compatibility
- [ ] Documentation updated (if needed)
- [x] Backward compatibility maintained (if applicable)
- [ ] Breaking changes discussed with maintainer first (see CONTRIBUTING.md)

### Performance
- [x] Performance impact considered
- [x] No significant performance regressions

## Screenshots / Examples

### Before

```yaml
# sst_config.yaml
project:
  semantic_models_dir: "snowflake_semantic_models"
  dbt_models_dir: "models"  # Required - duplicate of dbt_project.yml
```

### After

```yaml
# sst_config.yaml
project:
  semantic_models_dir: "snowflake_semantic_models"
  # Model paths auto-detected from dbt_project.yml ✨
```

### Multi-Path Support (New Capability)

```yaml
# dbt_project.yml
model-paths: ["models", "marts", "staging"]
```

SST will automatically scan all directories for dbt model files.

## Additional Notes

### Migration

- **Non-breaking**: Existing `dbt_models_dir` in `sst_config.yaml` will simply be ignored (not an error)
- **No action required**: Users can optionally remove `dbt_models_dir` from their configs

### Resolution Order

```
1. dbt_project.yml → model-paths (primary source)
2. Default → ["models"] (fallback if not specified)
```
