### PR TITLE
chore: Bump version to 0.2.2

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -207,7 +207,7 @@ sst debug --target prod --test-connection
 
 **Example output:**
 ```
-SST Debug (v0.2.1)
+SST Debug (v0.2.2)
 
   ──────────────────────────────────────────────────
   Profile Configuration

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -149,7 +149,7 @@ sst debug --target prod --test-connection
 #### Output Format
 
 ```
-SST Debug (v0.2.1)
+SST Debug (v0.2.2)
 
   ──────────────────────────────────────────────────
   Profile Configuration
@@ -633,7 +633,7 @@ sst migrate-meta models/ --verbose
 ### Output Format
 
 ```
-Running with sst=0.2.1
+Running with sst=0.2.2
 
 Migrating 15 YAML file(s)...
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -32,7 +32,7 @@ pip install snowflake-semantic-tools
 
 ```bash
 sst --version
-# Should show: snowflake-semantic-tools, version 0.2.1
+# Should show: snowflake-semantic-tools, version 0.2.2
 ```
 
 ---
@@ -218,7 +218,7 @@ sst --version
 
 **Example `sst debug` output:**
 ```
-SST Debug (v0.2.1)
+SST Debug (v0.2.2)
 
   ──────────────────────────────────────────────────
   Profile Configuration
@@ -270,7 +270,7 @@ sst enrich models/analytics/
 
 **Output:**
 ```
-09:15:00  Running with sst=0.2.1
+09:15:00  Running with sst=0.2.2
 09:15:00  Resolving 2 model name(s)...
 09:15:00  Resolved 2 model(s) [OK]
 09:15:00  Connecting to Snowflake...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "snowflake-semantic-tools"
-version = "0.2.1"
+version = "0.2.2"
 description = "dbt extension for managing Snowflake Semantic Views and Cortex Analyst semantic models"
 readme = "README.md"
 authors = ["Matt Luizzi <matthew.luizzi@whoop.com>"]

--- a/snowflake_semantic_tools/_version.py
+++ b/snowflake_semantic_tools/_version.py
@@ -1,3 +1,3 @@
 """Version information for snowflake-semantic-tools."""
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"


### PR DESCRIPTION
## Description

This PR bumps the package version from 0.2.1 to 0.2.2 for the next release.

## Changes

Updated version references in:
- `snowflake_semantic_tools/_version.py` - Core version string
- `pyproject.toml` - Poetry package version
- `docs/getting-started.md` - Documentation examples
- `docs/cli-reference.md` - CLI output examples
- `docs/authentication.md` - Debug output examples

## Release Notes

### v0.2.2

This release includes the following changes since v0.2.1:

- **feat:** Auto-detect dbt model paths from `dbt_project.yml` (#98)
- **fix:** Prevent duplicate table synonyms across tables in semantic views (#99)

## Checklist

- [x] Version updated in `_version.py`
- [x] Version updated in `pyproject.toml`
- [x] Documentation version references updated
