### PR TITLE
Fix: propagate semantic view descriptions during generation

### DIFF
--- a/snowflake_semantic_tools/services/generate_semantic_views.py
+++ b/snowflake_semantic_tools/services/generate_semantic_views.py
@@ -47,7 +47,7 @@ class MetadataClient:
         """Get list of available semantic views from metadata."""
         try:
             query = f"""
-            SELECT DISTINCT name, tables
+            SELECT DISTINCT name, tables, description
             FROM {self.database}.{self.schema}.SM_SEMANTIC_VIEWS
             ORDER BY name
             """
@@ -632,7 +632,13 @@ class SemanticViewGenerationService:
                     logger.warning(f"Failed to parse tables for view {view.get('NAME')}")
                     tables = []
 
-                view_configs.append({"name": view["NAME"], "tables": tables})
+                view_configs.append(
+                    {
+                        "name": view["NAME"],
+                        "tables": tables,
+                        "description": view.get("DESCRIPTION") or "",
+                    }
+                )
 
             # Filter by requested views if specified
             if config.views_to_generate:

--- a/tests/unit/services/test_generate_semantic_views.py
+++ b/tests/unit/services/test_generate_semantic_views.py
@@ -1,0 +1,288 @@
+"""Unit tests for semantic view generation service."""
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from snowflake_semantic_tools.services.generate_semantic_views import (
+    GenerateConfig,
+    GenerateResult,
+    MetadataClient,
+    SemanticViewGenerationService,
+    UnifiedGenerationConfig,
+)
+
+
+class TestMetadataClientDescriptionQuery:
+    """Test that MetadataClient queries include description."""
+
+    def test_get_available_views_includes_description(self):
+        """Verify that get_available_views query fetches description column."""
+        mock_client = MagicMock()
+        mock_df = pd.DataFrame(
+            [
+                {
+                    "NAME": "test_view",
+                    "TABLES": '["orders", "customers"]',
+                    "DESCRIPTION": "Comprehensive analytics view for customer orders",
+                }
+            ]
+        )
+        mock_client.execute_query.return_value = mock_df
+
+        metadata_client = MetadataClient(mock_client, "TEST_DB", "TEST_SCHEMA")
+        views = metadata_client.get_available_views()
+
+        # Verify the query was called
+        mock_client.execute_query.assert_called_once()
+        query = mock_client.execute_query.call_args[0][0]
+
+        # Verify description is in the query
+        assert "description" in query.lower()
+
+        # Verify the result includes description
+        assert len(views) == 1
+        assert views[0]["DESCRIPTION"] == "Comprehensive analytics view for customer orders"
+
+    def test_get_available_views_handles_null_description(self):
+        """Verify null description doesn't cause errors."""
+        mock_client = MagicMock()
+        mock_df = pd.DataFrame(
+            [
+                {
+                    "NAME": "test_view",
+                    "TABLES": '["orders"]',
+                    "DESCRIPTION": None,
+                }
+            ]
+        )
+        mock_client.execute_query.return_value = mock_df
+
+        metadata_client = MetadataClient(mock_client, "TEST_DB", "TEST_SCHEMA")
+        views = metadata_client.get_available_views()
+
+        assert len(views) == 1
+        assert views[0]["DESCRIPTION"] is None
+
+
+class TestGenerateMethodDescriptionFlow:
+    """Test that descriptions flow correctly through the generate() method."""
+
+    @patch("snowflake_semantic_tools.services.generate_semantic_views.SemanticViewBuilder")
+    @patch("snowflake_semantic_tools.services.generate_semantic_views.ConnectionManager")
+    @patch("snowflake_semantic_tools.services.generate_semantic_views.SnowflakeClient")
+    def test_description_included_in_view_configs(
+        self, mock_snowflake_client_class, mock_conn_manager_class, mock_builder_class
+    ):
+        """Verify that description from metadata is included in view_configs passed to execute()."""
+        # Mock SnowflakeClient for metadata queries
+        mock_client_instance = MagicMock()
+        mock_snowflake_client_class.return_value = mock_client_instance
+
+        # Mock the metadata query result with description
+        mock_df = pd.DataFrame(
+            [
+                {
+                    "NAME": "test_view",
+                    "TABLES": '["orders", "customers"]',
+                    "DESCRIPTION": "Comprehensive analytics view for customer orders",
+                }
+            ]
+        )
+
+        # Mock validation queries
+        mock_schema_df = pd.DataFrame([{"SCHEMA_EXISTS": 1}])
+        mock_tables_df = pd.DataFrame([{"TABLE_NAME": "SM_SEMANTIC_VIEWS"}])
+
+        def query_side_effect(query):
+            if "information_schema.schemata" in query:
+                return mock_schema_df
+            elif "information_schema.tables" in query:
+                return mock_tables_df
+            else:
+                return mock_df
+
+        mock_client_instance.execute_query.side_effect = query_side_effect
+
+        # Mock SnowflakeConfig
+        mock_config = MagicMock()
+
+        # Create the service (mocked internals)
+        service = SemanticViewGenerationService(mock_config)
+
+        # Capture what gets passed to execute()
+        captured_config = None
+
+        def capture_execute(config, **kwargs):
+            nonlocal captured_config
+            captured_config = config
+            return GenerateResult(
+                success=True,
+                views_generated=["test_view"],
+                views_failed=[],
+                errors=[],
+                sql_statements={"test_view": "CREATE ..."},
+            )
+
+        with patch.object(service, "execute", side_effect=capture_execute):
+            config = UnifiedGenerationConfig(
+                target_database="TEST_DB",
+                target_schema="TEST_SCHEMA",
+                metadata_database="TEST_DB",
+                metadata_schema="TEST_SCHEMA",
+            )
+            service.generate(config)
+
+        # Verify the description was passed through
+        assert captured_config is not None
+        view_config = captured_config.views_to_generate[0]
+        assert view_config.get("description") == "Comprehensive analytics view for customer orders"
+
+    @patch("snowflake_semantic_tools.services.generate_semantic_views.SemanticViewBuilder")
+    @patch("snowflake_semantic_tools.services.generate_semantic_views.ConnectionManager")
+    @patch("snowflake_semantic_tools.services.generate_semantic_views.SnowflakeClient")
+    def test_empty_description_handled_gracefully(
+        self, mock_snowflake_client_class, mock_conn_manager_class, mock_builder_class
+    ):
+        """Verify that empty/None descriptions don't cause errors."""
+        mock_client_instance = MagicMock()
+        mock_snowflake_client_class.return_value = mock_client_instance
+
+        # Mock the metadata query result with None description
+        mock_df = pd.DataFrame(
+            [
+                {
+                    "NAME": "test_view",
+                    "TABLES": '["orders"]',
+                    "DESCRIPTION": None,
+                }
+            ]
+        )
+
+        mock_schema_df = pd.DataFrame([{"SCHEMA_EXISTS": 1}])
+        mock_tables_df = pd.DataFrame([{"TABLE_NAME": "SM_SEMANTIC_VIEWS"}])
+
+        def query_side_effect(query):
+            if "information_schema.schemata" in query:
+                return mock_schema_df
+            elif "information_schema.tables" in query:
+                return mock_tables_df
+            else:
+                return mock_df
+
+        mock_client_instance.execute_query.side_effect = query_side_effect
+
+        mock_config = MagicMock()
+        service = SemanticViewGenerationService(mock_config)
+
+        captured_config = None
+
+        def capture_execute(config, **kwargs):
+            nonlocal captured_config
+            captured_config = config
+            return GenerateResult(
+                success=True,
+                views_generated=["test_view"],
+                views_failed=[],
+                errors=[],
+            )
+
+        with patch.object(service, "execute", side_effect=capture_execute):
+            config = UnifiedGenerationConfig(
+                target_database="TEST_DB",
+                target_schema="TEST_SCHEMA",
+                metadata_database="TEST_DB",
+                metadata_schema="TEST_SCHEMA",
+            )
+            service.generate(config)
+
+        # Verify empty string is used as fallback for None
+        view_config = captured_config.views_to_generate[0]
+        assert view_config.get("description") == ""
+
+
+class TestExecuteMethodDescriptionPassthrough:
+    """Test that execute() passes description to build_semantic_view."""
+
+    @patch("snowflake_semantic_tools.services.generate_semantic_views.SemanticViewBuilder")
+    @patch("snowflake_semantic_tools.services.generate_semantic_views.ConnectionManager")
+    def test_description_passed_to_builder(self, mock_conn_manager_class, mock_builder_class):
+        """Verify execute() passes description from view_config to builder."""
+        # Set up mock builder
+        mock_builder_instance = MagicMock()
+        mock_builder_instance.metadata_database = "TEST_DB"
+        mock_builder_instance.metadata_schema = "TEST_SCHEMA"
+        mock_builder_instance.build_semantic_view.return_value = {
+            "success": True,
+            "sql_statement": "CREATE SEMANTIC VIEW test_view ...",
+        }
+        mock_builder_class.return_value = mock_builder_instance
+
+        mock_config = MagicMock()
+        service = SemanticViewGenerationService(mock_config)
+
+        # Create config with description
+        view_configs = [
+            {
+                "name": "test_view",
+                "tables": ["orders", "customers"],
+                "description": "Business analytics view for order insights",
+            }
+        ]
+
+        config = GenerateConfig(
+            views_to_generate=view_configs,
+            target_database="TEST_DB",
+            target_schema="TEST_SCHEMA",
+            metadata_database="TEST_DB",
+            metadata_schema="TEST_SCHEMA",
+            execute=False,
+        )
+
+        service.execute(config)
+
+        # Verify build_semantic_view was called with the description
+        mock_builder_instance.build_semantic_view.assert_called_once()
+        call_kwargs = mock_builder_instance.build_semantic_view.call_args[1]
+        assert call_kwargs["description"] == "Business analytics view for order insights"
+
+    @patch("snowflake_semantic_tools.services.generate_semantic_views.SemanticViewBuilder")
+    @patch("snowflake_semantic_tools.services.generate_semantic_views.ConnectionManager")
+    def test_empty_description_passed_to_builder(self, mock_conn_manager_class, mock_builder_class):
+        """Verify execute() passes empty description without error."""
+        mock_builder_instance = MagicMock()
+        mock_builder_instance.metadata_database = "TEST_DB"
+        mock_builder_instance.metadata_schema = "TEST_SCHEMA"
+        mock_builder_instance.build_semantic_view.return_value = {
+            "success": True,
+            "sql_statement": "CREATE SEMANTIC VIEW test_view ...",
+        }
+        mock_builder_class.return_value = mock_builder_instance
+
+        mock_config = MagicMock()
+        service = SemanticViewGenerationService(mock_config)
+
+        view_configs = [
+            {
+                "name": "test_view",
+                "tables": ["orders"],
+                "description": "",  # Empty description
+            }
+        ]
+
+        config = GenerateConfig(
+            views_to_generate=view_configs,
+            target_database="TEST_DB",
+            target_schema="TEST_SCHEMA",
+            metadata_database="TEST_DB",
+            metadata_schema="TEST_SCHEMA",
+            execute=False,
+        )
+
+        service.execute(config)
+
+        # Verify build_semantic_view was called with empty description
+        mock_builder_instance.build_semantic_view.assert_called_once()
+        call_kwargs = mock_builder_instance.build_semantic_view.call_args[1]
+        assert call_kwargs["description"] == ""


### PR DESCRIPTION
## Description

Fixes a bug where descriptions defined in semantic view YAML files were not being applied to generated Snowflake SEMANTIC VIEW objects. Views received a generic placeholder comment instead of the meaningful business context from the YAML.

## Related Issue

This PR closes #109.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [X] Test improvements
- [ ] Other (please describe):

## Root Cause

The `generate()` method in `SemanticViewGenerationService` was not including the `DESCRIPTION` field when building `view_configs`:

1. `MetadataClient.get_available_views()` query only selected `name` and `tables` columns
2. The `view_configs` dict only included `name` and `tables`, dropping the description

## Changes Made

### Bug Fix (`snowflake_semantic_tools/services/generate_semantic_views.py`)

1. Added `description` to the SELECT query in `MetadataClient.get_available_views()`
2. Added `description` field to `view_configs` dict in `generate()` method
3. Handle `None` descriptions by defaulting to empty string

### Tests (`tests/unit/services/test_generate_semantic_views.py`)

- 6 new unit tests verifying description flow through the generation pipeline:
  - `TestMetadataClientDescriptionQuery` - Verifies query includes description
  - `TestGenerateMethodDescriptionFlow` - Verifies description passes to execute()
  - `TestExecuteMethodDescriptionPassthrough` - Verifies description reaches builder

## Testing

- [X] Unit tests pass (`pytest tests/unit/`)
- [X] All existing tests pass
- [X] New tests added for new functionality
- [X] Manual testing completed

### Test Results

```bash
# New unit tests pass
pytest tests/unit/services/test_generate_semantic_views.py -v
========================================== 6 passed ==========================================
```

### Manual Verification

Tested against real Snowflake instance:
1. Created semantic view with description in YAML
2. Ran `sst extract` - description stored in SM_SEMANTIC_VIEWS table
3. Ran `sst generate --dry-run` - generated SQL contains correct COMMENT clause

**Before fix:**
```sql
COMMENT = 'Semantic view generated for tables: CUSTOMERS, ORDERS, PRODUCTS'
```

**After fix:**
```sql
COMMENT = 'Comprehensive analytics view combining customers, orders, and products'
```

## Checklist

### Code Quality
- [X] Code follows the project's style guidelines (Black, line length 120)
- [X] Imports sorted with isort (black profile)
- [X] No new type hint issues introduced
- [X] No linting errors

### Testing & Validation
- [X] All tests pass (`pytest tests/unit/`)
- [X] New functionality has test coverage
- [X] Test results included above

### Documentation & Compatibility
- [X] Backward compatibility maintained
- [X] No breaking changes