### PR TITLE
[SST-128] Add AGENTS.md and Cortex Code skills for development workflows

### DIFF
--- a/.cortex/skills/opening-sst-pr/SKILL.md
+++ b/.cortex/skills/opening-sst-pr/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: opening-sst-pr
+description: "Create a pull request on the SST repo. Use when: opening a PR, creating a pull request, submitting changes. Triggers: open PR, create PR, pull request, submit PR, push and create PR."
+---
+
+# Opening an SST Pull Request
+
+Create a pull request on WhoopInc/snowflake-semantic-tools following project conventions.
+
+## Rules
+
+1. **Every PR must address exactly one GitHub issue.** Do not bundle multiple fixes or features.
+2. **Commit messages MUST match this regex** (enforced by GitHub):
+   ```
+   ^(\[[A-Z][A-Z0-9]*-\d+\]|[a-z]+\([A-Z][A-Z0-9]*-\d+\):|\([A-Z][A-Z0-9]*-\d+\)|Ver: (\d+\.\d+\.\d+(\.\d+)?|\d+\.\d+\.\d+-\d+)|(?i:initial commit))
+   ```
+   Valid formats:
+   - `[SST-119] Fix unique key error` (bracket prefix — **preferred**)
+   - `fix(SST-119): unique key error` (conventional commit)
+   - `(SST-119) Fix unique key error` (paren prefix)
+   - `Ver: 0.2.5` (version bumps only)
+3. **Tests must pass** before the PR is ready for review.
+
+## Workflow
+
+### Step 1: Identify the GitHub issue
+
+Every PR must link to a GitHub issue. If one doesn't exist yet, load the `sst-create-issue` skill and follow its workflow to create one first. Note the issue number (e.g., `119`).
+
+### Step 2: Create a feature branch
+
+```bash
+git checkout -b <branch-name> main
+```
+Branch naming: `fix/<description>` or `feature/<description>`
+
+### Step 3: Make changes, run tests
+
+```bash
+python -m pytest tests/unit/ -v
+black snowflake_semantic_tools/
+isort snowflake_semantic_tools/
+mypy snowflake_semantic_tools/
+```
+
+### Step 3b: Run E2E tests (for code changes)
+
+If the PR modifies Python code under `snowflake_semantic_tools/` or `tests/`, run end-to-end validation to verify the full pipeline still works. Load the `sst-e2e-test` skill and follow its workflow.
+
+Skip this step for documentation-only or config-only changes.
+
+### Step 4: Commit and push
+
+**⚠️ MANDATORY STOPPING POINT**: Confirm with the user before committing and pushing. Show them what will be committed (`git status` and `git diff` for modified files). Do NOT commit without explicit approval.
+
+The commit message MUST start with a ticket reference. Stage only the files the user approved — do NOT use `git add .` blindly:
+```bash
+git add <specific files...>
+git commit -m "[SST-<issue#>] <descriptive message>"
+git push -u origin <branch-name>
+```
+
+### Step 5: Create the PR
+
+**⚠️ MANDATORY STOPPING POINT**: Confirm with the user before creating the PR. Show them the title and body that will be used. Do NOT create without explicit approval.
+
+Read the PR template at `.github/pull_request_template.md` and use it as the body. Fill in the sections based on the changes made. Then create the PR:
+
+```bash
+gh pr create --repo WhoopInc/snowflake-semantic-tools \
+  --title "[SST-<issue#>] <description>" \
+  --body "<filled-in template>"
+```
+
+**CRITICAL**: The Related Issue section MUST contain `Closes #<issue-number>`. This auto-closes the linked issue when the PR merges. Without it, issues accumulate as stale open tickets.
+
+### Step 6: Verify the PR title matches the commit regex
+
+After creation, confirm the title starts with a valid ticket reference:
+```bash
+gh pr view <pr-number> --repo WhoopInc/snowflake-semantic-tools --json title --jq '.title'
+```
+If it doesn't match, update it:
+```bash
+gh pr edit <pr-number> --repo WhoopInc/snowflake-semantic-tools --title "[SST-<issue#>] <description>"
+```
+
+## Common Mistakes
+
+- **Missing ticket number**: Commit/merge will be rejected by GitHub. Always include a ticket prefix.
+- **Lowercase project key**: `[sst-119]` fails — must be uppercase `[SST-119]`.
+- **Multiple issues in one PR**: Split into separate PRs, one per issue.
+- **Forgetting to link the issue**: Use `Closes #<number>` in the PR body so it auto-closes on merge.
+
+## Stopping Points
+
+- ✋ Step 4: Before committing and pushing (get user approval)
+- ✋ Step 5: Before creating the PR (confirm title and body with user)
+
+## Output
+
+A GitHub pull request with proper ticket reference, linked issue, and passing tests.

--- a/.cortex/skills/sst-create-issue/SKILL.md
+++ b/.cortex/skills/sst-create-issue/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: sst-create-issue
+description: "Create a GitHub issue on the SST repo. Use when: filing bugs, requesting features, reporting doc issues. Triggers: create issue, file bug, feature request, report issue, open issue, new issue."
+---
+
+# Creating a GitHub Issue on SST
+
+File a properly formatted GitHub issue on WhoopInc/snowflake-semantic-tools.
+
+## Issue Templates
+
+This repo has three issue templates in `.github/ISSUE_TEMPLATE/`. Always use one of them.
+
+| Template | File | Title Prefix | Label |
+|----------|------|-------------|-------|
+| Bug Report | `bug_report.yml` | `[Bug]: ` | `bug` |
+| Feature Request | `feature_request.yml` | `[Feature]: ` | `enhancement` |
+| Documentation Issue | `documentation.yml` | `[Docs]: ` | `documentation` |
+
+## Workflow
+
+### Step 1: Search for duplicates
+
+```bash
+gh issue list --repo WhoopInc/snowflake-semantic-tools --search "<keywords>"
+```
+
+### Step 2: Determine issue type
+
+Ask the user which type of issue they want to create (bug, feature, or docs).
+
+### Step 3: Read the template
+
+Read the corresponding template file from `.github/ISSUE_TEMPLATE/` to get the required fields and structure. Use the fields defined in the YAML template to build the issue body.
+
+For bug reports, also gather environment info:
+```bash
+sst --version
+python --version
+```
+
+### Step 4: Draft the issue
+
+Populate the template fields based on the user's input and context. Use the correct title prefix and label from the table above.
+
+**⚠️ MANDATORY STOPPING POINT**: Present the drafted issue title and body to the user for review. Do NOT create the issue until user approves the content.
+
+### Step 5: Create the issue
+
+After user approval:
+```bash
+gh issue create --repo WhoopInc/snowflake-semantic-tools \
+  --title "<prefix> <concise description>" \
+  --label "<label>" \
+  --body "<filled-in template body>"
+```
+
+## Quality Checklist
+
+A good issue has:
+- A **specific title** (not "SST doesn't work")
+- **Reproduction steps** that someone else can follow
+- **Error messages** copied verbatim (not paraphrased)
+- **Environment details** so the maintainer can replicate the setup
+- **One issue per ticket** — don't combine multiple bugs or requests
+
+## Stopping Points
+
+- ✋ Step 4: Before creating the issue (present draft for user approval)
+
+## Output
+
+A GitHub issue URL with properly formatted content matching the repo's issue templates.

--- a/.cortex/skills/sst-e2e-test/SKILL.md
+++ b/.cortex/skills/sst-e2e-test/SKILL.md
@@ -200,7 +200,7 @@ cd "$JAFFLE_SHOP_DIR"
 echo "1" | sst enrich models/ --target <TARGET>
 ```
 
-Replace `<TARGET>` with the user's chosen dbt target from Phase 0e.
+Replace `<TARGET>` with the user's chosen dbt target from the Prerequisites section.
 
 After enrichment completes, show the diff:
 ```bash

--- a/.cortex/skills/sst-pr-review/SKILL.md
+++ b/.cortex/skills/sst-pr-review/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: sst-pr-review
+description: "Review a pull request on the SST repo. Use when: reviewing PRs, code review, checking PR changes. Triggers: review PR, pull request, code review, PR review."
+---
+
+# SST PR Review
+
+Review a pull request on WhoopInc/snowflake-semantic-tools.
+
+## Workflow
+
+### Step 1: Fetch PR metadata and diff
+
+```bash
+gh pr view <number> --repo WhoopInc/snowflake-semantic-tools --json title,body,state,author,baseRefName,headRefName,additions,deletions,changedFiles
+gh pr diff <number> --repo WhoopInc/snowflake-semantic-tools
+```
+
+### Step 2: Process enforcement checks
+
+These are non-negotiable. Fail the review if any are violated.
+
+**Commit message regex** — every commit on the PR must match:
+```
+^(\[[A-Z][A-Z0-9]*-\d+\]|[a-z]+\([A-Z][A-Z0-9]*-\d+\):|\([A-Z][A-Z0-9]*-\d+\)|Ver: (\d+\.\d+\.\d+(\.\d+)?|\d+\.\d+\.\d+-\d+)|(?i:initial commit))
+```
+Check with:
+```bash
+gh pr view <number> --repo WhoopInc/snowflake-semantic-tools --json commits --jq '.commits[].messageHeadline'
+```
+
+**Single issue** — the PR body must contain exactly one `Closes #<number>` or `Fixes #<number>`. Multiple linked issues means the PR should be split.
+
+**PR title** — must also match the commit regex (it becomes the merge commit message).
+
+### Step 3: Code review
+
+Read the diff carefully. Focus on:
+
+**Correctness**
+- Edge cases: null/empty inputs, case sensitivity (column/table names must use `.lower()`)
+- Set operations: set equality vs subset vs superset — wrong choice causes silent bugs
+- Control flow: every error-handling branch needs `continue`/`return` or the next check runs on bad state
+- Off-by-one: composite key checks (all columns vs any column)
+
+**Consistency with project conventions**
+- Read `AGENTS.md` and `CONTRIBUTING.md` for current conventions
+- Black formatting (line length 120), isort (black profile), type hints on new code
+- Error messages must be actionable — tell the user what's wrong AND how to fix it
+- Imports at module level, not inside functions
+
+**Architecture**
+- New validation rules belong in `core/validation/rules/` as methods on existing validator classes
+- New CLI options follow Click patterns in `interfaces/cli/commands/`
+- Template references (`{{ ref() }}`) are resolved in `core/parsing/`
+- SM_* table schemas are defined in `core/models/`
+
+### Step 4: Run tests
+
+Load the `sst-test` skill and follow its workflow to run unit tests against the PR branch.
+
+### Step 5: Run E2E tests (for code changes)
+
+If the PR modifies Python code under `snowflake_semantic_tools/` or `tests/`, load the `sst-e2e-test` skill and follow its workflow. Skip for docs/config-only changes.
+
+### Step 6: Present findings
+
+**⚠️ MANDATORY STOPPING POINT**: Present the full review to the user before submitting anything on GitHub. Get explicit approval on the findings.
+
+## Report Format
+
+Structure the review as:
+
+```
+## Process Checks
+- [ ] Commit messages match regex
+- [ ] Single issue linked with Closes #<number>
+- [ ] PR title matches regex
+
+## Findings
+
+### Bugs (must fix)
+1. [severity] file:line — description → suggested fix
+
+### Nits (non-blocking)
+1. file:line — description → suggestion
+
+## Test Results
+- Unit tests: X passed, Y failed
+- E2E: PASS/FAIL/SKIPPED
+
+## Verdict
+APPROVE / REQUEST CHANGES / COMMENT
+```
+
+## Bug Patterns Common in This Codebase
+
+1. **Missing `continue` after error** — validation loops that add an error but don't skip to the next item, causing cascading false errors
+2. **Case sensitivity** — comparing column names without `.lower()` causes mismatches between YAML (mixed case) and catalog (lowercase)
+3. **Set vs list comparison** — composite key validation must use set equality (order-independent), not list equality
+4. **Scope leaks** — variables computed inside an `if` branch referenced outside it (e.g., `right_columns_used` computed inside `if columns:` but used after)
+5. **Redundant imports** — imports inside functions that already exist at module level
+
+## Stopping Points
+
+- ✋ Step 4: Before running tests (ask user which conda environment via `sst-test` skill)
+- ✋ Step 5: Before E2E tests (confirm with user, involves Snowflake compute)
+- ✋ Step 6: Before submitting review on GitHub (present findings for approval)
+
+## Output
+
+Structured review report with process checks, categorized findings (bugs/nits with file:line references), test results, and a clear verdict.

--- a/.cortex/skills/sst-test/SKILL.md
+++ b/.cortex/skills/sst-test/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: sst-test
+description: "Run SST unit tests with pytest. Use when: running tests, checking test coverage, verifying fixes. Triggers: test, pytest, unit test, run tests."
+---
+
+# SST Test
+
+Run the SST test suite using pytest.
+
+## Prerequisites
+
+- Conda environment with SST installed via `pip install -e .`
+- Project uses **Poetry** for dependency management (NOT uv)
+
+## Workflow
+
+### Step 1: Activate environment and navigate to repo
+
+First, list the user's conda environments to find the one with SST installed:
+```bash
+source "$(conda info --base)/etc/profile.d/conda.sh" && conda env list
+```
+
+**⚠️ MANDATORY STOPPING POINT**: Present the results to the user and ask which environment has SST installed. Highlight any environments whose names contain "sst" as likely matches. Do NOT proceed until user responds.
+
+Then activate the chosen environment:
+```bash
+source "$(conda info --base)/etc/profile.d/conda.sh" && conda activate <env-name>
+cd "$(git rev-parse --show-toplevel)"
+```
+
+### Step 2: Run all unit tests
+
+```bash
+python -m pytest tests/unit/ -v
+```
+
+### Step 3: Run specific test file (if targeted testing needed)
+
+```bash
+python -m pytest tests/unit/core/validation/test_relationship_validation.py -v
+```
+
+### Step 4: Run specific test by name pattern
+
+```bash
+python -m pytest tests/unit/ -v -k "test_unique_key"
+```
+
+### Step 5: Run with coverage (optional)
+
+```bash
+python -m pytest tests/unit/ --cov=snowflake_semantic_tools --cov-report=term-missing
+```
+
+### On Failure
+
+**⚠️ MANDATORY STOPPING POINT**: If tests fail, report failures to the user with error messages before taking any corrective action. Do NOT auto-fix without approval.
+
+## Test Structure
+
+```
+tests/
+  unit/
+    core/
+      validation/
+        test_relationship_validation.py  # Relationship rule tests
+        test_validator.py                # Validator integration tests
+      generation/
+        test_semantic_view_builder.py    # SQL generation tests
+      parsing/
+        test_dbt_parser.py              # dbt manifest parsing tests
+```
+
+## Key Conventions
+
+- Test files: `test_*.py`
+- Test functions: `test_*`
+- Fixtures and helpers at the top of each test file
+- Tests use synthetic data (no Snowflake connection needed)
+- Relationship tests build mock `dbt_data` dicts with `sm_tables` and relationship YAML
+
+## Stopping Points
+
+- ✋ Step 1: After listing conda environments (ask user which to activate)
+- ✋ On Failure: After test failures (report before taking action)
+
+## Output
+
+Test results summary: total collected, passed count, failed count, and error messages for any failures.

--- a/.cortex/skills/sst-validate/SKILL.md
+++ b/.cortex/skills/sst-validate/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: sst-validate
+description: "Run SST validation against a dbt project. Use when: validating semantic models, checking relationships, running sst validate. Triggers: validate, sst validate, check models, relationship errors."
+---
+
+# SST Validate
+
+Run `sst validate` against a dbt project and interpret the results.
+
+## Prerequisites
+
+- Conda environment with SST installed
+- For dev branch testing: `pip install -e .` in the SST repo (NOT `poetry install` -- that targets Poetry's own venv)
+- The target dbt project must have `sst_config.yaml` with `project.dbt_models_dir` set
+- If Snowflake account is unavailable, set `snowflake_syntax_check: false` in sst_config.yaml
+
+## Workflow
+
+### Step 1: Activate the environment
+
+First, list the user's conda environments to find the one with SST installed:
+```bash
+source "$(conda info --base)/etc/profile.d/conda.sh" && conda env list
+```
+
+**⚠️ MANDATORY STOPPING POINT**: Present the results to the user and ask which environment has SST installed. Highlight any environments whose names contain "sst" as likely matches. Do NOT proceed until user responds.
+
+Then activate the chosen environment:
+```bash
+source "$(conda info --base)/etc/profile.d/conda.sh" && conda activate <env-name>
+```
+
+### Step 2: Verify SST version
+
+```bash
+sst --version
+```
+
+### Step 3: Run validation
+
+**⚠️ MANDATORY STOPPING POINT**: Ask the user for the path to their dbt project before running. Do NOT assume a path.
+
+```bash
+cd <dbt-project-dir>
+sst validate
+```
+
+### Step 4: Interpret results
+
+- **0 errors, 0 warnings**: Clean pass. Ready for `sst extract`.
+- **Warnings only**: Non-blocking. Usually missing metadata (primary_key, synonyms).
+- **Errors**: Must fix before deployment. Common categories:
+  - **Relationship errors**: Wrong join columns, self-references, circular references, missing PK/unique_keys
+  - **SQL syntax errors**: If `snowflake_syntax_check: true` and Snowflake account unavailable, disable it
+  - **Missing metadata**: Tables without `primary_key` in `config.meta.sst`
+
+### Step 5: Verbose output (if errors found)
+
+```bash
+sst validate --verbose
+```
+
+## Common Fixes
+
+- **"Missing required field 'project.dbt_models_dir'"**: Add `dbt_models_dir: "models"` under `project:` in sst_config.yaml
+- **"Table X skipped due to missing critical metadata (primary_key)"**: Add `primary_key: <column>` to the model's `config.meta.sst` section
+- **Relationship join column mismatch**: Ensure the right_table's join column matches its declared `primary_key` or `unique_keys`
+- **Self-reference error**: A relationship cannot have the same left_table and right_table
+- **Circular relationship**: Two or more relationships forming a cycle (A -> B -> A). Remove one direction.
+
+## Key Files
+
+- SST repo: Resolve dynamically with `SST_REPO=$(git rev-parse --show-toplevel)`
+- Validation rules: `snowflake_semantic_tools/core/validation/rules/`
+- Relationship validation: `snowflake_semantic_tools/core/validation/rules/references.py`
+
+## Stopping Points
+
+- ✋ Step 1: After listing conda environments (ask user which to activate)
+- ✋ Step 3: Before running validation (ask user for dbt project path)
+
+## Output
+
+Validation summary with error count, warning count, and actionable fix guidance for each issue found.

--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,6 @@ staging_tables_backup/
 # Development files
 api_test.py
 planning/*
+
+# Snowflake CLI
+.snowflake/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,10 @@
 {
     "workbench.editorAssociations": {
         "*.md": "vscode.markdown.preview.editor"
-    }
+    },
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# Snowflake Semantic Tools (SST)
+
+SST is a CLI tool that transforms dbt models into Snowflake Semantic Views for Cortex Analyst, Cortex Agents, and BI tools.
+
+**Key commands**: `sst validate`, `sst extract`, `sst deploy`, `sst enrich`, `sst generate`
+
+## Critical Rules
+
+- **NEVER commit or push without asking the user first.** Always confirm before running `git commit` or `git push`.
+- **Commit messages MUST match this regex** (enforced by GitHub):
+  ```
+  ^(\[[A-Z][A-Z0-9]*-\d+\]|[a-z]+\([A-Z][A-Z0-9]*-\d+\):|\([A-Z][A-Z0-9]*-\d+\)|Ver: (\d+\.\d+\.\d+(\.\d+)?|\d+\.\d+\.\d+-\d+)|(?i:initial commit))
+  ```
+  Preferred format: `[SST-<issue#>] <description>`
+- **Each PR addresses exactly one GitHub issue.** The PR body MUST contain `Closes #<number>`.
+- **Feature branches off `main`**: `fix/<description>` or `feature/<description>`
+- **When addressing PR review comments**: reply to the comment explaining the fix, then resolve the thread:
+  ```bash
+  # Reply to the comment
+  gh api repos/WhoopInc/snowflake-semantic-tools/pulls/<PR>/comments/<COMMENT_ID>/replies -f body="Fixed in <commit>"
+  # Resolve the thread (GraphQL — need the thread node_id from the comment's node_id)
+  gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<THREAD_NODE_ID>"}) { thread { isResolved } } }'
+  ```
+
+## Code Style
+
+- **Formatter**: `black snowflake_semantic_tools/` (line length 120)
+- **Import sorting**: `isort snowflake_semantic_tools/` (black profile)
+- **Type checking**: `mypy snowflake_semantic_tools/`
+- **Tests**: `python -m pytest tests/unit/ -v`
+- **Package manager**: Poetry (NOT uv)
+- **Error messages**: Must be actionable — tell the user what's wrong AND how to fix it
+
+## Skills
+
+Load the appropriate skill for each task. Do not duplicate skill logic in ad-hoc responses.
+
+| Skill | When to Use |
+|-------|-------------|
+| `sst-test` | Running unit tests, checking coverage, verifying fixes |
+| `sst-validate` | Running `sst validate` against a dbt project, interpreting results |
+| `sst-e2e-test` | End-to-end pipeline testing against sst-jaffle-shop (QA before release) |
+| `sst-pr-review` | Reviewing pull requests — process checks, code review, test verification |
+| `opening-sst-pr` | Creating a new PR — enforces commit regex, single-issue rule, PR template |
+| `sst-create-issue` | Filing GitHub issues — uses repo issue templates for bugs, features, docs |


### PR DESCRIPTION
## Description

Add project-level AGENTS.md and 5 Cortex Code skills to standardize SST development workflows. Also adds .snowflake/ to .gitignore, configures pytest in VS Code, and fixes a stale reference in sst-e2e-test.

## Related Issue

Closes #128

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Changes Made

- **AGENTS.md**: Project identity, critical rules (commit regex, never commit without asking, single-issue PRs), code style commands, skill routing table
- **opening-sst-pr**: PR creation skill -- enforces commit regex, references PR template, delegates to sst-create-issue and sst-e2e-test
- **sst-create-issue**: Issue creation skill -- references repo issue templates (bug, feature, docs)
- **sst-test**: Unit test workflow with pytest
- **sst-validate**: Validation workflow against dbt projects
- **sst-pr-review**: Code review with process enforcement, bug patterns, and skill delegation
- **sst-e2e-test**: Fixed stale "Phase 0e" reference to "Prerequisites section"
- **.gitignore**: Added .snowflake/ directory
- **.vscode/settings.json**: Added pytest configuration

## Testing

- [x] Unit tests pass
- [x] All existing tests pass
- [x] Manual testing completed (if applicable)

### Test Results

```
1197 passed, 4 errors (pre-existing fixture issue), 25 subtests passed in 2.60s
```

## Checklist

### Documentation & Compatibility
- [x] Documentation updated (if needed)
- [x] Backward compatibility maintained (if applicable)

### Performance
- [x] Performance impact considered
- [x] No significant performance regressions
