### PR TITLE
[SST-91] Add sst list command for exploring semantic model components

### DIFF
--- a/snowflake_semantic_tools/interfaces/cli/commands/list.py
+++ b/snowflake_semantic_tools/interfaces/cli/commands/list.py
@@ -32,15 +32,17 @@ from snowflake_semantic_tools.shared.events import setup_events
 
 
 FORMAT_OPTION = click.option(
-    "--format", "-f", "output_format", type=click.Choice(["table", "json", "yaml", "csv"]), default="table",
-    help="Output format (default: table)"
+    "--format",
+    "-f",
+    "output_format",
+    type=click.Choice(["table", "json", "yaml", "csv"]),
+    default="table",
+    help="Output format (default: table)",
 )
 OUTPUT_OPTION = click.option("--output", "-o", "output_file", help="Write output to file instead of stdout")
 VERBOSE_OPTION = click.option("--verbose", "-v", is_flag=True, help="Show additional details")
 QUIET_OPTION = click.option("--quiet", "-q", is_flag=True, help="Suppress all output except data")
-DBT_OPTION = click.option(
-    "--dbt", "dbt_path", help="dbt models path (auto-detected from config if not specified)"
-)
+DBT_OPTION = click.option("--dbt", "dbt_path", help="dbt models path (auto-detected from config if not specified)")
 SEMANTIC_OPTION = click.option(
     "--semantic", "semantic_path", help="Semantic models path (auto-detected from config if not specified)"
 )
@@ -309,7 +311,11 @@ def relationships(output_format, output_file, verbose, quiet, dbt_path, semantic
     if output_format == "csv":
         headers = ["Name", "Left Table", "Right Table"]
         rows = [
-            [str(r.get("relationship_name") or ""), str(r.get("left_table_name") or ""), str(r.get("right_table_name") or "")]
+            [
+                str(r.get("relationship_name") or ""),
+                str(r.get("left_table_name") or ""),
+                str(r.get("right_table_name") or ""),
+            ]
             for r in items
         ]
         write_output(format_csv_output(headers, rows), output_file)
@@ -377,7 +383,12 @@ def filters(output_format, output_file, verbose, quiet, dbt_path, semantic_path,
     if output_format == "csv":
         headers = ["Name", "Table", "Description", "Expression"]
         rows = [
-            [str(f.get("name") or ""), str(f.get("table_name") or ""), str(f.get("description") or ""), str(f.get("expr") or "")]
+            [
+                str(f.get("name") or ""),
+                str(f.get("table_name") or ""),
+                str(f.get("description") or ""),
+                str(f.get("expr") or ""),
+            ]
             for f in items
         ]
         write_output(format_csv_output(headers, rows), output_file)
@@ -512,7 +523,11 @@ def custom_instructions(output_format, output_file, verbose, quiet, dbt_path, se
     if output_format == "csv":
         headers = ["Name", "Question Categorization", "SQL Generation"]
         rows = [
-            [str(ci.get("name") or ""), str(ci.get("question_categorization") or ""), str(ci.get("sql_generation") or "")]
+            [
+                str(ci.get("name") or ""),
+                str(ci.get("question_categorization") or ""),
+                str(ci.get("sql_generation") or ""),
+            ]
             for ci in items
         ]
         write_output(format_csv_output(headers, rows), output_file)
@@ -579,7 +594,12 @@ def verified_queries(output_format, output_file, verbose, quiet, dbt_path, seman
     if output_format == "csv":
         headers = ["Name", "Question", "Verified By", "Verified At"]
         rows = [
-            [str(vq.get("name") or ""), str(vq.get("question") or ""), str(vq.get("verified_by") or ""), str(vq.get("verified_at") or "")]
+            [
+                str(vq.get("name") or ""),
+                str(vq.get("question") or ""),
+                str(vq.get("verified_by") or ""),
+                str(vq.get("verified_at") or ""),
+            ]
             for vq in items
         ]
         write_output(format_csv_output(headers, rows), output_file)
@@ -646,7 +666,12 @@ def tables(output_format, output_file, verbose, quiet, dbt_path, semantic_path, 
     if output_format == "csv":
         headers = ["Name", "Database", "Schema", "Primary Key"]
         rows = [
-            [str(t.get("table_name") or ""), str(t.get("database") or ""), str(t.get("schema") or ""), str(t.get("primary_key") or "")]
+            [
+                str(t.get("table_name") or ""),
+                str(t.get("database") or ""),
+                str(t.get("schema") or ""),
+                str(t.get("primary_key") or ""),
+            ]
             for t in items
         ]
         write_output(format_csv_output(headers, rows), output_file)
@@ -662,7 +687,12 @@ def tables(output_format, output_file, verbose, quiet, dbt_path, semantic_path, 
     else:
         headers = ["Name", "Database", "Schema", "Primary Key"]
         rows = [
-            [str(t.get("table_name") or ""), str(t.get("database") or ""), str(t.get("schema") or ""), str(t.get("primary_key") or "")]
+            [
+                str(t.get("table_name") or ""),
+                str(t.get("database") or ""),
+                str(t.get("schema") or ""),
+                str(t.get("primary_key") or ""),
+            ]
             for t in items
         ]
         click.echo(format_table(headers, rows))

--- a/snowflake_semantic_tools/interfaces/cli/commands/list.py
+++ b/snowflake_semantic_tools/interfaces/cli/commands/list.py
@@ -1,0 +1,682 @@
+"""
+List Command
+
+CLI command for listing and exploring semantic model components.
+Provides subcommands for each component type with filtering and output format options.
+"""
+
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Optional
+
+import click
+
+from snowflake_semantic_tools._version import __version__
+from snowflake_semantic_tools.interfaces.cli.formatters import (
+    format_csv_output,
+    format_json_output,
+    format_table,
+    format_yaml_output,
+    write_output,
+)
+from snowflake_semantic_tools.interfaces.cli.output import CLIOutput
+from snowflake_semantic_tools.services.list_semantic_components import (
+    ListConfig,
+    ListResult,
+    SemanticComponentListService,
+    _parse_tables_json,
+)
+from snowflake_semantic_tools.shared.events import setup_events
+
+
+FORMAT_OPTION = click.option(
+    "--format", "-f", "output_format", type=click.Choice(["table", "json", "yaml", "csv"]), default="table",
+    help="Output format (default: table)"
+)
+OUTPUT_OPTION = click.option("--output", "-o", "output_file", help="Write output to file instead of stdout")
+VERBOSE_OPTION = click.option("--verbose", "-v", is_flag=True, help="Show additional details")
+QUIET_OPTION = click.option("--quiet", "-q", is_flag=True, help="Suppress all output except data")
+DBT_OPTION = click.option(
+    "--dbt", "dbt_path", help="dbt models path (auto-detected from config if not specified)"
+)
+SEMANTIC_OPTION = click.option(
+    "--semantic", "semantic_path", help="Semantic models path (auto-detected from config if not specified)"
+)
+TABLE_FILTER_OPTION = click.option("--table", "table_filter", help="Filter by table name (substring match)")
+
+
+def _setup(verbose: bool, quiet: bool):
+    """Minimal CLI setup for list command (no config validation required)."""
+    setup_events(verbose=verbose, quiet=quiet, show_timestamps=False)
+    if verbose:
+        logging.getLogger("snowflake_semantic_tools").setLevel(logging.DEBUG)
+    elif quiet:
+        logging.getLogger("snowflake_semantic_tools").setLevel(logging.ERROR)
+
+
+def _build_config(dbt_path: Optional[str], semantic_path: Optional[str], table_filter: Optional[str]) -> ListConfig:
+    return ListConfig(
+        dbt_path=Path(dbt_path) if dbt_path else None,
+        semantic_path=Path(semantic_path) if semantic_path else None,
+        table_filter=table_filter,
+    )
+
+
+def _run_list(config: ListConfig) -> ListResult:
+    service = SemanticComponentListService()
+    return service.execute(config)
+
+
+def _show_errors(result: ListResult, output: CLIOutput):
+    """Display any errors from the list result."""
+    for err in result.errors:
+        output.warning(err)
+
+
+def _relativize_path(path_str: str) -> str:
+    """Convert absolute paths to relative for cleaner output."""
+    try:
+        return str(Path(path_str).relative_to(Path.cwd()))
+    except (ValueError, TypeError):
+        return path_str
+
+
+@click.group("list", invoke_without_command=True)
+@click.pass_context
+def list_cmd(ctx):
+    """
+    List semantic model components.
+
+    Explore metrics, relationships, filters, semantic views, tables,
+    custom instructions, and verified queries defined in your project.
+
+    \b
+    Examples:
+      sst list                    # Summary of all components
+      sst list metrics            # List all metrics
+      sst list tables             # List all tables
+      sst list metrics --table orders --format json
+    """
+    if ctx.invoked_subcommand is None:
+        ctx.invoke(summary)
+
+
+@list_cmd.command("summary")
+@FORMAT_OPTION
+@OUTPUT_OPTION
+@VERBOSE_OPTION
+@QUIET_OPTION
+@DBT_OPTION
+@SEMANTIC_OPTION
+def summary(output_format, output_file, verbose, quiet, dbt_path, semantic_path):
+    """Show a summary of all semantic model components."""
+    machine_output = output_format in ("json", "yaml", "csv") or output_file
+    _setup(verbose, quiet or machine_output)
+    output = CLIOutput(verbose=verbose, quiet=quiet or machine_output)
+    if not quiet and not machine_output:
+        output.info(f"Running with sst={__version__}")
+
+    config = _build_config(dbt_path, semantic_path, None)
+    start = time.time()
+    result = _run_list(config)
+    duration = time.time() - start
+
+    _show_errors(result, output)
+
+    if output_format == "json":
+        data = {
+            "summary": {
+                "tables": len(result.tables),
+                "metrics": len(result.metrics),
+                "relationships": len(result.relationships),
+                "filters": len(result.filters),
+                "semantic_views": len(result.semantic_views),
+                "custom_instructions": len(result.custom_instructions),
+                "verified_queries": len(result.verified_queries),
+            },
+            "total_count": result.total_count,
+        }
+        write_output(format_json_output(data), output_file)
+        return
+
+    if output_format == "yaml":
+        data = {
+            "summary": {
+                "tables": len(result.tables),
+                "metrics": len(result.metrics),
+                "relationships": len(result.relationships),
+                "filters": len(result.filters),
+                "semantic_views": len(result.semantic_views),
+                "custom_instructions": len(result.custom_instructions),
+                "verified_queries": len(result.verified_queries),
+            },
+            "total_count": result.total_count,
+        }
+        write_output(format_yaml_output(data), output_file)
+        return
+
+    if output_format == "csv":
+        headers = ["Component", "Count"]
+        rows = [
+            ["Tables", str(len(result.tables))],
+            ["Metrics", str(len(result.metrics))],
+            ["Relationships", str(len(result.relationships))],
+            ["Filters", str(len(result.filters))],
+            ["Semantic Views", str(len(result.semantic_views))],
+            ["Custom Instructions", str(len(result.custom_instructions))],
+            ["Verified Queries", str(len(result.verified_queries))],
+        ]
+        write_output(format_csv_output(headers, rows), output_file)
+        return
+
+    if not quiet:
+        output.blank_line()
+        output.header("Semantic Model Summary")
+        output.blank_line()
+
+    headers = ["Component", "Count"]
+    rows = [
+        ["Tables", str(len(result.tables))],
+        ["Metrics", str(len(result.metrics))],
+        ["Relationships", str(len(result.relationships))],
+        ["Filters", str(len(result.filters))],
+        ["Semantic Views", str(len(result.semantic_views))],
+        ["Custom Instructions", str(len(result.custom_instructions))],
+        ["Verified Queries", str(len(result.verified_queries))],
+        ["─" * 20, "─" * 5],
+        ["Total Components", str(result.total_count)],
+    ]
+    click.echo(format_table(headers, rows))
+
+    if not quiet:
+        output.blank_line()
+        output.success("Done", duration=duration)
+        click.echo(f"\n  Use 'sst list <component>' for details.")
+
+
+@list_cmd.command("metrics")
+@FORMAT_OPTION
+@OUTPUT_OPTION
+@VERBOSE_OPTION
+@QUIET_OPTION
+@DBT_OPTION
+@SEMANTIC_OPTION
+@TABLE_FILTER_OPTION
+@click.option("--with-expr", is_flag=True, help="Include full expressions in output")
+def metrics(output_format, output_file, verbose, quiet, dbt_path, semantic_path, table_filter, with_expr):
+    """List all metrics defined in semantic models."""
+    machine_output = output_format in ("json", "yaml", "csv") or output_file
+    _setup(verbose, quiet or machine_output)
+    output = CLIOutput(verbose=verbose, quiet=quiet or machine_output)
+    if not quiet and not machine_output:
+        output.info(f"Running with sst={__version__}")
+
+    config = _build_config(dbt_path, semantic_path, table_filter)
+    start = time.time()
+    result = _run_list(config)
+    duration = time.time() - start
+
+    _show_errors(result, output)
+    items = result.metrics
+
+    if output_format == "json":
+        data = {"metrics": _relativize_source_files(items), "total_count": len(items)}
+        write_output(format_json_output(data), output_file)
+        return
+
+    if output_format == "yaml":
+        data = {"metrics": _relativize_source_files(items), "total_count": len(items)}
+        write_output(format_yaml_output(data), output_file)
+        return
+
+    if output_format == "csv":
+        headers = ["Name", "Tables", "Description"]
+        if with_expr:
+            headers.append("Expression")
+        rows = []
+        for m in items:
+            tables = m.get("tables", [])
+            table_str = ", ".join(str(t) for t in tables) if tables else str(m.get("table_name") or "")
+            row = [str(m.get("name") or ""), table_str, str(m.get("description") or "")]
+            if with_expr:
+                row.append(str(m.get("expr") or ""))
+            rows.append(row)
+        write_output(format_csv_output(headers, rows), output_file)
+        return
+
+    if not quiet:
+        output.blank_line()
+        output.header(f"Metrics ({len(items)} total)")
+        output.blank_line()
+
+    if not items:
+        click.echo("  (no metrics found)")
+    else:
+        headers = ["Name", "Tables", "Description"]
+        if with_expr or verbose:
+            headers.append("Expression")
+        rows = []
+        for m in items:
+            tables = m.get("tables", [])
+            table_str = ", ".join(str(t) for t in tables) if tables else str(m.get("table_name") or "")
+            row = [str(m.get("name") or ""), table_str, str(m.get("description") or "")]
+            if with_expr or verbose:
+                row.append(str(m.get("expr") or ""))
+            rows.append(row)
+        click.echo(format_table(headers, rows))
+
+    if not quiet:
+        output.blank_line()
+        output.success("Done", duration=duration)
+
+
+@list_cmd.command("relationships")
+@FORMAT_OPTION
+@OUTPUT_OPTION
+@VERBOSE_OPTION
+@QUIET_OPTION
+@DBT_OPTION
+@SEMANTIC_OPTION
+@TABLE_FILTER_OPTION
+def relationships(output_format, output_file, verbose, quiet, dbt_path, semantic_path, table_filter):
+    """List all relationships defined in semantic models."""
+    machine_output = output_format in ("json", "yaml", "csv") or output_file
+    _setup(verbose, quiet or machine_output)
+    output = CLIOutput(verbose=verbose, quiet=quiet or machine_output)
+    if not quiet and not machine_output:
+        output.info(f"Running with sst={__version__}")
+
+    config = _build_config(dbt_path, semantic_path, table_filter)
+    start = time.time()
+    result = _run_list(config)
+    duration = time.time() - start
+
+    _show_errors(result, output)
+    items = result.relationships
+
+    if output_format == "json":
+        data = {"relationships": _relativize_source_files(items), "total_count": len(items)}
+        write_output(format_json_output(data), output_file)
+        return
+
+    if output_format == "yaml":
+        data = {"relationships": _relativize_source_files(items), "total_count": len(items)}
+        write_output(format_yaml_output(data), output_file)
+        return
+
+    if output_format == "csv":
+        headers = ["Name", "Left Table", "Right Table"]
+        rows = [
+            [str(r.get("relationship_name") or ""), str(r.get("left_table_name") or ""), str(r.get("right_table_name") or "")]
+            for r in items
+        ]
+        write_output(format_csv_output(headers, rows), output_file)
+        return
+
+    if not quiet:
+        output.blank_line()
+        output.header(f"Relationships ({len(items)} total)")
+        output.blank_line()
+
+    if not items:
+        click.echo("  (no relationships found)")
+    else:
+        headers = ["Name", "Left Table", "\u2192", "Right Table"]
+        rows = [
+            [
+                str(r.get("relationship_name") or ""),
+                str(r.get("left_table_name") or ""),
+                "\u2192",
+                str(r.get("right_table_name") or ""),
+            ]
+            for r in items
+        ]
+        click.echo(format_table(headers, rows))
+
+    if not quiet:
+        output.blank_line()
+        output.success("Done", duration=duration)
+
+
+@list_cmd.command("filters")
+@FORMAT_OPTION
+@OUTPUT_OPTION
+@VERBOSE_OPTION
+@QUIET_OPTION
+@DBT_OPTION
+@SEMANTIC_OPTION
+@TABLE_FILTER_OPTION
+def filters(output_format, output_file, verbose, quiet, dbt_path, semantic_path, table_filter):
+    """List all filters defined in semantic models."""
+    machine_output = output_format in ("json", "yaml", "csv") or output_file
+    _setup(verbose, quiet or machine_output)
+    output = CLIOutput(verbose=verbose, quiet=quiet or machine_output)
+    if not quiet and not machine_output:
+        output.info(f"Running with sst={__version__}")
+
+    config = _build_config(dbt_path, semantic_path, table_filter)
+    start = time.time()
+    result = _run_list(config)
+    duration = time.time() - start
+
+    _show_errors(result, output)
+    items = result.filters
+
+    if output_format == "json":
+        data = {"filters": _relativize_source_files(items), "total_count": len(items)}
+        write_output(format_json_output(data), output_file)
+        return
+
+    if output_format == "yaml":
+        data = {"filters": _relativize_source_files(items), "total_count": len(items)}
+        write_output(format_yaml_output(data), output_file)
+        return
+
+    if output_format == "csv":
+        headers = ["Name", "Table", "Description", "Expression"]
+        rows = [
+            [str(f.get("name") or ""), str(f.get("table_name") or ""), str(f.get("description") or ""), str(f.get("expr") or "")]
+            for f in items
+        ]
+        write_output(format_csv_output(headers, rows), output_file)
+        return
+
+    if not quiet:
+        output.blank_line()
+        output.header(f"Filters ({len(items)} total)")
+        output.blank_line()
+
+    if not items:
+        click.echo("  (no filters found)")
+    else:
+        headers = ["Name", "Table", "Description"]
+        if verbose:
+            headers.append("Expression")
+        rows = []
+        for f in items:
+            row = [str(f.get("name") or ""), str(f.get("table_name") or ""), str(f.get("description") or "")]
+            if verbose:
+                row.append(str(f.get("expr") or ""))
+            rows.append(row)
+        click.echo(format_table(headers, rows))
+
+    if not quiet:
+        output.blank_line()
+        output.success("Done", duration=duration)
+
+
+@list_cmd.command("semantic-views")
+@FORMAT_OPTION
+@OUTPUT_OPTION
+@VERBOSE_OPTION
+@QUIET_OPTION
+@DBT_OPTION
+@SEMANTIC_OPTION
+@TABLE_FILTER_OPTION
+def semantic_views(output_format, output_file, verbose, quiet, dbt_path, semantic_path, table_filter):
+    """List all semantic views defined in semantic models."""
+    machine_output = output_format in ("json", "yaml", "csv") or output_file
+    _setup(verbose, quiet or machine_output)
+    output = CLIOutput(verbose=verbose, quiet=quiet or machine_output)
+    if not quiet and not machine_output:
+        output.info(f"Running with sst={__version__}")
+
+    config = _build_config(dbt_path, semantic_path, table_filter)
+    start = time.time()
+    result = _run_list(config)
+    duration = time.time() - start
+
+    _show_errors(result, output)
+    items = result.semantic_views
+
+    if output_format == "json":
+        data = {"semantic_views": _relativize_source_files(items), "total_count": len(items)}
+        write_output(format_json_output(data), output_file)
+        return
+
+    if output_format == "yaml":
+        data = {"semantic_views": _relativize_source_files(items), "total_count": len(items)}
+        write_output(format_yaml_output(data), output_file)
+        return
+
+    if output_format == "csv":
+        headers = ["Name", "Description", "Tables"]
+        rows = []
+        for v in items:
+            tables = _parse_tables_json(v.get("tables", "[]"))
+            rows.append([str(v.get("name") or ""), str(v.get("description") or ""), ", ".join(str(t) for t in tables)])
+        write_output(format_csv_output(headers, rows), output_file)
+        return
+
+    if not quiet:
+        output.blank_line()
+        output.header(f"Semantic Views ({len(items)} total)")
+        output.blank_line()
+
+    if not items:
+        click.echo("  (no semantic views found)")
+    else:
+        headers = ["Name", "Description", "Tables"]
+        if verbose:
+            headers.append("Custom Instructions")
+        rows = []
+        for v in items:
+            tables = _parse_tables_json(v.get("tables", "[]"))
+            row = [str(v.get("name") or ""), str(v.get("description") or ""), ", ".join(str(t) for t in tables)]
+            if verbose:
+                ci = _parse_tables_json(v.get("custom_instructions", "[]"))
+                row.append(", ".join(str(c) for c in ci))
+            rows.append(row)
+        click.echo(format_table(headers, rows))
+
+    if not quiet:
+        output.blank_line()
+        output.success("Done", duration=duration)
+
+
+@list_cmd.command("custom-instructions")
+@FORMAT_OPTION
+@OUTPUT_OPTION
+@VERBOSE_OPTION
+@QUIET_OPTION
+@DBT_OPTION
+@SEMANTIC_OPTION
+def custom_instructions(output_format, output_file, verbose, quiet, dbt_path, semantic_path):
+    """List all custom instructions defined in semantic models."""
+    machine_output = output_format in ("json", "yaml", "csv") or output_file
+    _setup(verbose, quiet or machine_output)
+    output = CLIOutput(verbose=verbose, quiet=quiet or machine_output)
+    if not quiet and not machine_output:
+        output.info(f"Running with sst={__version__}")
+
+    config = _build_config(dbt_path, semantic_path, None)
+    start = time.time()
+    result = _run_list(config)
+    duration = time.time() - start
+
+    _show_errors(result, output)
+    items = result.custom_instructions
+
+    if output_format == "json":
+        data = {"custom_instructions": _relativize_source_files(items), "total_count": len(items)}
+        write_output(format_json_output(data), output_file)
+        return
+
+    if output_format == "yaml":
+        data = {"custom_instructions": _relativize_source_files(items), "total_count": len(items)}
+        write_output(format_yaml_output(data), output_file)
+        return
+
+    if output_format == "csv":
+        headers = ["Name", "Question Categorization", "SQL Generation"]
+        rows = [
+            [str(ci.get("name") or ""), str(ci.get("question_categorization") or ""), str(ci.get("sql_generation") or "")]
+            for ci in items
+        ]
+        write_output(format_csv_output(headers, rows), output_file)
+        return
+
+    if not quiet:
+        output.blank_line()
+        output.header(f"Custom Instructions ({len(items)} total)")
+        output.blank_line()
+
+    if not items:
+        click.echo("  (no custom instructions found)")
+    else:
+        headers = ["Name"]
+        if verbose:
+            headers.extend(["Question Categorization", "SQL Generation"])
+        rows = []
+        for ci in items:
+            row = [str(ci.get("name") or "")]
+            if verbose:
+                row.append(str(ci.get("question_categorization") or ""))
+                row.append(str(ci.get("sql_generation") or ""))
+            rows.append(row)
+        click.echo(format_table(headers, rows))
+
+    if not quiet:
+        output.blank_line()
+        output.success("Done", duration=duration)
+
+
+@list_cmd.command("verified-queries")
+@FORMAT_OPTION
+@OUTPUT_OPTION
+@VERBOSE_OPTION
+@QUIET_OPTION
+@DBT_OPTION
+@SEMANTIC_OPTION
+def verified_queries(output_format, output_file, verbose, quiet, dbt_path, semantic_path):
+    """List all verified queries defined in semantic models."""
+    machine_output = output_format in ("json", "yaml", "csv") or output_file
+    _setup(verbose, quiet or machine_output)
+    output = CLIOutput(verbose=verbose, quiet=quiet or machine_output)
+    if not quiet and not machine_output:
+        output.info(f"Running with sst={__version__}")
+
+    config = _build_config(dbt_path, semantic_path, None)
+    start = time.time()
+    result = _run_list(config)
+    duration = time.time() - start
+
+    _show_errors(result, output)
+    items = result.verified_queries
+
+    if output_format == "json":
+        data = {"verified_queries": _relativize_source_files(items), "total_count": len(items)}
+        write_output(format_json_output(data), output_file)
+        return
+
+    if output_format == "yaml":
+        data = {"verified_queries": _relativize_source_files(items), "total_count": len(items)}
+        write_output(format_yaml_output(data), output_file)
+        return
+
+    if output_format == "csv":
+        headers = ["Name", "Question", "Verified By", "Verified At"]
+        rows = [
+            [str(vq.get("name") or ""), str(vq.get("question") or ""), str(vq.get("verified_by") or ""), str(vq.get("verified_at") or "")]
+            for vq in items
+        ]
+        write_output(format_csv_output(headers, rows), output_file)
+        return
+
+    if not quiet:
+        output.blank_line()
+        output.header(f"Verified Queries ({len(items)} total)")
+        output.blank_line()
+
+    if not items:
+        click.echo("  (no verified queries found)")
+    else:
+        headers = ["Name", "Question", "Verified By"]
+        if verbose:
+            headers.append("SQL")
+        rows = []
+        for vq in items:
+            row = [str(vq.get("name") or ""), str(vq.get("question") or ""), str(vq.get("verified_by") or "")]
+            if verbose:
+                row.append(str(vq.get("sql") or ""))
+            rows.append(row)
+        click.echo(format_table(headers, rows))
+
+    if not quiet:
+        output.blank_line()
+        output.success("Done", duration=duration)
+
+
+@list_cmd.command("tables")
+@FORMAT_OPTION
+@OUTPUT_OPTION
+@VERBOSE_OPTION
+@QUIET_OPTION
+@DBT_OPTION
+@SEMANTIC_OPTION
+@TABLE_FILTER_OPTION
+def tables(output_format, output_file, verbose, quiet, dbt_path, semantic_path, table_filter):
+    """List all tables with SST annotations."""
+    machine_output = output_format in ("json", "yaml", "csv") or output_file
+    _setup(verbose, quiet or machine_output)
+    output = CLIOutput(verbose=verbose, quiet=quiet or machine_output)
+    if not quiet and not machine_output:
+        output.info(f"Running with sst={__version__}")
+
+    config = _build_config(dbt_path, semantic_path, table_filter)
+    start = time.time()
+    result = _run_list(config)
+    duration = time.time() - start
+
+    _show_errors(result, output)
+    items = result.tables
+
+    if output_format == "json":
+        data = {"tables": _relativize_source_files(items), "total_count": len(items)}
+        write_output(format_json_output(data), output_file)
+        return
+
+    if output_format == "yaml":
+        data = {"tables": _relativize_source_files(items), "total_count": len(items)}
+        write_output(format_yaml_output(data), output_file)
+        return
+
+    if output_format == "csv":
+        headers = ["Name", "Database", "Schema", "Primary Key"]
+        rows = [
+            [str(t.get("table_name") or ""), str(t.get("database") or ""), str(t.get("schema") or ""), str(t.get("primary_key") or "")]
+            for t in items
+        ]
+        write_output(format_csv_output(headers, rows), output_file)
+        return
+
+    if not quiet:
+        output.blank_line()
+        output.header(f"Tables ({len(items)} total)")
+        output.blank_line()
+
+    if not items:
+        click.echo("  (no tables found)")
+    else:
+        headers = ["Name", "Database", "Schema", "Primary Key"]
+        rows = [
+            [str(t.get("table_name") or ""), str(t.get("database") or ""), str(t.get("schema") or ""), str(t.get("primary_key") or "")]
+            for t in items
+        ]
+        click.echo(format_table(headers, rows))
+
+    if not quiet:
+        output.blank_line()
+        output.success("Done", duration=duration)
+
+
+def _relativize_source_files(items: list) -> list:
+    """Relativize source_file paths in items for cleaner output."""
+    result = []
+    for item in items:
+        if isinstance(item, dict) and "source_file" in item:
+            item = {**item, "source_file": _relativize_path(item["source_file"])}
+        result.append(item)
+    return result

--- a/snowflake_semantic_tools/interfaces/cli/commands/list.py
+++ b/snowflake_semantic_tools/interfaces/cli/commands/list.py
@@ -30,7 +30,6 @@ from snowflake_semantic_tools.services.list_semantic_components import (
 )
 from snowflake_semantic_tools.shared.events import setup_events
 
-
 FORMAT_OPTION = click.option(
     "--format",
     "-f",

--- a/snowflake_semantic_tools/interfaces/cli/formatters.py
+++ b/snowflake_semantic_tools/interfaces/cli/formatters.py
@@ -1,0 +1,144 @@
+"""
+Output Formatters
+
+Provides multiple output format renderers for the `sst list` command.
+Supports table (terminal), JSON, YAML, and CSV output formats.
+"""
+
+import csv
+import io
+import json
+import re
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+import click
+import yaml
+
+_CONTROL_CHAR_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+
+
+def _sanitize_terminal(value: str) -> str:
+    """Strip control characters that could manipulate terminal display."""
+    return _CONTROL_CHAR_RE.sub("", value)
+
+
+def format_table(headers: List[str], rows: List[List[str]], max_col_width: int = 40) -> str:
+    """
+    Format data as an aligned terminal table.
+
+    Args:
+        headers: Column header names
+        rows: List of row values (each row is a list of strings)
+        max_col_width: Maximum column width before truncation
+
+    Returns:
+        Formatted table string
+    """
+    if not rows:
+        return "  (no items found)"
+
+    max_col_width = max(max_col_width, 5)
+
+    padded_rows = []
+    for row in rows:
+        if len(row) < len(headers):
+            padded_rows.append(row + [""] * (len(headers) - len(row)))
+        else:
+            padded_rows.append(row)
+
+    all_rows = [headers] + padded_rows
+    col_widths = []
+    for col_idx in range(len(headers)):
+        max_width = 0
+        for row in all_rows:
+            if col_idx < len(row):
+                max_width = max(max_width, len(str(row[col_idx])))
+        col_widths.append(min(max_width, max_col_width))
+
+    def format_row(row: List[str]) -> str:
+        parts = []
+        for col_idx, value in enumerate(row):
+            width = col_widths[col_idx] if col_idx < len(col_widths) else max_col_width
+            val_str = _sanitize_terminal(str(value))
+            if len(val_str) > width:
+                val_str = val_str[: width - 3] + "..."
+            parts.append(val_str.ljust(width))
+        return "  " + "  ".join(parts)
+
+    lines = []
+    lines.append(format_row(headers))
+    separator = "  " + "  ".join("\u2500" * w for w in col_widths)
+    lines.append(separator)
+    for row in padded_rows:
+        lines.append(format_row(row))
+
+    return "\n".join(lines)
+
+
+def format_json_output(data: Dict[str, Any]) -> str:
+    """
+    Format data as JSON with metadata.
+
+    Args:
+        data: Dictionary to serialize
+
+    Returns:
+        Pretty-printed JSON string
+    """
+    output = {**data, "generated_at": datetime.now(timezone.utc).isoformat()}
+    return json.dumps(output, indent=2, default=str)
+
+
+def format_yaml_output(data: Dict[str, Any]) -> str:
+    """
+    Format data as YAML.
+
+    Args:
+        data: Dictionary to serialize
+
+    Returns:
+        YAML string
+    """
+    return yaml.dump(data, default_flow_style=False, sort_keys=False, allow_unicode=True)
+
+
+def format_csv_output(headers: List[str], rows: List[List[str]]) -> str:
+    """
+    Format data as CSV (RFC 4180 compliant).
+
+    Args:
+        headers: Column header names
+        rows: List of row values
+
+    Returns:
+        CSV string
+    """
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(headers)
+    for row in rows:
+        writer.writerow(row)
+    return output.getvalue()
+
+
+def write_output(content: str, output_file: Optional[str] = None) -> None:
+    """
+    Write content to file or stdout.
+
+    Args:
+        content: Content string to output
+        output_file: Optional file path. If None, prints to stdout.
+
+    Raises:
+        click.ClickException: If the file cannot be written
+    """
+    if output_file:
+        try:
+            with open(output_file, "w", encoding="utf-8") as f:
+                f.write(content)
+            click.echo(f"Output written to: {output_file}")
+        except OSError as e:
+            raise click.ClickException(f"Cannot write to '{output_file}': {e}")
+    else:
+        click.echo(content)

--- a/snowflake_semantic_tools/interfaces/cli/main.py
+++ b/snowflake_semantic_tools/interfaces/cli/main.py
@@ -99,6 +99,7 @@ LAZY_COMMANDS = {
     "validate": ("snowflake_semantic_tools.interfaces.cli.commands.validate", "validate"),
     "generate": ("snowflake_semantic_tools.interfaces.cli.commands.generate", "generate"),
     "deploy": ("snowflake_semantic_tools.interfaces.cli.commands.deploy", "deploy"),
+    "list": ("snowflake_semantic_tools.interfaces.cli.commands.list", "list_cmd"),
     "migrate-meta": ("snowflake_semantic_tools.interfaces.cli.commands.migrate_meta", "migrate_meta"),
 }
 
@@ -120,6 +121,7 @@ def cli():
     - EXTRACT: Parse and load semantic metadata to Snowflake
     - GENERATE: Create Snowflake semantic views and/or YAML models
     - DEPLOY: One-step validate → extract → generate workflow
+    - LIST: Explore semantic model components (metrics, tables, views, etc.)
     - MIGRATE-META: Migrate meta.sst to config.meta.sst (dbt Fusion compatibility)
 
     Use --help with any command for detailed options.

--- a/snowflake_semantic_tools/services/__init__.py
+++ b/snowflake_semantic_tools/services/__init__.py
@@ -69,6 +69,11 @@ from snowflake_semantic_tools.services.generate_semantic_views import (
     UnifiedGenerationConfig,
     UnifiedGenerationResult,
 )
+from snowflake_semantic_tools.services.list_semantic_components import (
+    ListConfig,
+    ListResult,
+    SemanticComponentListService,
+)
 from snowflake_semantic_tools.services.validate_semantic_models import SemanticMetadataCollectionValidationService
 
 __all__ = [
@@ -85,4 +90,7 @@ __all__ = [
     "DeployService",
     "DeployConfig",
     "DeployResult",
+    "SemanticComponentListService",
+    "ListConfig",
+    "ListResult",
 ]

--- a/snowflake_semantic_tools/services/list_semantic_components.py
+++ b/snowflake_semantic_tools/services/list_semantic_components.py
@@ -1,0 +1,274 @@
+"""
+List Semantic Components Service
+
+Provides introspection of semantic model components from parsed YAML files.
+Enables users to discover metrics, relationships, filters, semantic views,
+custom instructions, verified queries, and tables without requiring a
+Snowflake connection or compiled manifest.
+"""
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from snowflake_semantic_tools.core.parsing import Parser
+from snowflake_semantic_tools.core.parsing.parser import ParsingCriticalError
+from snowflake_semantic_tools.shared.utils import get_logger
+from snowflake_semantic_tools.shared.utils.file_utils import find_dbt_model_files, find_semantic_model_files
+
+logger = get_logger("list_semantic_components")
+
+
+def _safe_str(value: Any) -> str:
+    """Safely convert a value to string, handling None."""
+    if value is None:
+        return ""
+    return str(value)
+
+
+def _parse_tables_json(tables_field: Any) -> List[str]:
+    """Parse a tables field that may be a JSON string or a list."""
+    if isinstance(tables_field, list):
+        return tables_field
+    if isinstance(tables_field, str):
+        try:
+            parsed = json.loads(tables_field)
+            return parsed if isinstance(parsed, list) else []
+        except (json.JSONDecodeError, TypeError):
+            return []
+    return []
+
+
+@dataclass
+class ListConfig:
+    """Configuration for listing semantic components."""
+
+    dbt_path: Optional[Path] = None
+    semantic_path: Optional[Path] = None
+    exclude_dirs: Optional[List[str]] = None
+    table_filter: Optional[str] = None
+
+
+@dataclass
+class ListResult:
+    """Results from listing semantic model components."""
+
+    tables: List[Dict[str, Any]] = field(default_factory=list)
+    metrics: List[Dict[str, Any]] = field(default_factory=list)
+    relationships: List[Dict[str, Any]] = field(default_factory=list)
+    filters: List[Dict[str, Any]] = field(default_factory=list)
+    semantic_views: List[Dict[str, Any]] = field(default_factory=list)
+    custom_instructions: List[Dict[str, Any]] = field(default_factory=list)
+    verified_queries: List[Dict[str, Any]] = field(default_factory=list)
+    errors: List[str] = field(default_factory=list)
+
+    @property
+    def total_count(self) -> int:
+        return (
+            len(self.tables)
+            + len(self.metrics)
+            + len(self.relationships)
+            + len(self.filters)
+            + len(self.semantic_views)
+            + len(self.custom_instructions)
+            + len(self.verified_queries)
+        )
+
+
+class SemanticComponentListService:
+    """
+    Service for listing semantic model components.
+
+    Parses dbt and semantic model YAML files and returns structured
+    component inventories. No Snowflake connection required.
+    """
+
+    def __init__(self):
+        self.parser = Parser(enable_template_resolution=True)
+
+    def execute(self, config: ListConfig) -> ListResult:
+        """
+        Execute the list workflow.
+
+        Args:
+            config: List configuration with paths and filters
+
+        Returns:
+            ListResult with all discovered components
+        """
+        result = ListResult()
+
+        if config.exclude_dirs is None:
+            config = ListConfig(
+                dbt_path=config.dbt_path,
+                semantic_path=config.semantic_path,
+                exclude_dirs=self._get_config_exclusions(),
+                table_filter=config.table_filter,
+            )
+
+        dbt_files = self._find_dbt_files(config)
+        semantic_files = self._find_semantic_files(config)
+
+        if not dbt_files and not semantic_files:
+            result.errors.append("No dbt or semantic model files found in project.")
+            return result
+
+        self._try_load_manifest()
+
+        try:
+            parse_result = self.parser.parse_all_files(dbt_files, semantic_files)
+        except ParsingCriticalError as e:
+            logger.debug(f"Parsing completed with errors (partial results available): {e}")
+            parse_result = {
+                "dbt": self._safe_parse_dbt(dbt_files),
+                "semantic": self._safe_parse_semantic(semantic_files),
+            }
+            result.errors.extend(e.errors)
+
+        self._extract_tables(parse_result, result, config)
+        self._extract_metrics(parse_result, result, config)
+        self._extract_relationships(parse_result, result, config)
+        self._extract_filters(parse_result, result, config)
+        self._extract_semantic_views(parse_result, result, config)
+        self._extract_custom_instructions(parse_result, result, config)
+        self._extract_verified_queries(parse_result, result, config)
+
+        return result
+
+    def _get_config_exclusions(self) -> Optional[List[str]]:
+        """Load exclusion patterns from sst_config.yml if available."""
+        try:
+            from snowflake_semantic_tools.shared.config import get_config
+
+            config = get_config()
+            exclude_dirs = config.get("validation.exclude_dirs", [])
+            return exclude_dirs if exclude_dirs else None
+        except Exception:
+            return None
+
+    def _find_dbt_files(self, config: ListConfig) -> List[Path]:
+        if config.dbt_path:
+            dbt_path = config.dbt_path if config.dbt_path.is_absolute() else Path.cwd() / config.dbt_path
+            from snowflake_semantic_tools.shared.utils.file_utils import _is_dbt_model_file
+
+            all_yml = list(dbt_path.rglob("*.yml")) + list(dbt_path.rglob("*.yaml"))
+            return [f for f in all_yml if _is_dbt_model_file(f)]
+        return find_dbt_model_files(exclude_dirs=config.exclude_dirs)
+
+    def _find_semantic_files(self, config: ListConfig) -> List[Path]:
+        if config.semantic_path:
+            sem_path = config.semantic_path if config.semantic_path.is_absolute() else Path.cwd() / config.semantic_path
+            return list(sem_path.rglob("*.yml")) + list(sem_path.rglob("*.yaml"))
+        try:
+            return find_semantic_model_files()
+        except Exception:
+            return []
+
+    def _try_load_manifest(self):
+        try:
+            from snowflake_semantic_tools.core.parsing.parsers.manifest_parser import ManifestParser
+
+            manifest_parser = ManifestParser()
+            if manifest_parser.load():
+                self.parser.manifest_parser = manifest_parser
+                logger.debug("Loaded manifest for template resolution")
+        except ImportError as e:
+            logger.warning(f"Could not import manifest parser: {e}")
+        except Exception as e:
+            logger.warning(f"Could not load manifest (template resolution may be limited): {e}")
+
+    def _safe_parse_dbt(self, dbt_files: List[Path]) -> Dict[str, Any]:
+        try:
+            fresh_parser = Parser(enable_template_resolution=False)
+            fresh_parser._build_dbt_catalog(dbt_files)
+            return {"models": list(fresh_parser.dbt_catalog.values()), "sm_tables": []}
+        except Exception:
+            return {"models": [], "sm_tables": []}
+
+    def _safe_parse_semantic(self, semantic_files: List[Path]) -> Dict[str, Any]:
+        return {}
+
+    def _extract_tables(self, parse_result: Dict[str, Any], result: ListResult, config: ListConfig):
+        dbt_data = parse_result.get("dbt", {})
+        tables = dbt_data.get("sm_tables", [])
+        for table in tables:
+            if not isinstance(table, dict):
+                continue
+            table_name = _safe_str(table.get("table_name"))
+            if config.table_filter and config.table_filter.upper() not in table_name.upper():
+                continue
+            result.tables.append(table)
+
+    def _extract_metrics(self, parse_result: Dict[str, Any], result: ListResult, config: ListConfig):
+        semantic_data = parse_result.get("semantic", {})
+        metrics_data = semantic_data.get("metrics", {})
+        items = metrics_data.get("items", []) if isinstance(metrics_data, dict) else []
+        for metric in items:
+            if not isinstance(metric, dict):
+                continue
+            if config.table_filter:
+                tables = metric.get("tables") or []
+                table_name = _safe_str(metric.get("table_name"))
+                filter_upper = config.table_filter.upper()
+                if filter_upper not in table_name.upper() and not any(
+                    filter_upper in _safe_str(t).upper() for t in tables
+                ):
+                    continue
+            result.metrics.append(metric)
+
+    def _extract_relationships(self, parse_result: Dict[str, Any], result: ListResult, config: ListConfig):
+        semantic_data = parse_result.get("semantic", {})
+        rel_data = semantic_data.get("relationships", {})
+        items = rel_data.get("items", []) if isinstance(rel_data, dict) else []
+        for rel in items:
+            if not isinstance(rel, dict):
+                continue
+            if config.table_filter:
+                filter_upper = config.table_filter.upper()
+                left = _safe_str(rel.get("left_table_name"))
+                right = _safe_str(rel.get("right_table_name"))
+                if filter_upper not in left.upper() and filter_upper not in right.upper():
+                    continue
+            result.relationships.append(rel)
+
+    def _extract_filters(self, parse_result: Dict[str, Any], result: ListResult, config: ListConfig):
+        semantic_data = parse_result.get("semantic", {})
+        filters_data = semantic_data.get("filters", {})
+        items = filters_data.get("items", []) if isinstance(filters_data, dict) else []
+        for f in items:
+            if not isinstance(f, dict):
+                continue
+            table_name = _safe_str(f.get("table_name"))
+            if config.table_filter and config.table_filter.upper() not in table_name.upper():
+                continue
+            result.filters.append(f)
+
+    def _extract_semantic_views(self, parse_result: Dict[str, Any], result: ListResult, config: ListConfig):
+        semantic_data = parse_result.get("semantic", {})
+        views_data = semantic_data.get("semantic_views", {})
+        items = views_data.get("items", []) if isinstance(views_data, dict) else []
+        for view in items:
+            if not isinstance(view, dict):
+                continue
+            if config.table_filter:
+                tables = _parse_tables_json(view.get("tables", "[]"))
+                if not any(config.table_filter.upper() in _safe_str(t).upper() for t in tables):
+                    continue
+            result.semantic_views.append(view)
+
+    def _extract_custom_instructions(self, parse_result: Dict[str, Any], result: ListResult, config: ListConfig):
+        semantic_data = parse_result.get("semantic", {})
+        ci_data = semantic_data.get("custom_instructions", {})
+        items = ci_data.get("items", []) if isinstance(ci_data, dict) else []
+        for ci in items:
+            if isinstance(ci, dict):
+                result.custom_instructions.append(ci)
+
+    def _extract_verified_queries(self, parse_result: Dict[str, Any], result: ListResult, config: ListConfig):
+        semantic_data = parse_result.get("semantic", {})
+        vq_data = semantic_data.get("verified_queries", {})
+        items = vq_data.get("items", []) if isinstance(vq_data, dict) else []
+        for vq in items:
+            if isinstance(vq, dict):
+                result.verified_queries.append(vq)

--- a/tests/unit/interfaces/cli/test_list.py
+++ b/tests/unit/interfaces/cli/test_list.py
@@ -1,0 +1,789 @@
+"""
+Tests for the sst list command.
+
+Tests the list service, formatters, and CLI command invocation.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from snowflake_semantic_tools.interfaces.cli.commands.list import list_cmd
+from snowflake_semantic_tools.interfaces.cli.formatters import (
+    format_csv_output,
+    format_json_output,
+    format_table,
+    format_yaml_output,
+    write_output,
+)
+from snowflake_semantic_tools.services.list_semantic_components import (
+    ListConfig,
+    ListResult,
+    SemanticComponentListService,
+    _parse_tables_json,
+    _safe_str,
+)
+
+
+class TestHelpers:
+    def test_safe_str_none(self):
+        assert _safe_str(None) == ""
+
+    def test_safe_str_normal(self):
+        assert _safe_str("hello") == "hello"
+
+    def test_safe_str_number(self):
+        assert _safe_str(42) == "42"
+
+    def test_parse_tables_json_string(self):
+        assert _parse_tables_json('["a","b"]') == ["a", "b"]
+
+    def test_parse_tables_json_list(self):
+        assert _parse_tables_json(["a", "b"]) == ["a", "b"]
+
+    def test_parse_tables_json_invalid(self):
+        assert _parse_tables_json("not json{") == []
+
+    def test_parse_tables_json_none(self):
+        assert _parse_tables_json(None) == []
+
+
+class TestListResult:
+    def test_empty_result(self):
+        result = ListResult()
+        assert result.total_count == 0
+        assert result.tables == []
+        assert result.metrics == []
+
+    def test_total_count(self):
+        result = ListResult(
+            tables=[{"table_name": "A"}],
+            metrics=[{"name": "M1"}, {"name": "M2"}],
+            relationships=[{"relationship_name": "R1"}],
+        )
+        assert result.total_count == 4
+
+
+class TestFormatTable:
+    def test_empty_rows(self):
+        output = format_table(["Name", "Value"], [])
+        assert "(no items found)" in output
+
+    def test_basic_table(self):
+        headers = ["Name", "Count"]
+        rows = [["Tables", "5"], ["Metrics", "3"]]
+        output = format_table(headers, rows)
+        assert "Name" in output
+        assert "Tables" in output
+        assert "Metrics" in output
+        assert "\u2500" in output
+
+    def test_truncation(self):
+        headers = ["Name"]
+        rows = [["A" * 100]]
+        output = format_table(headers, rows, max_col_width=20)
+        assert "..." in output
+
+    def test_rows_shorter_than_headers(self):
+        headers = ["Name", "Value", "Extra"]
+        rows = [["hello"]]
+        output = format_table(headers, rows)
+        assert "hello" in output
+        assert "Name" in output
+
+    def test_min_col_width_enforced(self):
+        headers = ["A"]
+        rows = [["hello"]]
+        output = format_table(headers, rows, max_col_width=1)
+        assert "hello" in output or "he..." in output
+
+    def test_sanitizes_control_chars(self):
+        headers = ["Name"]
+        rows = [["\x1b[31mEVIL\x1b[0m"]]
+        output = format_table(headers, rows)
+        assert "\x1b" not in output
+        assert "EVIL" in output
+
+    def test_unicode_content(self):
+        headers = ["Name"]
+        rows = [["\u00e9\u00e0\u00fc\u00f1"]]
+        output = format_table(headers, rows)
+        assert "\u00e9\u00e0\u00fc\u00f1" in output
+
+
+class TestFormatJson:
+    def test_basic_json(self):
+        data = {"metrics": [{"name": "total_revenue"}], "total_count": 1}
+        output = format_json_output(data)
+        parsed = json.loads(output)
+        assert parsed["total_count"] == 1
+        assert "generated_at" in parsed
+        assert len(parsed["metrics"]) == 1
+
+    def test_json_empty(self):
+        data = {"metrics": [], "total_count": 0}
+        output = format_json_output(data)
+        parsed = json.loads(output)
+        assert parsed["total_count"] == 0
+
+
+class TestFormatYaml:
+    def test_basic_yaml(self):
+        data = {"metrics": [{"name": "revenue"}]}
+        output = format_yaml_output(data)
+        assert "revenue" in output
+        assert "metrics:" in output
+
+
+class TestFormatCsv:
+    def test_basic_csv(self):
+        headers = ["Name", "Description"]
+        rows = [["revenue", "Total revenue"], ["orders", "Order count"]]
+        output = format_csv_output(headers, rows)
+        lines = output.strip().split("\n")
+        assert len(lines) == 3
+        assert "Name,Description" in lines[0]
+        assert "revenue" in lines[1]
+
+    def test_csv_quoting(self):
+        headers = ["Name", "Description"]
+        rows = [["metric", "Has a, comma"]]
+        output = format_csv_output(headers, rows)
+        assert '"Has a, comma"' in output
+
+    def test_csv_newline_in_value(self):
+        headers = ["Name", "SQL"]
+        rows = [["q1", "SELECT\n  1"]]
+        output = format_csv_output(headers, rows)
+        assert "q1" in output
+
+
+class TestWriteOutput:
+    def test_write_to_file(self, tmp_path):
+        filepath = str(tmp_path / "out.txt")
+        write_output("hello world", filepath)
+        with open(filepath) as f:
+            assert f.read() == "hello world"
+
+    def test_write_to_invalid_path(self):
+        with pytest.raises(Exception):
+            write_output("data", "/nonexistent/dir/file.txt")
+
+
+class TestListService:
+    @patch("snowflake_semantic_tools.services.list_semantic_components.find_dbt_model_files")
+    @patch("snowflake_semantic_tools.services.list_semantic_components.find_semantic_model_files")
+    def test_no_files_returns_error(self, mock_semantic, mock_dbt):
+        mock_dbt.return_value = []
+        mock_semantic.return_value = []
+        service = SemanticComponentListService()
+        result = service.execute(ListConfig())
+        assert len(result.errors) > 0
+        assert result.total_count == 0
+
+    @patch("snowflake_semantic_tools.services.list_semantic_components.find_dbt_model_files")
+    @patch("snowflake_semantic_tools.services.list_semantic_components.find_semantic_model_files")
+    def test_table_filter(self, mock_semantic, mock_dbt, tmp_path):
+        dbt_file = tmp_path / "models.yml"
+        dbt_file.write_text("""
+models:
+  - name: orders
+    description: Order table
+    config:
+      meta:
+        sst:
+          primary_key: order_id
+    columns:
+      - name: order_id
+        config:
+          meta:
+            sst:
+              column_type: dimension
+              data_type: TEXT
+""")
+        mock_dbt.return_value = [dbt_file]
+        mock_semantic.return_value = []
+        service = SemanticComponentListService()
+        config = ListConfig(table_filter="NONEXISTENT")
+        result = service.execute(config)
+        assert len(result.tables) == 0
+
+    @patch("snowflake_semantic_tools.services.list_semantic_components.find_dbt_model_files")
+    @patch("snowflake_semantic_tools.services.list_semantic_components.find_semantic_model_files")
+    def test_parsing_critical_error_populates_errors(self, mock_semantic, mock_dbt, tmp_path):
+        from snowflake_semantic_tools.core.parsing.parser import ParsingCriticalError
+
+        dbt_file = tmp_path / "models.yml"
+        dbt_file.write_text("models:\n  - name: orders\n")
+        mock_dbt.return_value = [dbt_file]
+        mock_semantic.return_value = []
+
+        service = SemanticComponentListService()
+        with patch.object(
+            service.parser, "parse_all_files",
+            side_effect=ParsingCriticalError("test error", ["error1", "error2"])
+        ):
+            result = service.execute(ListConfig())
+        assert "error1" in result.errors
+        assert "error2" in result.errors
+
+    @patch("snowflake_semantic_tools.services.list_semantic_components.find_dbt_model_files")
+    @patch("snowflake_semantic_tools.services.list_semantic_components.find_semantic_model_files")
+    def test_none_table_name_does_not_crash(self, mock_semantic, mock_dbt):
+        mock_dbt.return_value = []
+        mock_semantic.return_value = []
+        service = SemanticComponentListService()
+        parse_result = {"dbt": {"sm_tables": [{"table_name": None, "database": "DB"}]}, "semantic": {}}
+        result = ListResult()
+        service._extract_tables(parse_result, result, ListConfig(table_filter="test"))
+        assert len(result.tables) == 0
+
+
+class TestListCLI:
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_summary_table_format(self, mock_run):
+        mock_run.return_value = ListResult(
+            tables=[{"table_name": "ORDERS"}],
+            metrics=[{"name": "REVENUE"}],
+        )
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["summary"])
+        assert result.exit_code == 0
+        assert "Tables" in result.output
+        assert "Metrics" in result.output
+        assert "1" in result.output
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_summary_json_format(self, mock_run):
+        mock_run.return_value = ListResult(
+            tables=[{"table_name": "ORDERS"}],
+            metrics=[{"name": "REVENUE"}],
+        )
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["summary", "--format", "json"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["summary"]["tables"] == 1
+        assert parsed["summary"]["metrics"] == 1
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_summary_yaml_format(self, mock_run):
+        mock_run.return_value = ListResult(tables=[{"table_name": "T1"}])
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["summary", "--format", "yaml"])
+        assert result.exit_code == 0
+        assert "tables:" in result.output
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_summary_csv_format(self, mock_run):
+        mock_run.return_value = ListResult(tables=[{"table_name": "T1"}])
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["summary", "--format", "csv"])
+        assert result.exit_code == 0
+        assert "Component,Count" in result.output
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_metrics_subcommand(self, mock_run):
+        mock_run.return_value = ListResult(
+            metrics=[
+                {"name": "REVENUE", "tables": ["ORDERS"], "table_name": "ORDERS", "description": "Total rev", "expr": "SUM(amount)"}
+            ]
+        )
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["metrics"])
+        assert result.exit_code == 0
+        assert "REVENUE" in result.output
+        assert "ORDERS" in result.output
+        assert "Total rev" in result.output
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_metrics_verbose_shows_expression(self, mock_run):
+        mock_run.return_value = ListResult(
+            metrics=[{"name": "REVENUE", "tables": ["ORDERS"], "table_name": "ORDERS", "description": "Rev", "expr": "SUM(amount)"}]
+        )
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["metrics", "--verbose"])
+        assert result.exit_code == 0
+        assert "Expression" in result.output
+        assert "SUM(amount)" in result.output
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_metrics_with_expr(self, mock_run):
+        mock_run.return_value = ListResult(
+            metrics=[{"name": "REVENUE", "tables": ["ORDERS"], "table_name": "ORDERS", "description": "Rev", "expr": "SUM(amount)"}]
+        )
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["metrics", "--with-expr"])
+        assert result.exit_code == 0
+        assert "Expression" in result.output
+        assert "SUM(amount)" in result.output
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_metrics_json(self, mock_run):
+        mock_run.return_value = ListResult(
+            metrics=[
+                {"name": "REVENUE", "tables": ["ORDERS"], "table_name": "ORDERS", "description": "Total rev", "expr": "SUM(amount)"}
+            ]
+        )
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["metrics", "--format", "json"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["total_count"] == 1
+        assert parsed["metrics"][0]["name"] == "REVENUE"
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_metrics_csv(self, mock_run):
+        mock_run.return_value = ListResult(
+            metrics=[{"name": "REVENUE", "tables": ["ORDERS"], "table_name": "ORDERS", "description": "Rev", "expr": "SUM(a)"}]
+        )
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["metrics", "--format", "csv"])
+        assert result.exit_code == 0
+        assert "Name,Tables,Description" in result.output
+        assert "REVENUE" in result.output
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_metrics_empty(self, mock_run):
+        mock_run.return_value = ListResult()
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["metrics"])
+        assert result.exit_code == 0
+        assert "(no metrics found)" in result.output
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_relationships_subcommand(self, mock_run):
+        mock_run.return_value = ListResult(
+            relationships=[
+                {"relationship_name": "ORDERS_TO_CUSTOMERS", "left_table_name": "ORDERS", "right_table_name": "CUSTOMERS"}
+            ]
+        )
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["relationships"])
+        assert result.exit_code == 0
+        assert "ORDERS_TO_CUSTOMERS" in result.output
+        assert "ORDERS" in result.output
+        assert "\u2192" in result.output
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_relationships_csv(self, mock_run):
+        mock_run.return_value = ListResult(
+            relationships=[{"relationship_name": "R1", "left_table_name": "A", "right_table_name": "B"}]
+        )
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["relationships", "--format", "csv"])
+        assert result.exit_code == 0
+        assert "Name,Left Table,Right Table" in result.output
+        assert "R1" in result.output
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_filters_subcommand(self, mock_run):
+        mock_run.return_value = ListResult(
+            filters=[{"name": "ACTIVE_ONLY", "table_name": "USERS", "description": "Active users", "expr": "status='active'"}]
+        )
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["filters"])
+        assert result.exit_code == 0
+        assert "ACTIVE_ONLY" in result.output
+        assert "USERS" in result.output
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_filters_verbose_shows_expression(self, mock_run):
+        mock_run.return_value = ListResult(
+            filters=[{"name": "F1", "table_name": "T", "description": "D", "expr": "x > 0"}]
+        )
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["filters", "--verbose"])
+        assert result.exit_code == 0
+        assert "Expression" in result.output
+        assert "x > 0" in result.output
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_filters_empty(self, mock_run):
+        mock_run.return_value = ListResult()
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["filters"])
+        assert result.exit_code == 0
+        assert "(no filters found)" in result.output
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_tables_subcommand(self, mock_run):
+        mock_run.return_value = ListResult(
+            tables=[{"table_name": "ORDERS", "database": "ANALYTICS", "schema": "CORE", "primary_key": "ORDER_ID"}]
+        )
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["tables"])
+        assert result.exit_code == 0
+        assert "ORDERS" in result.output
+        assert "ANALYTICS" in result.output
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_semantic_views_subcommand(self, mock_run):
+        mock_run.return_value = ListResult(
+            semantic_views=[{"name": "customer_360", "description": "Customer view", "tables": '["customers","orders"]'}]
+        )
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["semantic-views"])
+        assert result.exit_code == 0
+        assert "customer_360" in result.output
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_semantic_views_verbose_shows_instructions(self, mock_run):
+        mock_run.return_value = ListResult(
+            semantic_views=[{"name": "sv1", "description": "D", "tables": '["t1"]', "custom_instructions": '["CI1","CI2"]'}]
+        )
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["semantic-views", "--verbose"])
+        assert result.exit_code == 0
+        assert "Custom Instructions" in result.output
+        assert "CI1" in result.output
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_semantic_views_malformed_json(self, mock_run):
+        mock_run.return_value = ListResult(
+            semantic_views=[{"name": "sv1", "description": "D", "tables": "not valid json{", "custom_instructions": "bad"}]
+        )
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["semantic-views", "--verbose"])
+        assert result.exit_code == 0
+        assert "sv1" in result.output
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_custom_instructions_subcommand(self, mock_run):
+        mock_run.return_value = ListResult(
+            custom_instructions=[{"name": "SALES_CI", "question_categorization": "Cat", "sql_generation": "Gen"}]
+        )
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["custom-instructions"])
+        assert result.exit_code == 0
+        assert "SALES_CI" in result.output
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_custom_instructions_verbose(self, mock_run):
+        mock_run.return_value = ListResult(
+            custom_instructions=[{"name": "CI1", "question_categorization": "Cat text", "sql_generation": "Gen text"}]
+        )
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["custom-instructions", "--verbose"])
+        assert result.exit_code == 0
+        assert "Question Categorization" in result.output
+        assert "Cat text" in result.output
+        assert "Gen text" in result.output
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_custom_instructions_empty(self, mock_run):
+        mock_run.return_value = ListResult()
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["custom-instructions"])
+        assert result.exit_code == 0
+        assert "(no custom instructions found)" in result.output
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_verified_queries_subcommand(self, mock_run):
+        mock_run.return_value = ListResult(
+            verified_queries=[{"name": "VQ1", "question": "What is revenue?", "verified_by": "alice", "verified_at": "2025-01-01", "sql": "SELECT 1"}]
+        )
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["verified-queries"])
+        assert result.exit_code == 0
+        assert "VQ1" in result.output
+        assert "What is revenue?" in result.output
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_verified_queries_verbose_shows_sql(self, mock_run):
+        mock_run.return_value = ListResult(
+            verified_queries=[{"name": "VQ1", "question": "Q?", "verified_by": "bob", "sql": "SELECT 1"}]
+        )
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["verified-queries", "--verbose"])
+        assert result.exit_code == 0
+        assert "SQL" in result.output
+        assert "SELECT 1" in result.output
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_verified_queries_empty(self, mock_run):
+        mock_run.return_value = ListResult()
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["verified-queries"])
+        assert result.exit_code == 0
+        assert "(no verified queries found)" in result.output
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_verified_queries_yaml(self, mock_run):
+        mock_run.return_value = ListResult(
+            verified_queries=[{"name": "VQ1", "question": "Q?", "verified_by": "bob", "sql": "SELECT 1"}]
+        )
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["verified-queries", "--format", "yaml"])
+        assert result.exit_code == 0
+        assert "VQ1" in result.output
+        assert "verified_queries:" in result.output
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_quiet_mode(self, mock_run):
+        mock_run.return_value = ListResult(
+            metrics=[{"name": "REVENUE", "tables": ["ORDERS"], "table_name": "ORDERS", "description": "Rev", "expr": "SUM(a)"}]
+        )
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["metrics", "--quiet"])
+        assert result.exit_code == 0
+        assert "Running with sst=" not in result.output
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_output_to_file(self, mock_run, tmp_path):
+        mock_run.return_value = ListResult(
+            metrics=[{"name": "REVENUE", "tables": ["ORDERS"], "table_name": "ORDERS", "description": "Rev", "expr": "SUM(a)"}]
+        )
+        output_file = str(tmp_path / "out.json")
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["metrics", "--format", "json", "--output", output_file])
+        assert result.exit_code == 0
+        with open(output_file) as f:
+            data = json.load(f)
+        assert data["total_count"] == 1
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_invoke_without_subcommand_shows_summary(self, mock_run):
+        mock_run.return_value = ListResult(tables=[{"table_name": "T1"}])
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, [])
+        assert result.exit_code == 0
+        assert "Tables" in result.output
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_errors_displayed_as_warnings(self, mock_run):
+        mock_run.return_value = ListResult(errors=["Something went wrong"])
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["summary"])
+        assert result.exit_code == 0
+        assert "Something went wrong" in result.output
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_tables_json(self, mock_run):
+        mock_run.return_value = ListResult(
+            tables=[{"table_name": "ORDERS", "database": "DB", "schema": "S", "primary_key": "ID"}]
+        )
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["tables", "--format", "json"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["total_count"] == 1
+        assert parsed["tables"][0]["table_name"] == "ORDERS"
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_tables_csv(self, mock_run):
+        mock_run.return_value = ListResult(
+            tables=[{"table_name": "ORDERS", "database": "DB", "schema": "S", "primary_key": "ID"}]
+        )
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["tables", "--format", "csv"])
+        assert result.exit_code == 0
+        assert "Name,Database,Schema,Primary Key" in result.output
+        assert "ORDERS" in result.output
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_tables_yaml(self, mock_run):
+        mock_run.return_value = ListResult(
+            tables=[{"table_name": "ORDERS", "database": "DB", "schema": "S", "primary_key": "ID"}]
+        )
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["tables", "--format", "yaml"])
+        assert result.exit_code == 0
+        assert "tables:" in result.output
+        assert "ORDERS" in result.output
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_tables_empty(self, mock_run):
+        mock_run.return_value = ListResult()
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["tables"])
+        assert result.exit_code == 0
+        assert "(no tables found)" in result.output
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_relationships_json(self, mock_run):
+        mock_run.return_value = ListResult(
+            relationships=[{"relationship_name": "R1", "left_table_name": "A", "right_table_name": "B"}]
+        )
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["relationships", "--format", "json"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["total_count"] == 1
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_relationships_yaml(self, mock_run):
+        mock_run.return_value = ListResult(
+            relationships=[{"relationship_name": "R1", "left_table_name": "A", "right_table_name": "B"}]
+        )
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["relationships", "--format", "yaml"])
+        assert result.exit_code == 0
+        assert "relationships:" in result.output
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_relationships_empty(self, mock_run):
+        mock_run.return_value = ListResult()
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["relationships"])
+        assert result.exit_code == 0
+        assert "(no relationships found)" in result.output
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_filters_json(self, mock_run):
+        mock_run.return_value = ListResult(
+            filters=[{"name": "F1", "table_name": "T", "description": "D", "expr": "x > 0"}]
+        )
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["filters", "--format", "json"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["total_count"] == 1
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_filters_csv(self, mock_run):
+        mock_run.return_value = ListResult(
+            filters=[{"name": "F1", "table_name": "T", "description": "D", "expr": "x > 0"}]
+        )
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["filters", "--format", "csv"])
+        assert result.exit_code == 0
+        assert "Name,Table,Description,Expression" in result.output
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_custom_instructions_json(self, mock_run):
+        mock_run.return_value = ListResult(
+            custom_instructions=[{"name": "CI1", "question_categorization": "Q", "sql_generation": "S"}]
+        )
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["custom-instructions", "--format", "json"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["total_count"] == 1
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_custom_instructions_csv(self, mock_run):
+        mock_run.return_value = ListResult(
+            custom_instructions=[{"name": "CI1", "question_categorization": "Q", "sql_generation": "S"}]
+        )
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["custom-instructions", "--format", "csv"])
+        assert result.exit_code == 0
+        assert "Name,Question Categorization,SQL Generation" in result.output
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_semantic_views_json(self, mock_run):
+        mock_run.return_value = ListResult(
+            semantic_views=[{"name": "sv1", "description": "D", "tables": '["t1"]'}]
+        )
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["semantic-views", "--format", "json"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["total_count"] == 1
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_semantic_views_csv(self, mock_run):
+        mock_run.return_value = ListResult(
+            semantic_views=[{"name": "sv1", "description": "D", "tables": '["t1","t2"]'}]
+        )
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["semantic-views", "--format", "csv"])
+        assert result.exit_code == 0
+        assert "Name,Description,Tables" in result.output
+        assert "t1, t2" in result.output
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_semantic_views_empty(self, mock_run):
+        mock_run.return_value = ListResult()
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["semantic-views"])
+        assert result.exit_code == 0
+        assert "(no semantic views found)" in result.output
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_verified_queries_json(self, mock_run):
+        mock_run.return_value = ListResult(
+            verified_queries=[{"name": "VQ1", "question": "Q?", "verified_by": "bob", "verified_at": "2025-01", "sql": "S"}]
+        )
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["verified-queries", "--format", "json"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["total_count"] == 1
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_verified_queries_csv(self, mock_run):
+        mock_run.return_value = ListResult(
+            verified_queries=[{"name": "VQ1", "question": "Q?", "verified_by": "bob", "verified_at": "2025-01", "sql": "S"}]
+        )
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["verified-queries", "--format", "csv"])
+        assert result.exit_code == 0
+        assert "Name,Question,Verified By,Verified At" in result.output
+
+    @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
+    def test_metrics_with_source_file_relativized(self, mock_run):
+        mock_run.return_value = ListResult(
+            metrics=[{"name": "M1", "tables": [], "table_name": "T", "description": "D", "expr": "E", "source_file": "/absolute/path/file.yml"}]
+        )
+        runner = CliRunner()
+        result = runner.invoke(list_cmd, ["metrics", "--format", "json"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        source = parsed["metrics"][0].get("source_file", "")
+        assert not source.startswith("/absolute") or "path/file.yml" in source
+
+
+class TestServiceEdgeCases:
+    def test_get_config_exclusions_no_config(self):
+        service = SemanticComponentListService()
+        result = service._get_config_exclusions()
+        assert result is None or isinstance(result, list)
+
+    @patch("snowflake_semantic_tools.services.list_semantic_components.find_dbt_model_files")
+    @patch("snowflake_semantic_tools.services.list_semantic_components.find_semantic_model_files")
+    def test_extract_metrics_with_none_values(self, mock_semantic, mock_dbt):
+        mock_dbt.return_value = []
+        mock_semantic.return_value = []
+        service = SemanticComponentListService()
+        parse_result = {
+            "dbt": {},
+            "semantic": {"metrics": {"items": [{"name": None, "tables": None, "table_name": None}]}}
+        }
+        result = ListResult()
+        service._extract_metrics(parse_result, result, ListConfig(table_filter="test"))
+        assert len(result.metrics) == 0
+
+    @patch("snowflake_semantic_tools.services.list_semantic_components.find_dbt_model_files")
+    @patch("snowflake_semantic_tools.services.list_semantic_components.find_semantic_model_files")
+    def test_extract_relationships_with_none_values(self, mock_semantic, mock_dbt):
+        mock_dbt.return_value = []
+        mock_semantic.return_value = []
+        service = SemanticComponentListService()
+        parse_result = {
+            "dbt": {},
+            "semantic": {"relationships": {"items": [{"left_table_name": None, "right_table_name": None}]}}
+        }
+        result = ListResult()
+        service._extract_relationships(parse_result, result, ListConfig(table_filter="test"))
+        assert len(result.relationships) == 0
+
+    def test_find_semantic_files_with_custom_path(self, tmp_path):
+        sem_dir = tmp_path / "sem"
+        sem_dir.mkdir()
+        (sem_dir / "test.yml").write_text("snowflake_metrics:\n  - name: m1\n")
+        service = SemanticComponentListService()
+        files = service._find_semantic_files(ListConfig(semantic_path=sem_dir))
+        assert len(files) == 1
+
+    def test_find_dbt_files_with_custom_path(self, tmp_path):
+        dbt_dir = tmp_path / "models"
+        dbt_dir.mkdir()
+        (dbt_dir / "schema.yml").write_text("models:\n  - name: test\n")
+        service = SemanticComponentListService()
+        files = service._find_dbt_files(ListConfig(dbt_path=dbt_dir))
+        assert len(files) == 1

--- a/tests/unit/interfaces/cli/test_list.py
+++ b/tests/unit/interfaces/cli/test_list.py
@@ -188,7 +188,8 @@ class TestListService:
     @patch("snowflake_semantic_tools.services.list_semantic_components.find_semantic_model_files")
     def test_table_filter(self, mock_semantic, mock_dbt, tmp_path):
         dbt_file = tmp_path / "models.yml"
-        dbt_file.write_text("""
+        dbt_file.write_text(
+            """
 models:
   - name: orders
     description: Order table
@@ -203,7 +204,8 @@ models:
             sst:
               column_type: dimension
               data_type: TEXT
-""")
+"""
+        )
         mock_dbt.return_value = [dbt_file]
         mock_semantic.return_value = []
         service = SemanticComponentListService()
@@ -223,8 +225,7 @@ models:
 
         service = SemanticComponentListService()
         with patch.object(
-            service.parser, "parse_all_files",
-            side_effect=ParsingCriticalError("test error", ["error1", "error2"])
+            service.parser, "parse_all_files", side_effect=ParsingCriticalError("test error", ["error1", "error2"])
         ):
             result = service.execute(ListConfig())
         assert "error1" in result.errors
@@ -289,7 +290,13 @@ class TestListCLI:
     def test_metrics_subcommand(self, mock_run):
         mock_run.return_value = ListResult(
             metrics=[
-                {"name": "REVENUE", "tables": ["ORDERS"], "table_name": "ORDERS", "description": "Total rev", "expr": "SUM(amount)"}
+                {
+                    "name": "REVENUE",
+                    "tables": ["ORDERS"],
+                    "table_name": "ORDERS",
+                    "description": "Total rev",
+                    "expr": "SUM(amount)",
+                }
             ]
         )
         runner = CliRunner()
@@ -302,7 +309,15 @@ class TestListCLI:
     @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
     def test_metrics_verbose_shows_expression(self, mock_run):
         mock_run.return_value = ListResult(
-            metrics=[{"name": "REVENUE", "tables": ["ORDERS"], "table_name": "ORDERS", "description": "Rev", "expr": "SUM(amount)"}]
+            metrics=[
+                {
+                    "name": "REVENUE",
+                    "tables": ["ORDERS"],
+                    "table_name": "ORDERS",
+                    "description": "Rev",
+                    "expr": "SUM(amount)",
+                }
+            ]
         )
         runner = CliRunner()
         result = runner.invoke(list_cmd, ["metrics", "--verbose"])
@@ -313,7 +328,15 @@ class TestListCLI:
     @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
     def test_metrics_with_expr(self, mock_run):
         mock_run.return_value = ListResult(
-            metrics=[{"name": "REVENUE", "tables": ["ORDERS"], "table_name": "ORDERS", "description": "Rev", "expr": "SUM(amount)"}]
+            metrics=[
+                {
+                    "name": "REVENUE",
+                    "tables": ["ORDERS"],
+                    "table_name": "ORDERS",
+                    "description": "Rev",
+                    "expr": "SUM(amount)",
+                }
+            ]
         )
         runner = CliRunner()
         result = runner.invoke(list_cmd, ["metrics", "--with-expr"])
@@ -325,7 +348,13 @@ class TestListCLI:
     def test_metrics_json(self, mock_run):
         mock_run.return_value = ListResult(
             metrics=[
-                {"name": "REVENUE", "tables": ["ORDERS"], "table_name": "ORDERS", "description": "Total rev", "expr": "SUM(amount)"}
+                {
+                    "name": "REVENUE",
+                    "tables": ["ORDERS"],
+                    "table_name": "ORDERS",
+                    "description": "Total rev",
+                    "expr": "SUM(amount)",
+                }
             ]
         )
         runner = CliRunner()
@@ -338,7 +367,15 @@ class TestListCLI:
     @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
     def test_metrics_csv(self, mock_run):
         mock_run.return_value = ListResult(
-            metrics=[{"name": "REVENUE", "tables": ["ORDERS"], "table_name": "ORDERS", "description": "Rev", "expr": "SUM(a)"}]
+            metrics=[
+                {
+                    "name": "REVENUE",
+                    "tables": ["ORDERS"],
+                    "table_name": "ORDERS",
+                    "description": "Rev",
+                    "expr": "SUM(a)",
+                }
+            ]
         )
         runner = CliRunner()
         result = runner.invoke(list_cmd, ["metrics", "--format", "csv"])
@@ -358,7 +395,11 @@ class TestListCLI:
     def test_relationships_subcommand(self, mock_run):
         mock_run.return_value = ListResult(
             relationships=[
-                {"relationship_name": "ORDERS_TO_CUSTOMERS", "left_table_name": "ORDERS", "right_table_name": "CUSTOMERS"}
+                {
+                    "relationship_name": "ORDERS_TO_CUSTOMERS",
+                    "left_table_name": "ORDERS",
+                    "right_table_name": "CUSTOMERS",
+                }
             ]
         )
         runner = CliRunner()
@@ -382,7 +423,9 @@ class TestListCLI:
     @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
     def test_filters_subcommand(self, mock_run):
         mock_run.return_value = ListResult(
-            filters=[{"name": "ACTIVE_ONLY", "table_name": "USERS", "description": "Active users", "expr": "status='active'"}]
+            filters=[
+                {"name": "ACTIVE_ONLY", "table_name": "USERS", "description": "Active users", "expr": "status='active'"}
+            ]
         )
         runner = CliRunner()
         result = runner.invoke(list_cmd, ["filters"])
@@ -423,7 +466,9 @@ class TestListCLI:
     @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
     def test_semantic_views_subcommand(self, mock_run):
         mock_run.return_value = ListResult(
-            semantic_views=[{"name": "customer_360", "description": "Customer view", "tables": '["customers","orders"]'}]
+            semantic_views=[
+                {"name": "customer_360", "description": "Customer view", "tables": '["customers","orders"]'}
+            ]
         )
         runner = CliRunner()
         result = runner.invoke(list_cmd, ["semantic-views"])
@@ -433,7 +478,9 @@ class TestListCLI:
     @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
     def test_semantic_views_verbose_shows_instructions(self, mock_run):
         mock_run.return_value = ListResult(
-            semantic_views=[{"name": "sv1", "description": "D", "tables": '["t1"]', "custom_instructions": '["CI1","CI2"]'}]
+            semantic_views=[
+                {"name": "sv1", "description": "D", "tables": '["t1"]', "custom_instructions": '["CI1","CI2"]'}
+            ]
         )
         runner = CliRunner()
         result = runner.invoke(list_cmd, ["semantic-views", "--verbose"])
@@ -444,7 +491,9 @@ class TestListCLI:
     @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
     def test_semantic_views_malformed_json(self, mock_run):
         mock_run.return_value = ListResult(
-            semantic_views=[{"name": "sv1", "description": "D", "tables": "not valid json{", "custom_instructions": "bad"}]
+            semantic_views=[
+                {"name": "sv1", "description": "D", "tables": "not valid json{", "custom_instructions": "bad"}
+            ]
         )
         runner = CliRunner()
         result = runner.invoke(list_cmd, ["semantic-views", "--verbose"])
@@ -484,7 +533,15 @@ class TestListCLI:
     @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
     def test_verified_queries_subcommand(self, mock_run):
         mock_run.return_value = ListResult(
-            verified_queries=[{"name": "VQ1", "question": "What is revenue?", "verified_by": "alice", "verified_at": "2025-01-01", "sql": "SELECT 1"}]
+            verified_queries=[
+                {
+                    "name": "VQ1",
+                    "question": "What is revenue?",
+                    "verified_by": "alice",
+                    "verified_at": "2025-01-01",
+                    "sql": "SELECT 1",
+                }
+            ]
         )
         runner = CliRunner()
         result = runner.invoke(list_cmd, ["verified-queries"])
@@ -525,7 +582,15 @@ class TestListCLI:
     @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
     def test_quiet_mode(self, mock_run):
         mock_run.return_value = ListResult(
-            metrics=[{"name": "REVENUE", "tables": ["ORDERS"], "table_name": "ORDERS", "description": "Rev", "expr": "SUM(a)"}]
+            metrics=[
+                {
+                    "name": "REVENUE",
+                    "tables": ["ORDERS"],
+                    "table_name": "ORDERS",
+                    "description": "Rev",
+                    "expr": "SUM(a)",
+                }
+            ]
         )
         runner = CliRunner()
         result = runner.invoke(list_cmd, ["metrics", "--quiet"])
@@ -535,7 +600,15 @@ class TestListCLI:
     @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
     def test_output_to_file(self, mock_run, tmp_path):
         mock_run.return_value = ListResult(
-            metrics=[{"name": "REVENUE", "tables": ["ORDERS"], "table_name": "ORDERS", "description": "Rev", "expr": "SUM(a)"}]
+            metrics=[
+                {
+                    "name": "REVENUE",
+                    "tables": ["ORDERS"],
+                    "table_name": "ORDERS",
+                    "description": "Rev",
+                    "expr": "SUM(a)",
+                }
+            ]
         )
         output_file = str(tmp_path / "out.json")
         runner = CliRunner()
@@ -676,9 +749,7 @@ class TestListCLI:
 
     @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
     def test_semantic_views_json(self, mock_run):
-        mock_run.return_value = ListResult(
-            semantic_views=[{"name": "sv1", "description": "D", "tables": '["t1"]'}]
-        )
+        mock_run.return_value = ListResult(semantic_views=[{"name": "sv1", "description": "D", "tables": '["t1"]'}])
         runner = CliRunner()
         result = runner.invoke(list_cmd, ["semantic-views", "--format", "json"])
         assert result.exit_code == 0
@@ -707,7 +778,9 @@ class TestListCLI:
     @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
     def test_verified_queries_json(self, mock_run):
         mock_run.return_value = ListResult(
-            verified_queries=[{"name": "VQ1", "question": "Q?", "verified_by": "bob", "verified_at": "2025-01", "sql": "S"}]
+            verified_queries=[
+                {"name": "VQ1", "question": "Q?", "verified_by": "bob", "verified_at": "2025-01", "sql": "S"}
+            ]
         )
         runner = CliRunner()
         result = runner.invoke(list_cmd, ["verified-queries", "--format", "json"])
@@ -718,7 +791,9 @@ class TestListCLI:
     @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
     def test_verified_queries_csv(self, mock_run):
         mock_run.return_value = ListResult(
-            verified_queries=[{"name": "VQ1", "question": "Q?", "verified_by": "bob", "verified_at": "2025-01", "sql": "S"}]
+            verified_queries=[
+                {"name": "VQ1", "question": "Q?", "verified_by": "bob", "verified_at": "2025-01", "sql": "S"}
+            ]
         )
         runner = CliRunner()
         result = runner.invoke(list_cmd, ["verified-queries", "--format", "csv"])
@@ -728,7 +803,16 @@ class TestListCLI:
     @patch("snowflake_semantic_tools.interfaces.cli.commands.list._run_list")
     def test_metrics_with_source_file_relativized(self, mock_run):
         mock_run.return_value = ListResult(
-            metrics=[{"name": "M1", "tables": [], "table_name": "T", "description": "D", "expr": "E", "source_file": "/absolute/path/file.yml"}]
+            metrics=[
+                {
+                    "name": "M1",
+                    "tables": [],
+                    "table_name": "T",
+                    "description": "D",
+                    "expr": "E",
+                    "source_file": "/absolute/path/file.yml",
+                }
+            ]
         )
         runner = CliRunner()
         result = runner.invoke(list_cmd, ["metrics", "--format", "json"])
@@ -752,7 +836,7 @@ class TestServiceEdgeCases:
         service = SemanticComponentListService()
         parse_result = {
             "dbt": {},
-            "semantic": {"metrics": {"items": [{"name": None, "tables": None, "table_name": None}]}}
+            "semantic": {"metrics": {"items": [{"name": None, "tables": None, "table_name": None}]}},
         }
         result = ListResult()
         service._extract_metrics(parse_result, result, ListConfig(table_filter="test"))
@@ -766,7 +850,7 @@ class TestServiceEdgeCases:
         service = SemanticComponentListService()
         parse_result = {
             "dbt": {},
-            "semantic": {"relationships": {"items": [{"left_table_name": None, "right_table_name": None}]}}
+            "semantic": {"relationships": {"items": [{"left_table_name": None, "right_table_name": None}]}},
         }
         result = ListResult()
         service._extract_relationships(parse_result, result, ListConfig(table_filter="test"))


### PR DESCRIPTION
## Description

Adds a new `sst list` command for exploring semantic model components directly from parsed YAML. Users can list metrics, relationships, filters, semantic views, custom instructions, verified queries, and tables without requiring a Snowflake connection or compiled manifest.

Supports 4 output formats (table, JSON, YAML, CSV), filtering by table name, verbose mode for extra detail, quiet mode for scripting, and file output.

## Related Issue

Closes #91

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test improvements
- [ ] Other (please describe):

## Changes Made

**New files:**
- `snowflake_semantic_tools/services/list_semantic_components.py` — Service layer with `ListConfig`, `ListResult`, and `SemanticComponentListService`
- `snowflake_semantic_tools/interfaces/cli/commands/list.py` — Click command group with 8 subcommands (summary, metrics, relationships, filters, semantic-views, custom-instructions, verified-queries, tables)
- `snowflake_semantic_tools/interfaces/cli/formatters.py` — Output formatters (table, JSON, YAML, CSV) with terminal sanitization
- `tests/unit/interfaces/cli/test_list.py` — 80 unit tests

**Modified files:**
- `snowflake_semantic_tools/interfaces/cli/main.py` — Registered `list` in `LAZY_COMMANDS`
- `snowflake_semantic_tools/services/__init__.py` — Exported new service classes

**Key design decisions:**
- No Snowflake connection required (purely local YAML parsing)
- Manifest loading is best-effort (works without `dbt compile`)
- Machine-readable formats (json/yaml/csv) suppress CLIOutput decoration for clean piping
- Control characters sanitized in terminal output to prevent ANSI injection
- Absolute file paths relativized in JSON/YAML output
- Exclude patterns from `sst_config.yml` automatically honored
- `--table` filter uses case-insensitive substring matching

## Testing

- [x] Unit tests pass (`pytest tests/unit/`)
- [x] All existing tests pass (1277 passed, 4 pre-existing errors from missing pytest-mock)
- [x] New tests added for new functionality (80 tests)
- [ ] Tested locally with Python 3.9-3.11
- [x] Manual testing completed (if applicable)
- [x] Test coverage maintained or improved (target: >90%)

### Test Results

```
tests/unit/interfaces/cli/test_list.py — 80 passed in 0.81s
tests/unit/ (full suite) — 1277 passed, 4 errors (pre-existing), 25 subtests passed in 2.00s
```

E2E validated against sst-jaffle-shop:
- `sst list` -> 64 total components (13 tables, 41 metrics, 5 relationships, 3 views, 2 instructions)
- `sst validate` -> PASSED (0 errors, 0 warnings)
- All subcommands, all formats, filtering, verbose/quiet modes tested

## Checklist

### Code Quality
- [x] Code follows the project's style guidelines (Black, line length 120)
- [x] Imports sorted with isort (black profile)
- [x] Type hints added for new code
- [x] Docstrings added for public functions/classes
- [x] No linting errors
- [ ] Pre-commit hooks pass (if using pre-commit)

### Testing and Validation
- [x] All tests pass (`pytest tests/unit/`)
- [x] New functionality has test coverage
- [x] Test results included above

### Documentation and Compatibility
- [x] Documentation updated (if needed)
- [x] Backward compatibility maintained (if applicable)
- [ ] Breaking changes discussed with maintainer first (see CONTRIBUTING.md)

### Performance
- [x] Performance impact considered
- [x] No significant performance regressions

## Screenshots / Examples

```
$ sst list
14:32:45  Running with sst=0.2.4

14:32:45  Semantic Model Summary
14:32:45  ======================

  Component             Count
  --------------------  -----
  Tables                13
  Metrics               41
  Relationships         5
  Filters               0
  Semantic Views        3
  Custom Instructions   2
  Verified Queries      0
  --------------------  -----
  Total Components      64

14:32:45  Done [OK in 0.2s]
```

```
$ sst list relationships
14:35:22  Relationships (5 total)

  Name                     Left Table   ->  Right Table
  -----------------------  -----------  --  -----------
  ORDERS_TO_CUSTOMERS      ORDERS       ->  CUSTOMERS
  ORDERS_TO_LOCATIONS      ORDERS       ->  LOCATIONS
  ORDER_ITEMS_TO_ORDERS    ORDER_ITEMS  ->  ORDERS
  ORDER_ITEMS_TO_PRODUCTS  ORDER_ITEMS  ->  PRODUCTS
  SUPPLIES_TO_PRODUCTS     SUPPLIES     ->  PRODUCTS

14:35:22  Done [OK in 0.2s]
```

## Additional Notes

- The `--table` filter uses substring matching (e.g., `--table order` matches both `ORDERS` and `ORDER_ITEMS`). This is intentional for discoverability.
- The command reuses the existing `Parser` infrastructure with template resolution enabled, so resolved metric expressions and table references are shown in the output.
- Follows the same LazyGroup pattern as all other commands for fast `sst --version`.
