### PR TITLE
[SST-136] Fix: Emit synonyms in FACTS clause

### DIFF
--- a/snowflake_semantic_tools/core/generation/semantic_view_builder.py
+++ b/snowflake_semantic_tools/core/generation/semantic_view_builder.py
@@ -954,6 +954,17 @@ class SemanticViewBuilder:
 
             fact_def = f"    {table_name}.{fact_name} AS {expression}"
 
+            # Add synonyms if available
+            if fact.get("SYNONYMS"):
+                synonyms = self._parse_json_field(fact["SYNONYMS"], "synonyms")
+                if synonyms and isinstance(synonyms, list):
+                    synonyms_filtered = [s for s in synonyms if s is not None]
+                    if synonyms_filtered:
+                        synonyms_cleaned = CharacterSanitizer.sanitize_synonym_list(synonyms_filtered)
+                        if synonyms_cleaned:
+                            synonyms_str = ", ".join([f"'{syn}'" for syn in synonyms_cleaned])
+                            fact_def += f"\n      WITH SYNONYMS = ({synonyms_str})"
+
             # Add comment if available
             if fact.get("DESCRIPTION"):
                 description = self._sanitize_description(fact["DESCRIPTION"])

--- a/tests/unit/core/generation/test_semantic_view_builder.py
+++ b/tests/unit/core/generation/test_semantic_view_builder.py
@@ -958,5 +958,125 @@ class TestTableNotFoundErrorFormatting:
         assert "Original error:" in result
 
 
+class TestFactSynonyms:
+    """Test cases for synonym emission in the FACTS clause."""
+
+    @pytest.fixture
+    def builder(self):
+        """Create a SemanticViewBuilder instance for testing."""
+        config = SnowflakeConfig(
+            account="test",
+            user="test",
+            password="test",
+            role="test",
+            warehouse="test",
+            database="test_db",
+            schema="test_schema",
+        )
+        return SemanticViewBuilder(config)
+
+    def test_fact_synonyms_emitted_in_ddl(self, builder, monkeypatch):
+        """Test that facts with synonyms emit WITH SYNONYMS clause."""
+
+        def mock_get_facts(conn, table_name):
+            return [
+                {
+                    "NAME": "subtotal_cents",
+                    "EXPR": "SUBTOTAL_CENTS",
+                    "DESCRIPTION": "Subtotal in cents",
+                    "SYNONYMS": '["subtotal in cents", "subtotal amount"]',
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        monkeypatch.setattr(builder, "_get_facts", mock_get_facts)
+
+        result = builder._build_facts_clause(None, ["orders"])
+
+        assert "WITH SYNONYMS = ('subtotal in cents', 'subtotal amount')" in result
+        assert "ORDERS.SUBTOTAL_CENTS AS SUBTOTAL_CENTS" in result
+
+    def test_fact_without_synonyms_no_clause(self, builder, monkeypatch):
+        """Test that facts without synonyms don't emit WITH SYNONYMS clause."""
+
+        def mock_get_facts(conn, table_name):
+            return [
+                {
+                    "NAME": "amount",
+                    "EXPR": "AMOUNT",
+                    "DESCRIPTION": "Order amount",
+                    "SYNONYMS": None,
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        monkeypatch.setattr(builder, "_get_facts", mock_get_facts)
+
+        result = builder._build_facts_clause(None, ["orders"])
+
+        assert "WITH SYNONYMS" not in result
+        assert "ORDERS.AMOUNT AS AMOUNT" in result
+
+    def test_fact_synonyms_empty_list(self, builder, monkeypatch):
+        """Test that empty synonym list doesn't emit WITH SYNONYMS clause."""
+
+        def mock_get_facts(conn, table_name):
+            return [
+                {
+                    "NAME": "quantity",
+                    "EXPR": "QUANTITY",
+                    "DESCRIPTION": "Item quantity",
+                    "SYNONYMS": "[]",
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        monkeypatch.setattr(builder, "_get_facts", mock_get_facts)
+
+        result = builder._build_facts_clause(None, ["orders"])
+
+        assert "WITH SYNONYMS" not in result
+
+    def test_fact_synonyms_null_values_filtered(self, builder, monkeypatch):
+        """Test that None values in synonym list are filtered out."""
+
+        def mock_get_facts(conn, table_name):
+            return [
+                {
+                    "NAME": "cost",
+                    "EXPR": "COST",
+                    "DESCRIPTION": "Item cost",
+                    "SYNONYMS": '[null, null]',
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        monkeypatch.setattr(builder, "_get_facts", mock_get_facts)
+
+        result = builder._build_facts_clause(None, ["orders"])
+
+        assert "WITH SYNONYMS" not in result
+
+    def test_fact_synonyms_mixed_null_and_valid(self, builder, monkeypatch):
+        """Test that valid synonyms are kept when mixed with None values."""
+
+        def mock_get_facts(conn, table_name):
+            return [
+                {
+                    "NAME": "price",
+                    "EXPR": "PRICE",
+                    "DESCRIPTION": "Item price",
+                    "SYNONYMS": '[null, "unit price", null, "cost per item"]',
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        monkeypatch.setattr(builder, "_get_facts", mock_get_facts)
+
+        result = builder._build_facts_clause(None, ["orders"])
+
+        assert "WITH SYNONYMS = ('unit price', 'cost per item')" in result
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Description

Facts with synonyms defined in SST metadata were not emitting the `WITH SYNONYMS` clause in generated DDL, unlike dimensions which already supported this. This copies the synonym emission pattern from `_build_dimensions_clause()` into `_build_facts_clause()`.

## Related Issue

Closes #136

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test improvements
- [ ] Other (please describe):

## Changes Made

- Added synonym emission logic (~11 lines) to `_build_facts_clause()` in `semantic_view_builder.py`
- Mirrors the existing pattern used in `_build_dimensions_clause()` (null filtering, sanitization, formatting)

## Testing

- [x] Unit tests pass (`pytest tests/unit/`)
- [x] All existing tests pass
- [x] New tests added for new functionality
- [ ] Tested locally with Python 3.9-3.11
- [ ] Manual testing completed (if applicable)
- [x] Test coverage maintained or improved (target: >90%)

### Test Results

```
5 new tests in TestFactSynonyms:
- test_fact_synonyms_emitted_in_ddl (happy path)
- test_fact_without_synonyms_no_clause (None synonyms)
- test_fact_synonyms_empty_list (empty JSON array)
- test_fact_synonyms_null_values_filtered (all nulls filtered)
- test_fact_synonyms_mixed_null_and_valid (mixed nulls + valid)

Full suite: 1280 passed, 4 deselected (pre-existing pytest-mock issue)
```

## Checklist

### Code Quality
- [x] Code follows the project's style guidelines (Black, line length 120)
- [x] Imports sorted with isort (black profile)
- [x] Type hints added for new code
- [x] No linting errors

### Testing & Validation
- [x] All tests pass (`pytest tests/unit/`)
- [x] New functionality has test coverage
- [x] Test results included above

### Documentation & Compatibility
- [x] Backward compatibility maintained (if applicable)

### Performance
- [x] Performance impact considered
- [x] No significant performance regressions

## Additional Notes

sst-jaffle-shop already has facts with synonyms defined (e.g., `subtotal_cents` in `models/marts/orders.yml`), so it exercises this fix without modification during e2e testing.

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)
