### PR TITLE
[SST-137] Feature: Convert filters to AI_SQL_GENERATION instructions

### DIFF
--- a/snowflake_semantic_tools/core/generation/semantic_view_builder.py
+++ b/snowflake_semantic_tools/core/generation/semantic_view_builder.py
@@ -1272,23 +1272,97 @@ class SemanticViewBuilder:
             logger.warning(f"Failed to retrieve custom instructions: {e}")
             return []
 
-    def _build_ai_guidance_clauses(self, conn: Any, custom_instruction_names: Optional[List[str]]) -> str:
+    def _get_filters_for_tables(self, conn: Any, table_names: List[str]) -> List[Dict[str, Any]]:
         """
-        Build AI_QUESTION_CATEGORIZATION and AI_SQL_GENERATION clauses from custom instructions.
+        Retrieve filters from SM_FILTERS for the given tables.
+
+        Args:
+            conn: Database connection
+            table_names: List of table names to get filters for
+
+        Returns:
+            List of filter dictionaries with NAME, TABLE_NAME, DESCRIPTION, EXPR
+        """
+        if not table_names:
+            return []
+
+        try:
+            tlist = ", ".join([f"'{t.upper()}'" for t in table_names])
+            sql = (
+                f"SELECT NAME, TABLE_NAME, DESCRIPTION, EXPR "
+                f"FROM {self.metadata_database}.{self.metadata_schema}.SM_FILTERS "
+                f"WHERE UPPER(TABLE_NAME) IN ({tlist})"
+            )
+            return self._execute_query(conn, sql)
+        except Exception as e:
+            logger.warning(f"Failed to retrieve filters: {e}")
+            return []
+
+    def _build_filters_as_instructions(self, conn: Any, table_names: List[str]) -> str:
+        """
+        Convert filter definitions into AI_SQL_GENERATION instruction text.
+
+        Snowflake's CREATE SEMANTIC VIEW DDL has no native FILTERS clause.
+        This method converts filters into natural language instructions that are
+        appended to the AI_SQL_GENERATION clause, making filters functional.
+
+        Args:
+            conn: Database connection
+            table_names: List of table names in the current semantic view
+
+        Returns:
+            Instruction text for filters, or empty string if no filters found
+        """
+        from snowflake_semantic_tools.shared.config import get_config
+
+        config = get_config()
+        if not config.get("generation.filters_to_instructions", True):
+            return ""
+
+        filters = self._get_filters_for_tables(conn, table_names)
+        if not filters:
+            return ""
+
+        filter_lines = []
+        for f in filters:
+            table_name = f.get("TABLE_NAME", "").upper()
+            expr = f.get("EXPR", "")
+            description = f.get("DESCRIPTION", "")
+            if expr:
+                if description:
+                    filter_lines.append(
+                        f"- When querying {table_name}, apply: {expr} ({description}) "
+                        f"unless the user explicitly requests unfiltered data."
+                    )
+                else:
+                    filter_lines.append(
+                        f"- When querying {table_name}, apply: {expr} "
+                        f"unless the user explicitly requests unfiltered data."
+                    )
+
+        if not filter_lines:
+            return ""
+
+        header = "Default Filters:"
+        return header + "\n" + "\n".join(filter_lines)
+
+    def _build_ai_guidance_clauses(
+        self, conn: Any, custom_instruction_names: Optional[List[str]], table_names: Optional[List[str]] = None
+    ) -> str:
+        """
+        Build AI_QUESTION_CATEGORIZATION and AI_SQL_GENERATION clauses from custom instructions and filters.
 
         Args:
             conn: Database connection
             custom_instruction_names: List of custom instruction names to aggregate
+            table_names: List of table names for filter-to-instruction conversion
 
         Returns:
             String containing AI_QUESTION_CATEGORIZATION and/or AI_SQL_GENERATION clauses, or empty string
         """
-        if not custom_instruction_names:
-            return ""
-
-        instructions = self._get_custom_instructions_for_view(conn, custom_instruction_names)
-        if not instructions:
-            return ""
+        instructions = []
+        if custom_instruction_names:
+            instructions = self._get_custom_instructions_for_view(conn, custom_instruction_names)
 
         # Aggregate fields from all instructions
         question_cat_parts = []
@@ -1298,6 +1372,15 @@ class SemanticViewBuilder:
                 question_cat_parts.append(inst["question_categorization"].strip())
             if inst.get("sql_generation"):
                 sql_gen_parts.append(inst["sql_generation"].strip())
+
+        # Append filter-based instructions to AI_SQL_GENERATION
+        if table_names:
+            filter_instructions = self._build_filters_as_instructions(conn, table_names)
+            if filter_instructions:
+                sql_gen_parts.append(filter_instructions)
+
+        if not sql_gen_parts and not question_cat_parts:
+            return ""
 
         clauses = []
 
@@ -1407,9 +1490,9 @@ class SemanticViewBuilder:
             comment = f"Semantic view generated for tables: {', '.join(table_names)}"
         sql_parts.append(f"  COMMENT = '{comment}'")
 
-        # Build AI guidance clauses from custom instructions
+        # Build AI guidance clauses from custom instructions and filters
         # These come after COMMENT per Snowflake syntax: COMMENT, then AI_SQL_GENERATION, then AI_QUESTION_CATEGORIZATION
-        ai_guidance_clauses = self._build_ai_guidance_clauses(conn, custom_instruction_names)
+        ai_guidance_clauses = self._build_ai_guidance_clauses(conn, custom_instruction_names, table_names=table_names)
         if ai_guidance_clauses:
             sql_parts.append(ai_guidance_clauses)
 

--- a/snowflake_semantic_tools/core/generation/semantic_view_builder.py
+++ b/snowflake_semantic_tools/core/generation/semantic_view_builder.py
@@ -1287,13 +1287,18 @@ class SemanticViewBuilder:
             return []
 
         try:
-            tlist = ", ".join([f"'{t.upper()}'" for t in table_names])
+            cursor = conn.cursor()
+            placeholders = ", ".join(["%s"] * len(table_names))
             sql = (
                 f"SELECT NAME, TABLE_NAME, DESCRIPTION, EXPR "
                 f"FROM {self.metadata_database}.{self.metadata_schema}.SM_FILTERS "
-                f"WHERE UPPER(TABLE_NAME) IN ({tlist})"
+                f"WHERE UPPER(TABLE_NAME) IN ({placeholders})"
             )
-            return self._execute_query(conn, sql)
+            params = [t.upper() for t in table_names]
+            cursor.execute(sql, params)
+            columns = [desc[0] for desc in cursor.description]
+            rows = cursor.fetchall()
+            return [dict(zip(columns, row)) for row in rows]
         except Exception as e:
             logger.warning(f"Failed to retrieve filters: {e}")
             return []

--- a/snowflake_semantic_tools/core/validation/rules/semantic_models.py
+++ b/snowflake_semantic_tools/core/validation/rules/semantic_models.py
@@ -70,6 +70,15 @@ class SemanticModelValidator:
 
         if "filters" in semantic_data:
             self._validate_filters(semantic_data["filters"], result)
+            filter_items = semantic_data["filters"].get("items", [])
+            if filter_items:
+                result.add_warning(
+                    "snowflake_filters is deprecated and will be removed in a future major version. "
+                    "Filters are auto-converted to AI_SQL_GENERATION instructions at generation time, "
+                    "but for full control over instruction wording, migrate to snowflake_custom_instructions "
+                    "with sql_generation text.",
+                    context={"type": "DEPRECATION"},
+                )
 
         if "custom_instructions" in semantic_data:
             self._validate_custom_instructions(semantic_data["custom_instructions"], result)

--- a/snowflake_semantic_tools/shared/config.py
+++ b/snowflake_semantic_tools/shared/config.py
@@ -76,6 +76,9 @@ class Config:
                 "state_path": None,  # Path to state artifacts directory
                 "auto_compile": False,  # Auto-compile manifest if not found (dbt Core only)
             },
+            "generation": {
+                "filters_to_instructions": True,  # Convert filters to AI_SQL_GENERATION instructions
+            },
             "logging": {"level": "INFO", "format": "%(asctime)s - %(name)s - %(levelname)s - %(message)s"},
         }
 

--- a/tests/unit/core/generation/test_semantic_view_builder.py
+++ b/tests/unit/core/generation/test_semantic_view_builder.py
@@ -958,5 +958,167 @@ class TestTableNotFoundErrorFormatting:
         assert "Original error:" in result
 
 
+class TestFiltersToInstructions:
+    """Test cases for filter-to-AI_SQL_GENERATION instruction conversion."""
+
+    @pytest.fixture
+    def builder(self):
+        """Create a SemanticViewBuilder instance for testing."""
+        config = SnowflakeConfig(
+            account="test",
+            user="test",
+            password="test",
+            role="test",
+            warehouse="test",
+            database="test_db",
+            schema="test_schema",
+        )
+        builder = SemanticViewBuilder(config)
+        builder.metadata_database = "TEST_DB"
+        builder.metadata_schema = "TEST_SCHEMA"
+        return builder
+
+    def test_filters_converted_to_instructions(self, builder, monkeypatch):
+        """Test that filters are converted to AI_SQL_GENERATION instruction text."""
+
+        def mock_get_filters(conn, table_names):
+            return [
+                {
+                    "NAME": "ACTIVE_CUSTOMERS_ONLY",
+                    "TABLE_NAME": "CUSTOMERS",
+                    "DESCRIPTION": "Only include active customers",
+                    "EXPR": "CUSTOMERS.STATUS = 'Active'",
+                }
+            ]
+
+        monkeypatch.setattr(builder, "_get_filters_for_tables", mock_get_filters)
+
+        result = builder._build_filters_as_instructions(None, ["customers"])
+
+        assert "Default Filters:" in result
+        assert "CUSTOMERS.STATUS = 'Active'" in result
+        assert "Only include active customers" in result
+        assert "unless the user explicitly requests unfiltered data" in result
+
+    def test_multiple_filters_all_included(self, builder, monkeypatch):
+        """Test that multiple filters are all included in instructions."""
+
+        def mock_get_filters(conn, table_names):
+            return [
+                {
+                    "NAME": "ACTIVE_ONLY",
+                    "TABLE_NAME": "CUSTOMERS",
+                    "DESCRIPTION": "Active customers",
+                    "EXPR": "CUSTOMERS.STATUS = 'Active'",
+                },
+                {
+                    "NAME": "LAST_90_DAYS",
+                    "TABLE_NAME": "ORDERS",
+                    "DESCRIPTION": "Recent orders",
+                    "EXPR": "ORDERS.ORDERED_AT >= DATEADD('day', -90, CURRENT_DATE())",
+                },
+            ]
+
+        monkeypatch.setattr(builder, "_get_filters_for_tables", mock_get_filters)
+
+        result = builder._build_filters_as_instructions(None, ["customers", "orders"])
+
+        assert "CUSTOMERS.STATUS = 'Active'" in result
+        assert "ORDERS.ORDERED_AT >= DATEADD" in result
+
+    def test_no_filters_returns_empty(self, builder, monkeypatch):
+        """Test that no filters returns empty string."""
+
+        def mock_get_filters(conn, table_names):
+            return []
+
+        monkeypatch.setattr(builder, "_get_filters_for_tables", mock_get_filters)
+
+        result = builder._build_filters_as_instructions(None, ["customers"])
+
+        assert result == ""
+
+    def test_filter_without_description(self, builder, monkeypatch):
+        """Test that filters without description still work."""
+
+        def mock_get_filters(conn, table_names):
+            return [
+                {
+                    "NAME": "ACTIVE_ONLY",
+                    "TABLE_NAME": "CUSTOMERS",
+                    "DESCRIPTION": "",
+                    "EXPR": "CUSTOMERS.IS_ACTIVE = TRUE",
+                }
+            ]
+
+        monkeypatch.setattr(builder, "_get_filters_for_tables", mock_get_filters)
+
+        result = builder._build_filters_as_instructions(None, ["customers"])
+
+        assert "CUSTOMERS.IS_ACTIVE = TRUE" in result
+        assert "unless the user explicitly requests unfiltered data" in result
+
+    def test_filters_disabled_via_config(self, builder, monkeypatch):
+        """Test that filters_to_instructions=false skips conversion."""
+        from snowflake_semantic_tools.shared.config import Config
+
+        def mock_get_filters(conn, table_names):
+            return [
+                {
+                    "NAME": "ACTIVE_ONLY",
+                    "TABLE_NAME": "CUSTOMERS",
+                    "DESCRIPTION": "Active only",
+                    "EXPR": "CUSTOMERS.STATUS = 'Active'",
+                }
+            ]
+
+        monkeypatch.setattr(builder, "_get_filters_for_tables", mock_get_filters)
+
+        original_get = Config.get
+
+        def mock_config_get(self, key_path, default=None):
+            if key_path == "generation.filters_to_instructions":
+                return False
+            return original_get(self, key_path, default)
+
+        monkeypatch.setattr(Config, "get", mock_config_get)
+
+        result = builder._build_filters_as_instructions(None, ["customers"])
+
+        assert result == ""
+
+    def test_filters_appended_to_ai_sql_generation(self, builder, monkeypatch):
+        """Test that filters are appended to existing AI_SQL_GENERATION content."""
+
+        def mock_get_custom_instructions(conn, names):
+            return [
+                {
+                    "name": "BUSINESS_RULES",
+                    "question_categorization": None,
+                    "sql_generation": "Always use fiscal year calendar.",
+                }
+            ]
+
+        def mock_get_filters(conn, table_names):
+            return [
+                {
+                    "NAME": "ACTIVE_ONLY",
+                    "TABLE_NAME": "CUSTOMERS",
+                    "DESCRIPTION": "Active only",
+                    "EXPR": "CUSTOMERS.STATUS = 'Active'",
+                }
+            ]
+
+        monkeypatch.setattr(builder, "_get_custom_instructions_for_view", mock_get_custom_instructions)
+        monkeypatch.setattr(builder, "_get_filters_for_tables", mock_get_filters)
+
+        result = builder._build_ai_guidance_clauses(None, ["business_rules"], table_names=["customers"])
+
+        assert "AI_SQL_GENERATION" in result
+        assert "fiscal year calendar" in result
+        assert "CUSTOMERS.STATUS" in result
+        assert "Default Filters:" in result
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/core/validation/test_semantic_models.py
+++ b/tests/unit/core/validation/test_semantic_models.py
@@ -361,6 +361,25 @@ class TestFilterValidation:
         errors = [i.message for i in result.issues if i.severity.name == "ERROR"]
         assert any("missing required field: expr" in e for e in errors)
 
+    def test_filter_deprecation_warning(self, validator):
+        """Test that filters emit a deprecation warning."""
+        semantic_data = {
+            "filters": {
+                "items": [
+                    {
+                        "name": "active_users",
+                        "description": "Active users only",
+                        "expr": "status = 'active'",
+                    }
+                ]
+            }
+        }
+
+        result = validator.validate(semantic_data)
+        warnings = [i.message for i in result.issues if i.severity.name == "WARNING"]
+        assert any("deprecated" in w.lower() for w in warnings)
+        assert any("snowflake_custom_instructions" in w for w in warnings)
+
 
 class TestCustomInstructionValidation:
     """Test custom instruction validation rules."""


### PR DESCRIPTION
## Description

Snowflake's CREATE SEMANTIC VIEW DDL has no native FILTERS clause, so SST filters were parsed, validated, and extracted but silently dropped during generation. This change converts filter definitions into natural language AI_SQL_GENERATION instructions, making them functional. It also emits a deprecation warning guiding users toward `snowflake_custom_instructions`.

## Related Issue

Closes #137

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test improvements
- [ ] Other (please describe):

## Changes Made

- Added `_get_filters_for_tables()` method to query SM_FILTERS for the current view's tables
- Added `_build_filters_as_instructions()` to convert filter definitions into natural language instructions
- Modified `_build_ai_guidance_clauses()` to accept `table_names` and append filter-based instructions to AI_SQL_GENERATION
- Added `generation.filters_to_instructions` config option (default: `true`) in `shared/config.py`
- Added deprecation warning in `semantic_models.py` validation when filters are detected
- Added `filters.yml` to sst-jaffle-shop for e2e testing

## Testing

- [x] Unit tests pass (`pytest tests/unit/`)
- [x] All existing tests pass
- [x] New tests added for new functionality
- [ ] Tested locally with Python 3.9-3.11
- [ ] Manual testing completed (if applicable)
- [x] Test coverage maintained or improved (target: >90%)

### Test Results

```
7 new tests:
- TestFiltersToInstructions (6 tests): happy path, multiple filters, no filters,
  no description, config disabled, appended to existing AI_SQL_GENERATION
- TestFilterValidation.test_filter_deprecation_warning (1 test)

Full suite: 1284 passed, 4 deselected
```

## Checklist

### Code Quality
- [x] Code follows the project's style guidelines (Black, line length 120)
- [x] Imports sorted with isort (black profile)
- [x] Type hints added for new code
- [x] No linting errors

### Testing & Validation
- [x] All tests pass (`pytest tests/unit/`)
- [x] New functionality has test coverage
- [x] Test results included above

### Documentation & Compatibility
- [x] Backward compatibility maintained (if applicable) - filters still work, just also emit instructions now

### Performance
- [x] Performance impact considered
- [x] No significant performance regressions

## Additional Notes

- Filter instructions format: "When querying TABLE, apply: EXPR (description) unless the user explicitly requests unfiltered data."
- Config-gated: users who have already migrated to custom_instructions can set `generation.filters_to_instructions: false`
- sst-jaffle-shop now has `snowflake_semantic_models/filters/filters.yml` with two example filters for e2e testing

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)
