### PR TITLE
[SST-140] Feature: Support PRIVATE/PUBLIC visibility on facts and metrics

### DIFF
--- a/snowflake_semantic_tools/core/generation/semantic_view_builder.py
+++ b/snowflake_semantic_tools/core/generation/semantic_view_builder.py
@@ -952,7 +952,11 @@ class SemanticViewBuilder:
             fact_name = fact["NAME"].upper()
             expression = fact["EXPR"]
 
-            fact_def = f"    {table_name}.{fact_name} AS {expression}"
+            visibility_prefix = ""
+            if fact.get("VISIBILITY") and fact["VISIBILITY"].upper() == "PRIVATE":
+                visibility_prefix = "PRIVATE "
+
+            fact_def = f"    {visibility_prefix}{table_name}.{fact_name} AS {expression}"
 
             # Add comment if available
             if fact.get("DESCRIPTION"):
@@ -1101,7 +1105,11 @@ class SemanticViewBuilder:
             if not primary_table:
                 primary_table = table_names[0].upper()  # Fallback to first table
 
-            metric_def = f"    {primary_table}.{metric_name} AS {expression}"
+            visibility_prefix = ""
+            if metric.get("VISIBILITY") and metric["VISIBILITY"].upper() == "PRIVATE":
+                visibility_prefix = "PRIVATE "
+
+            metric_def = f"    {visibility_prefix}{primary_table}.{metric_name} AS {expression}"
 
             # Add comment if available
             if metric.get("DESCRIPTION"):

--- a/snowflake_semantic_tools/core/models/schemas.py
+++ b/snowflake_semantic_tools/core/models/schemas.py
@@ -212,6 +212,11 @@ class SemanticTableSchemas:
                     description="Alternative terms users might use (e.g., 'revenue' vs 'sales amount')",
                 ),
                 Column("sample_values", ColumnType.ARRAY, description="Example numeric values for reference"),
+                Column(
+                    "visibility",
+                    ColumnType.VARCHAR,
+                    description="Visibility control: 'private' hides from end users, 'public' (default) is queryable",
+                ),
             ],
         )
 
@@ -261,6 +266,11 @@ class SemanticTableSchemas:
                     description="Alternative terms users might use (e.g., 'total revenue' vs 'gross sales')",
                 ),
                 Column("sample_values", ColumnType.ARRAY, description="Example calculated values for reference"),
+                Column(
+                    "visibility",
+                    ColumnType.VARCHAR,
+                    description="Visibility control: 'private' hides from end users, 'public' (default) is queryable",
+                ),
             ],
         )
 

--- a/snowflake_semantic_tools/core/parsing/parsers/data_extractors.py
+++ b/snowflake_semantic_tools/core/parsing/parsers/data_extractors.py
@@ -305,6 +305,7 @@ def extract_column_info(column: Dict[str, Any], table_name: str, file_path: Path
             "synonyms": sst_meta.get("synonyms", []),
             "sample_values": sst_meta.get("sample_values", []),
             "is_enum": sst_meta.get("is_enum", False),
+            "visibility": sst_meta.get("visibility"),
             "source_file": str(file_path),  # Store the file path for validation errors
         }
 

--- a/snowflake_semantic_tools/core/validation/rules/dbt_models.py
+++ b/snowflake_semantic_tools/core/validation/rules/dbt_models.py
@@ -480,6 +480,22 @@ class DbtModelValidator:
                 context={"table": table_name, "column": column_name, "field": "description", "level": "column"},
             )
 
+        # Visibility validation: only facts and metrics can be private
+        visibility = column.get("visibility")
+        if visibility:
+            if visibility.lower() not in ("public", "private"):
+                result.add_error(
+                    f"Column '{column_name}' in table '{table_name}' has invalid visibility: '{visibility}'. Must be 'public' or 'private'",
+                    file_path=source_file,
+                    context={"table": table_name, "column": column_name, "field": "visibility", "level": "column"},
+                )
+            elif visibility.lower() == "private" and column_type in ("dimension", "time_dimension"):
+                result.add_error(
+                    f"Column '{column_name}' in table '{table_name}' cannot be PRIVATE: only facts and metrics support visibility control (Snowflake restriction)",
+                    file_path=source_file,
+                    context={"table": table_name, "column": column_name, "field": "visibility", "level": "column"},
+                )
+
     def _determine_column_type(self, column: Dict[str, Any]) -> str:
         """Get the column type from metadata (no longer defaults or infers)."""
         # Column type must be explicitly set now - no defaults

--- a/tests/unit/core/generation/test_semantic_view_builder.py
+++ b/tests/unit/core/generation/test_semantic_view_builder.py
@@ -958,5 +958,123 @@ class TestTableNotFoundErrorFormatting:
         assert "Original error:" in result
 
 
+class TestVisibility:
+    """Test cases for PRIVATE/PUBLIC visibility on facts and metrics."""
+
+    @pytest.fixture
+    def builder(self):
+        """Create a SemanticViewBuilder instance for testing."""
+        config = SnowflakeConfig(
+            account="test",
+            user="test",
+            password="test",
+            role="test",
+            warehouse="test",
+            database="test_db",
+            schema="test_schema",
+        )
+        return SemanticViewBuilder(config)
+
+    def test_private_fact_emits_keyword(self, builder, monkeypatch):
+        """Test that a private fact emits PRIVATE keyword in DDL."""
+
+        def mock_get_facts(conn, table_name):
+            return [
+                {
+                    "NAME": "raw_discount",
+                    "EXPR": "RAW_DISCOUNT",
+                    "DESCRIPTION": "Internal discount",
+                    "SYNONYMS": None,
+                    "VISIBILITY": "private",
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        monkeypatch.setattr(builder, "_get_facts", mock_get_facts)
+
+        result = builder._build_facts_clause(None, ["orders"])
+
+        assert "PRIVATE ORDERS.RAW_DISCOUNT AS RAW_DISCOUNT" in result
+
+    def test_public_fact_no_keyword(self, builder, monkeypatch):
+        """Test that a public fact does not emit visibility keyword."""
+
+        def mock_get_facts(conn, table_name):
+            return [
+                {
+                    "NAME": "amount",
+                    "EXPR": "AMOUNT",
+                    "DESCRIPTION": "Order amount",
+                    "SYNONYMS": None,
+                    "VISIBILITY": "public",
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        monkeypatch.setattr(builder, "_get_facts", mock_get_facts)
+
+        result = builder._build_facts_clause(None, ["orders"])
+
+        assert "PRIVATE" not in result
+        assert "PUBLIC" not in result
+        assert "ORDERS.AMOUNT AS AMOUNT" in result
+
+    def test_null_visibility_no_keyword(self, builder, monkeypatch):
+        """Test that null visibility does not emit any keyword."""
+
+        def mock_get_facts(conn, table_name):
+            return [
+                {
+                    "NAME": "quantity",
+                    "EXPR": "QUANTITY",
+                    "DESCRIPTION": "Quantity",
+                    "SYNONYMS": None,
+                    "VISIBILITY": None,
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        monkeypatch.setattr(builder, "_get_facts", mock_get_facts)
+
+        result = builder._build_facts_clause(None, ["orders"])
+
+        assert "PRIVATE" not in result
+        assert "ORDERS.QUANTITY AS QUANTITY" in result
+
+    def test_private_metric_emits_keyword(self, builder, monkeypatch):
+        """Test that a private metric emits PRIVATE keyword in DDL."""
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "INTERMEDIATE_SUM",
+                    "EXPR": "SUM(ORDERS.AMOUNT)",
+                    "DESCRIPTION": "Internal intermediate calc",
+                    "TABLE_NAME": '["orders"]',
+                    "SYNONYMS": None,
+                    "VISIBILITY": "private",
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        def mock_get_dims(conn, t):
+            return []
+
+        def mock_get_facts(conn, t):
+            return []
+
+        def mock_get_time_dims(conn, t):
+            return []
+
+        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
+        monkeypatch.setattr(builder, "_get_dimensions", mock_get_dims)
+        monkeypatch.setattr(builder, "_get_facts", mock_get_facts)
+        monkeypatch.setattr(builder, "_get_time_dimensions", mock_get_time_dims)
+
+        result = builder._build_metrics_clause(None, ["orders"])
+
+        assert "PRIVATE ORDERS.INTERMEDIATE_SUM AS SUM(ORDERS.AMOUNT)" in result
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/core/validation/test_dbt_model_validator.py
+++ b/tests/unit/core/validation/test_dbt_model_validator.py
@@ -223,3 +223,72 @@ class TestDbtModelValidator:
         assert error.context["column"] == "my_column"
         assert error.context["column_type"] == "invalid_type"
         assert error.context["level"] == "column"
+
+    def test_private_dimension_rejected(self):
+        """Test that a dimension with visibility: private produces an error."""
+        dbt_data = {
+            "sm_tables": [
+                {
+                    "table_name": "CUSTOMERS",
+                    "database": "ANALYTICS",
+                    "schema": "PUBLIC",
+                    "primary_key": ["customer_id"],
+                }
+            ],
+            "sm_dimensions": {
+                "items": [
+                    {
+                        "table_name": "CUSTOMERS",
+                        "name": "status",
+                        "column_type": "dimension",
+                        "data_type": "TEXT",
+                        "description": "Customer status",
+                        "visibility": "private",
+                    }
+                ]
+            },
+        }
+
+        result = self.validator.validate(dbt_data)
+
+        visibility_errors = [
+            issue
+            for issue in result.issues
+            if issue.severity == ValidationSeverity.ERROR and "PRIVATE" in issue.message
+        ]
+        assert len(visibility_errors) == 1
+        assert "only facts and metrics" in visibility_errors[0].message
+
+    def test_private_fact_accepted(self):
+        """Test that a fact with visibility: private does not produce an error."""
+        dbt_data = {
+            "sm_tables": [
+                {
+                    "table_name": "ORDERS",
+                    "database": "ANALYTICS",
+                    "schema": "PUBLIC",
+                    "primary_key": ["order_id"],
+                }
+            ],
+            "sm_facts": {
+                "items": [
+                    {
+                        "table_name": "ORDERS",
+                        "name": "raw_discount",
+                        "column_type": "fact",
+                        "data_type": "NUMBER",
+                        "description": "Internal discount amount",
+                        "visibility": "private",
+                    }
+                ]
+            },
+        }
+
+        result = self.validator.validate(dbt_data)
+
+        visibility_errors = [
+            issue
+            for issue in result.issues
+            if issue.severity == ValidationSeverity.ERROR and "visibility" in issue.message.lower()
+        ]
+        assert len(visibility_errors) == 0


### PR DESCRIPTION
## Description

Adds visibility control so facts and metrics can be marked `PRIVATE` (hidden from end users, cannot be queried directly) or `PUBLIC` (default, queryable). This is essential for intermediate calculations that compose into other metrics but should not be exposed to Cortex Analyst or BI tools.

## Related Issue

Closes #140

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test improvements
- [ ] Other (please describe):

## Changes Made

- Added `visibility` field extraction in `data_extractors.py` (`extract_column_info()`)
- Added `VISIBILITY` column to SM_FACTS and SM_METRICS schemas in `schemas.py`
- Builder prepends `PRIVATE` keyword in `_build_facts_clause()` and `_build_metrics_clause()`
- Validation rejects `visibility: private` on dimensions/time_dimensions (Snowflake restriction)

## Testing

- [x] Unit tests pass (`pytest tests/unit/`)
- [x] All existing tests pass
- [x] New tests added for new functionality
- [ ] Tested locally with Python 3.9-3.11
- [ ] Manual testing completed (if applicable)
- [x] Test coverage maintained or improved (target: >90%)

### Test Results

```
6 new tests:
- TestVisibility (4 tests): private fact, public fact, null visibility, private metric
- TestDbtModelValidator (2 tests): private dimension rejected, private fact accepted

Full suite: 1283 passed, 4 deselected
```

## Checklist

### Code Quality
- [x] Code follows the project's style guidelines (Black, line length 120)
- [x] Imports sorted with isort (black profile)
- [x] Type hints added for new code
- [x] No linting errors

### Testing & Validation
- [x] All tests pass (`pytest tests/unit/`)
- [x] New functionality has test coverage
- [x] Test results included above

### Documentation & Compatibility
- [x] Backward compatibility maintained - field is optional, defaults to public (no change to existing behavior)

### Performance
- [x] Performance impact considered
- [x] No significant performance regressions

## Additional Notes

- Only `private` emits the keyword; `public` or absent = no keyword (Snowflake defaults to PUBLIC)
- Snowflake restriction: dimensions/time_dimensions cannot be PRIVATE — validation enforces this

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)
