### PR TITLE
[SST-138] Feature: Support NON ADDITIVE BY for semi-additive metrics

### DIFF
--- a/snowflake_semantic_tools/core/generation/semantic_view_builder.py
+++ b/snowflake_semantic_tools/core/generation/semantic_view_builder.py
@@ -1101,7 +1101,27 @@ class SemanticViewBuilder:
             if not primary_table:
                 primary_table = table_names[0].upper()  # Fallback to first table
 
-            metric_def = f"    {primary_table}.{metric_name} AS {expression}"
+            metric_def = f"    {primary_table}.{metric_name}"
+
+            # Add NON ADDITIVE BY clause for semi-additive metrics
+            non_additive_by = self._parse_json_field(metric.get("NON_ADDITIVE_BY"), "non_additive_by")
+            if non_additive_by and isinstance(non_additive_by, list):
+                nab_parts = []
+                for entry in non_additive_by:
+                    if isinstance(entry, dict):
+                        dim = entry.get("dimension", "").upper()
+                        order = entry.get("order", "").upper()
+                        nulls = entry.get("nulls", "").upper()
+                        part = dim
+                        if order:
+                            part += f" {order}"
+                        if nulls:
+                            part += f" NULLS {nulls}"
+                        nab_parts.append(part)
+                if nab_parts:
+                    metric_def += f"\n      NON ADDITIVE BY ({', '.join(nab_parts)})"
+
+            metric_def += f" AS {expression}"
 
             # Add comment if available
             if metric.get("DESCRIPTION"):

--- a/snowflake_semantic_tools/core/generation/semantic_view_builder.py
+++ b/snowflake_semantic_tools/core/generation/semantic_view_builder.py
@@ -1110,6 +1110,8 @@ class SemanticViewBuilder:
                 for entry in non_additive_by:
                     if isinstance(entry, dict):
                         dim = entry.get("dimension", "").upper()
+                        if not dim:
+                            continue
                         order = entry.get("order", "").upper()
                         nulls = entry.get("nulls", "").upper()
                         part = dim

--- a/snowflake_semantic_tools/core/models/schemas.py
+++ b/snowflake_semantic_tools/core/models/schemas.py
@@ -261,6 +261,11 @@ class SemanticTableSchemas:
                     description="Alternative terms users might use (e.g., 'total revenue' vs 'gross sales')",
                 ),
                 Column("sample_values", ColumnType.ARRAY, description="Example calculated values for reference"),
+                Column(
+                    "non_additive_by",
+                    ColumnType.ARRAY,
+                    description="Semi-additive dimensions: list of {dimension, order, nulls} for NON ADDITIVE BY clause",
+                ),
             ],
         )
 

--- a/snowflake_semantic_tools/core/parsing/parsers/semantic_parser.py
+++ b/snowflake_semantic_tools/core/parsing/parsers/semantic_parser.py
@@ -133,6 +133,7 @@ def parse_snowflake_metrics(metrics: List[Dict[str, Any]], file_path: Path) -> L
                 "expr": metric.get("expr", ""),
                 "synonyms": metric.get("synonyms", []),
                 "sample_values": metric.get("sample_values", []),
+                "non_additive_by": metric.get("non_additive_by", []),
                 "source_file": str(file_path),  # Store the file path for validation errors
             }
             metric_records.append(metric_record)

--- a/tests/unit/core/generation/test_semantic_view_builder.py
+++ b/tests/unit/core/generation/test_semantic_view_builder.py
@@ -958,5 +958,110 @@ class TestTableNotFoundErrorFormatting:
         assert "Original error:" in result
 
 
+class TestNonAdditiveBy:
+    """Test cases for NON ADDITIVE BY clause on metrics."""
+
+    @pytest.fixture
+    def builder(self):
+        """Create a SemanticViewBuilder instance for testing."""
+        config = SnowflakeConfig(
+            account="test",
+            user="test",
+            password="test",
+            role="test",
+            warehouse="test",
+            database="test_db",
+            schema="test_schema",
+        )
+        return SemanticViewBuilder(config)
+
+    def test_non_additive_by_emitted(self, builder, monkeypatch):
+        """Test that NON ADDITIVE BY clause is emitted for semi-additive metrics."""
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "CURRENT_BALANCE",
+                    "EXPR": "BALANCE",
+                    "DESCRIPTION": "Account balance",
+                    "TABLE_NAME": '["accounts"]',
+                    "SYNONYMS": None,
+                    "NON_ADDITIVE_BY": '[{"dimension": "snapshot_date", "order": "DESC", "nulls": "LAST"}]',
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        def mock_noop(conn, t):
+            return []
+
+        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
+        monkeypatch.setattr(builder, "_get_dimensions", mock_noop)
+        monkeypatch.setattr(builder, "_get_facts", mock_noop)
+        monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
+
+        result = builder._build_metrics_clause(None, ["accounts"])
+
+        assert "NON ADDITIVE BY (SNAPSHOT_DATE DESC NULLS LAST)" in result
+        assert "AS BALANCE" in result
+
+    def test_non_additive_by_without_nulls(self, builder, monkeypatch):
+        """Test NON ADDITIVE BY with only dimension and order."""
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "HEADCOUNT",
+                    "EXPR": "HEAD_COUNT",
+                    "DESCRIPTION": "Headcount",
+                    "TABLE_NAME": '["hr_snapshots"]',
+                    "SYNONYMS": None,
+                    "NON_ADDITIVE_BY": '[{"dimension": "snapshot_date", "order": "DESC"}]',
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        def mock_noop(conn, t):
+            return []
+
+        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
+        monkeypatch.setattr(builder, "_get_dimensions", mock_noop)
+        monkeypatch.setattr(builder, "_get_facts", mock_noop)
+        monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
+
+        result = builder._build_metrics_clause(None, ["hr_snapshots"])
+
+        assert "NON ADDITIVE BY (SNAPSHOT_DATE DESC)" in result
+        assert "NULLS" not in result
+
+    def test_no_non_additive_by(self, builder, monkeypatch):
+        """Test that metrics without non_additive_by don't emit the clause."""
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "TOTAL_REVENUE",
+                    "EXPR": "SUM(ORDERS.AMOUNT)",
+                    "DESCRIPTION": "Total revenue",
+                    "TABLE_NAME": '["orders"]',
+                    "SYNONYMS": None,
+                    "NON_ADDITIVE_BY": None,
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        def mock_noop(conn, t):
+            return []
+
+        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
+        monkeypatch.setattr(builder, "_get_dimensions", mock_noop)
+        monkeypatch.setattr(builder, "_get_facts", mock_noop)
+        monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
+
+        result = builder._build_metrics_clause(None, ["orders"])
+
+        assert "NON ADDITIVE BY" not in result
+        assert "ORDERS.TOTAL_REVENUE AS SUM(ORDERS.AMOUNT)" in result
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/core/generation/test_semantic_view_builder.py
+++ b/tests/unit/core/generation/test_semantic_view_builder.py
@@ -1003,6 +1003,9 @@ class TestNonAdditiveBy:
 
         assert "NON ADDITIVE BY (SNAPSHOT_DATE DESC NULLS LAST)" in result
         assert "AS BALANCE" in result
+        nab_pos = result.index("NON ADDITIVE BY")
+        as_pos = result.index("AS BALANCE")
+        assert nab_pos < as_pos, "NON ADDITIVE BY must come before AS"
 
     def test_non_additive_by_without_nulls(self, builder, monkeypatch):
         """Test NON ADDITIVE BY with only dimension and order."""
@@ -1061,6 +1064,62 @@ class TestNonAdditiveBy:
 
         assert "NON ADDITIVE BY" not in result
         assert "ORDERS.TOTAL_REVENUE AS SUM(ORDERS.AMOUNT)" in result
+
+    def test_non_additive_by_empty_list(self, builder, monkeypatch):
+        """Test that empty non_additive_by list doesn't emit clause."""
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "REVENUE",
+                    "EXPR": "SUM(ORDERS.AMOUNT)",
+                    "DESCRIPTION": "Revenue",
+                    "TABLE_NAME": '["orders"]',
+                    "SYNONYMS": None,
+                    "NON_ADDITIVE_BY": "[]",
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        def mock_noop(conn, t):
+            return []
+
+        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
+        monkeypatch.setattr(builder, "_get_dimensions", mock_noop)
+        monkeypatch.setattr(builder, "_get_facts", mock_noop)
+        monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
+
+        result = builder._build_metrics_clause(None, ["orders"])
+
+        assert "NON ADDITIVE BY" not in result
+
+    def test_non_additive_by_missing_dimension(self, builder, monkeypatch):
+        """Test that entries with missing dimension field are skipped."""
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "BAD_METRIC",
+                    "EXPR": "SUM(ORDERS.AMOUNT)",
+                    "DESCRIPTION": "Bad",
+                    "TABLE_NAME": '["orders"]',
+                    "SYNONYMS": None,
+                    "NON_ADDITIVE_BY": '[{"order": "DESC"}]',
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        def mock_noop(conn, t):
+            return []
+
+        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
+        monkeypatch.setattr(builder, "_get_dimensions", mock_noop)
+        monkeypatch.setattr(builder, "_get_facts", mock_noop)
+        monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
+
+        result = builder._build_metrics_clause(None, ["orders"])
+
+        assert "NON ADDITIVE BY" not in result
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Adds `non_additive_by` field to metric definitions for semi-additive measures (balances, headcount, inventory) that cannot be meaningfully summed across time. The builder emits `NON ADDITIVE BY (dimension ORDER NULLS)` in the METRICS DDL clause.

## Related Issue

Closes #138

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test improvements
- [ ] Other (please describe):

## Changes Made

- Added `non_additive_by` field to metric parsing in `semantic_parser.py`
- Added `NON_ADDITIVE_BY` column to SM_METRICS schema in `schemas.py`
- Builder emits `NON ADDITIVE BY (dim ORDER NULLS)` clause between metric name and AS expression
- Supports multiple dimensions, optional order (ASC/DESC), optional nulls (FIRST/LAST)

## Testing

- [x] Unit tests pass (`pytest tests/unit/`)
- [x] All existing tests pass
- [x] New tests added for new functionality
- [ ] Tested locally with Python 3.9-3.11
- [ ] Manual testing completed (if applicable)
- [x] Test coverage maintained or improved (target: >90%)

### Test Results

```
3 new tests in TestNonAdditiveBy:
- test_non_additive_by_emitted (full clause with DESC NULLS LAST)
- test_non_additive_by_without_nulls (dimension + order only)
- test_no_non_additive_by (absent = no clause)

Full suite: 1280 passed, 4 deselected
```

## Checklist

### Code Quality
- [x] Code follows the project's style guidelines (Black, line length 120)
- [x] Imports sorted with isort (black profile)
- [x] Type hints added for new code
- [x] No linting errors

### Testing & Validation
- [x] All tests pass (`pytest tests/unit/`)
- [x] New functionality has test coverage
- [x] Test results included above

### Documentation & Compatibility
- [x] Backward compatibility maintained - field is optional

### Performance
- [x] Performance impact considered
- [x] No significant performance regressions

## Additional Notes

YAML syntax:
```yaml
snowflake_metrics:
  - name: current_balance
    non_additive_by:
      - dimension: snapshot_date
        order: DESC
        nulls: LAST
```

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)
