### PR TITLE
[SST-141] Feature: Support USING (relationship_name) on metrics

### DIFF
--- a/snowflake_semantic_tools/core/generation/semantic_view_builder.py
+++ b/snowflake_semantic_tools/core/generation/semantic_view_builder.py
@@ -1101,7 +1101,16 @@ class SemanticViewBuilder:
             if not primary_table:
                 primary_table = table_names[0].upper()  # Fallback to first table
 
-            metric_def = f"    {primary_table}.{metric_name} AS {expression}"
+            metric_def = f"    {primary_table}.{metric_name}"
+
+            # Add USING clause for relationship path disambiguation
+            using_rels = self._parse_json_field(metric.get("USING_RELATIONSHIPS"), "using_relationships")
+            if using_rels and isinstance(using_rels, list):
+                rel_names = [str(r).upper() for r in using_rels if r]
+                if rel_names:
+                    metric_def += f"\n      USING ({', '.join(rel_names)})"
+
+            metric_def += f" AS {expression}"
 
             # Add comment if available
             if metric.get("DESCRIPTION"):

--- a/snowflake_semantic_tools/core/models/schemas.py
+++ b/snowflake_semantic_tools/core/models/schemas.py
@@ -261,6 +261,11 @@ class SemanticTableSchemas:
                     description="Alternative terms users might use (e.g., 'total revenue' vs 'gross sales')",
                 ),
                 Column("sample_values", ColumnType.ARRAY, description="Example calculated values for reference"),
+                Column(
+                    "using_relationships",
+                    ColumnType.ARRAY,
+                    description="Relationship names to use for join path disambiguation (USING clause)",
+                ),
             ],
         )
 

--- a/snowflake_semantic_tools/core/parsing/parsers/semantic_parser.py
+++ b/snowflake_semantic_tools/core/parsing/parsers/semantic_parser.py
@@ -133,6 +133,7 @@ def parse_snowflake_metrics(metrics: List[Dict[str, Any]], file_path: Path) -> L
                 "expr": metric.get("expr", ""),
                 "synonyms": metric.get("synonyms", []),
                 "sample_values": metric.get("sample_values", []),
+                "using_relationships": metric.get("using_relationships", []),
                 "source_file": str(file_path),  # Store the file path for validation errors
             }
             metric_records.append(metric_record)

--- a/tests/unit/core/generation/test_semantic_view_builder.py
+++ b/tests/unit/core/generation/test_semantic_view_builder.py
@@ -1003,6 +1003,9 @@ class TestUsingRelationships:
 
         assert "USING (ORDERS_TO_SHIPPING_ADDRESS)" in result
         assert "AS SUM(ORDERS.AMOUNT)" in result
+        using_pos = result.index("USING")
+        as_pos = result.index("AS SUM")
+        assert using_pos < as_pos, "USING must come before AS"
 
     def test_using_multiple_relationships(self, builder, monkeypatch):
         """Test USING clause with multiple relationships."""
@@ -1044,6 +1047,34 @@ class TestUsingRelationships:
                     "TABLE_NAME": '["orders"]',
                     "SYNONYMS": None,
                     "USING_RELATIONSHIPS": None,
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        def mock_noop(conn, t):
+            return []
+
+        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
+        monkeypatch.setattr(builder, "_get_dimensions", mock_noop)
+        monkeypatch.setattr(builder, "_get_facts", mock_noop)
+        monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
+
+        result = builder._build_metrics_clause(None, ["orders"])
+
+        assert "USING" not in result
+
+    def test_using_relationships_empty_list(self, builder, monkeypatch):
+        """Test that empty using_relationships list doesn't emit USING."""
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "METRIC",
+                    "EXPR": "SUM(ORDERS.AMOUNT)",
+                    "DESCRIPTION": "Metric",
+                    "TABLE_NAME": '["orders"]',
+                    "SYNONYMS": None,
+                    "USING_RELATIONSHIPS": "[]",
                     "SAMPLE_VALUES": None,
                 }
             ]

--- a/tests/unit/core/generation/test_semantic_view_builder.py
+++ b/tests/unit/core/generation/test_semantic_view_builder.py
@@ -958,5 +958,108 @@ class TestTableNotFoundErrorFormatting:
         assert "Original error:" in result
 
 
+class TestUsingRelationships:
+    """Test cases for USING (relationship_name) on metrics."""
+
+    @pytest.fixture
+    def builder(self):
+        """Create a SemanticViewBuilder instance for testing."""
+        config = SnowflakeConfig(
+            account="test",
+            user="test",
+            password="test",
+            role="test",
+            warehouse="test",
+            database="test_db",
+            schema="test_schema",
+        )
+        return SemanticViewBuilder(config)
+
+    def test_using_single_relationship(self, builder, monkeypatch):
+        """Test USING clause with a single relationship."""
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "REVENUE_BY_SHIPPING",
+                    "EXPR": "SUM(ORDERS.AMOUNT)",
+                    "DESCRIPTION": "Revenue by shipping",
+                    "TABLE_NAME": '["orders"]',
+                    "SYNONYMS": None,
+                    "USING_RELATIONSHIPS": '["orders_to_shipping_address"]',
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        def mock_noop(conn, t):
+            return []
+
+        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
+        monkeypatch.setattr(builder, "_get_dimensions", mock_noop)
+        monkeypatch.setattr(builder, "_get_facts", mock_noop)
+        monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
+
+        result = builder._build_metrics_clause(None, ["orders"])
+
+        assert "USING (ORDERS_TO_SHIPPING_ADDRESS)" in result
+        assert "AS SUM(ORDERS.AMOUNT)" in result
+
+    def test_using_multiple_relationships(self, builder, monkeypatch):
+        """Test USING clause with multiple relationships."""
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "COMPLEX_METRIC",
+                    "EXPR": "COUNT(*)",
+                    "DESCRIPTION": "Complex",
+                    "TABLE_NAME": '["orders"]',
+                    "SYNONYMS": None,
+                    "USING_RELATIONSHIPS": '["rel_a", "rel_b"]',
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        def mock_noop(conn, t):
+            return []
+
+        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
+        monkeypatch.setattr(builder, "_get_dimensions", mock_noop)
+        monkeypatch.setattr(builder, "_get_facts", mock_noop)
+        monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
+
+        result = builder._build_metrics_clause(None, ["orders"])
+
+        assert "USING (REL_A, REL_B)" in result
+
+    def test_no_using_relationships(self, builder, monkeypatch):
+        """Test that metrics without using_relationships don't emit USING."""
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "TOTAL_REVENUE",
+                    "EXPR": "SUM(ORDERS.AMOUNT)",
+                    "DESCRIPTION": "Total revenue",
+                    "TABLE_NAME": '["orders"]',
+                    "SYNONYMS": None,
+                    "USING_RELATIONSHIPS": None,
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        def mock_noop(conn, t):
+            return []
+
+        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
+        monkeypatch.setattr(builder, "_get_dimensions", mock_noop)
+        monkeypatch.setattr(builder, "_get_facts", mock_noop)
+        monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
+
+        result = builder._build_metrics_clause(None, ["orders"])
+
+        assert "USING" not in result
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Description

Adds `using_relationships` field to metric definitions for join path disambiguation. When a semantic view has multiple relationship paths between two tables, Snowflake requires metrics to specify which path to use via `USING (relationship_name)`.

## Related Issue

Closes #141

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test improvements
- [ ] Other (please describe):

## Changes Made

- Added `using_relationships` field to metric parsing in `semantic_parser.py`
- Added `USING_RELATIONSHIPS` column to SM_METRICS schema in `schemas.py`
- Builder emits `USING (REL_NAME)` clause between metric name and AS expression

## Testing

- [x] Unit tests pass (`pytest tests/unit/`)
- [x] All existing tests pass
- [x] New tests added for new functionality
- [ ] Tested locally with Python 3.9-3.11
- [ ] Manual testing completed (if applicable)
- [x] Test coverage maintained or improved (target: >90%)

### Test Results

```
3 new tests in TestUsingRelationships:
- test_using_single_relationship
- test_using_multiple_relationships
- test_no_using_relationships (absent = no clause)

Full suite: 1280 passed, 4 deselected
```

## Checklist

### Code Quality
- [x] Code follows the project's style guidelines (Black, line length 120)
- [x] Imports sorted with isort (black profile)
- [x] Type hints added for new code
- [x] No linting errors

### Testing & Validation
- [x] All tests pass (`pytest tests/unit/`)
- [x] New functionality has test coverage
- [x] Test results included above

### Documentation & Compatibility
- [x] Backward compatibility maintained - field is optional

### Performance
- [x] Performance impact considered
- [x] No significant performance regressions

## Additional Notes

Note: This is a Snowflake preview feature but the syntax is simple and stable. Common use case: tables with multiple FK references to the same dimension (e.g., billing_address vs shipping_address).

YAML syntax:
```yaml
snowflake_metrics:
  - name: revenue_by_shipping_state
    using_relationships:
      - orders_to_shipping_address
```

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)
