### PR TITLE
[SST-144] Feature: Support CONSTRAINT DISTINCT RANGE on tables

### DIFF
--- a/snowflake_semantic_tools/core/generation/semantic_view_builder.py
+++ b/snowflake_semantic_tools/core/generation/semantic_view_builder.py
@@ -886,6 +886,17 @@ class SemanticViewBuilder:
                                 f"\n      CONSTRAINT {c_name} DISTINCT RANGE"
                                 f"\n          BETWEEN {start_col} AND {end_col} EXCLUSIVE"
                             )
+                        else:
+                            missing = [f for f in ["name", "start_column", "end_column"] if not constraint.get(f)]
+                            logger.warning(
+                                f"Table '{table_name}' has a distinct_range constraint with missing fields: "
+                                f"{', '.join(missing)}. Constraint will be skipped."
+                            )
+                    elif isinstance(constraint, dict):
+                        logger.warning(
+                            f"Table '{table_name}' has unrecognized constraint type: "
+                            f"'{constraint.get('type', 'unknown')}'. Only 'distinct_range' is supported."
+                        )
 
             # Add synonyms if available
             if table_info.get("SYNONYMS"):

--- a/snowflake_semantic_tools/core/generation/semantic_view_builder.py
+++ b/snowflake_semantic_tools/core/generation/semantic_view_builder.py
@@ -873,6 +873,20 @@ class SemanticViewBuilder:
                     uk_cols = ", ".join([col.upper() for col in unique_key_cols])
                     table_def += f"\n      UNIQUE ({uk_cols})"
 
+            # Add CONSTRAINT DISTINCT RANGE if available (preview feature)
+            constraints = self._parse_json_field(table_info.get("CONSTRAINTS"), "constraints")
+            if constraints and isinstance(constraints, list):
+                for constraint in constraints:
+                    if isinstance(constraint, dict) and constraint.get("type") == "distinct_range":
+                        c_name = constraint.get("name", "").upper()
+                        start_col = constraint.get("start_column", "").upper()
+                        end_col = constraint.get("end_column", "").upper()
+                        if c_name and start_col and end_col:
+                            table_def += (
+                                f"\n      CONSTRAINT {c_name} DISTINCT RANGE"
+                                f"\n          BETWEEN {start_col} AND {end_col} EXCLUSIVE"
+                            )
+
             # Add synonyms if available
             if table_info.get("SYNONYMS"):
                 synonyms = self._parse_json_field(table_info["SYNONYMS"], "synonyms")

--- a/snowflake_semantic_tools/core/models/schemas.py
+++ b/snowflake_semantic_tools/core/models/schemas.py
@@ -122,6 +122,11 @@ class SemanticTableSchemas:
                     ColumnType.BOOLEAN,
                     description="Whether to include this table in Cortex Analyst queries",
                 ),
+                Column(
+                    "constraints",
+                    ColumnType.ARRAY,
+                    description="Table constraints (e.g., DISTINCT RANGE for range joins). Preview feature.",
+                ),
             ],
         )
 

--- a/snowflake_semantic_tools/core/parsing/parsers/data_extractors.py
+++ b/snowflake_semantic_tools/core/parsing/parsers/data_extractors.py
@@ -177,6 +177,7 @@ def extract_table_info(
             "description": description,
             "primary_key": primary_keys_upper,
             "unique_keys": unique_keys_upper,
+            "constraints": sst_meta.get("constraints", []),
             "synonyms": sst_meta.get("synonyms", []),
             "model_name": name,  # Store the original model name
             "source_file": str(file_path),  # Store the file path for validation errors

--- a/tests/unit/core/generation/test_semantic_view_builder.py
+++ b/tests/unit/core/generation/test_semantic_view_builder.py
@@ -1019,6 +1019,54 @@ class TestConstraintDistinctRange:
         assert "CONSTRAINT" not in result
         assert "DISTINCT RANGE" not in result
 
+    def test_constraint_missing_fields_warns(self, builder, monkeypatch, caplog):
+        """Test that missing constraint fields log a warning and skip."""
+        import logging
+
+        def mock_get_table_info(conn, table_name):
+            return {
+                "TABLE_NAME": "RATES",
+                "DATABASE": "TEST_DB",
+                "SCHEMA": "TEST_SCHEMA",
+                "PRIMARY_KEY": '["rate_id"]',
+                "UNIQUE_KEYS": None,
+                "CONSTRAINTS": '[{"type": "distinct_range", "name": "", "start_column": "start_date", "end_column": "end_date"}]',
+                "DESCRIPTION": "Rates",
+                "SYNONYMS": None,
+            }
+
+        monkeypatch.setattr(builder, "_get_table_info", mock_get_table_info)
+
+        with caplog.at_level(logging.WARNING):
+            result = builder._build_tables_clause(None, ["rates"])
+
+        assert "CONSTRAINT" not in result
+        assert "missing fields" in caplog.text
+
+    def test_constraint_unrecognized_type_warns(self, builder, monkeypatch, caplog):
+        """Test that unrecognized constraint type logs a warning."""
+        import logging
+
+        def mock_get_table_info(conn, table_name):
+            return {
+                "TABLE_NAME": "ORDERS",
+                "DATABASE": "TEST_DB",
+                "SCHEMA": "TEST_SCHEMA",
+                "PRIMARY_KEY": '["order_id"]',
+                "UNIQUE_KEYS": None,
+                "CONSTRAINTS": '[{"type": "unknown_type", "name": "foo"}]',
+                "DESCRIPTION": "Orders",
+                "SYNONYMS": None,
+            }
+
+        monkeypatch.setattr(builder, "_get_table_info", mock_get_table_info)
+
+        with caplog.at_level(logging.WARNING):
+            result = builder._build_tables_clause(None, ["orders"])
+
+        assert "CONSTRAINT" not in result
+        assert "unrecognized constraint type" in caplog.text
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/core/generation/test_semantic_view_builder.py
+++ b/tests/unit/core/generation/test_semantic_view_builder.py
@@ -958,5 +958,67 @@ class TestTableNotFoundErrorFormatting:
         assert "Original error:" in result
 
 
+class TestConstraintDistinctRange:
+    """Test cases for CONSTRAINT DISTINCT RANGE on tables."""
+
+    @pytest.fixture
+    def builder(self):
+        """Create a SemanticViewBuilder instance for testing."""
+        config = SnowflakeConfig(
+            account="test",
+            user="test",
+            password="test",
+            role="test",
+            warehouse="test",
+            database="test_db",
+            schema="test_schema",
+        )
+        return SemanticViewBuilder(config)
+
+    def test_constraint_emitted(self, builder, monkeypatch):
+        """Test that CONSTRAINT DISTINCT RANGE is emitted in table DDL."""
+
+        def mock_get_table_info(conn, table_name):
+            return {
+                "TABLE_NAME": "RATE_PERIODS",
+                "DATABASE": "TEST_DB",
+                "SCHEMA": "TEST_SCHEMA",
+                "PRIMARY_KEY": '["rate_id"]',
+                "UNIQUE_KEYS": None,
+                "CONSTRAINTS": '[{"type": "distinct_range", "name": "rate_date_range", "start_column": "effective_start", "end_column": "effective_end"}]',
+                "DESCRIPTION": "Rate periods",
+                "SYNONYMS": None,
+            }
+
+        monkeypatch.setattr(builder, "_get_table_info", mock_get_table_info)
+
+        result = builder._build_tables_clause(None, ["rate_periods"])
+
+        assert "CONSTRAINT RATE_DATE_RANGE DISTINCT RANGE" in result
+        assert "BETWEEN EFFECTIVE_START AND EFFECTIVE_END EXCLUSIVE" in result
+
+    def test_no_constraint_when_absent(self, builder, monkeypatch):
+        """Test that no CONSTRAINT clause when constraints not defined."""
+
+        def mock_get_table_info(conn, table_name):
+            return {
+                "TABLE_NAME": "ORDERS",
+                "DATABASE": "TEST_DB",
+                "SCHEMA": "TEST_SCHEMA",
+                "PRIMARY_KEY": '["order_id"]',
+                "UNIQUE_KEYS": None,
+                "CONSTRAINTS": None,
+                "DESCRIPTION": "Orders",
+                "SYNONYMS": None,
+            }
+
+        monkeypatch.setattr(builder, "_get_table_info", mock_get_table_info)
+
+        result = builder._build_tables_clause(None, ["orders"])
+
+        assert "CONSTRAINT" not in result
+        assert "DISTINCT RANGE" not in result
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Description

Adds `constraints` field to table-level `config.meta.sst` for declaring non-overlapping ranges via `CONSTRAINT name DISTINCT RANGE BETWEEN start AND end EXCLUSIVE`. This is a prerequisite for range join relationships (#142).

**Note**: This is currently a Snowflake Preview Feature (Open).

## Related Issue

Closes #144

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test improvements
- [ ] Other (please describe):

## Changes Made

- Added `constraints` extraction in `data_extractors.py` (`extract_table_info()`)
- Added `CONSTRAINTS` column to SM_TABLES schema in `schemas.py`
- Builder emits `CONSTRAINT name DISTINCT RANGE BETWEEN start AND end EXCLUSIVE` after UNIQUE in table definitions

## Testing

- [x] Unit tests pass (`pytest tests/unit/`)
- [x] All existing tests pass
- [x] New tests added for new functionality
- [ ] Tested locally with Python 3.9-3.11
- [ ] Manual testing completed (if applicable)
- [x] Test coverage maintained or improved (target: >90%)

### Test Results

```
2 new tests in TestConstraintDistinctRange:
- test_constraint_emitted (full CONSTRAINT clause)
- test_no_constraint_when_absent

Full suite: 1279 passed, 4 deselected
```

## Checklist

### Code Quality
- [x] Code follows the project's style guidelines (Black, line length 120)
- [x] Imports sorted with isort (black profile)
- [x] Type hints added for new code
- [x] No linting errors

### Testing & Validation
- [x] All tests pass (`pytest tests/unit/`)
- [x] New functionality has test coverage
- [x] Test results included above

### Documentation & Compatibility
- [x] Backward compatibility maintained - field is optional

### Performance
- [x] Performance impact considered
- [x] No significant performance regressions

## Additional Notes

YAML syntax:
```yaml
config:
  meta:
    sst:
      primary_key: rate_id
      constraints:
        - type: distinct_range
          name: rate_effective_range
          start_column: effective_start_date
          end_column: effective_end_date
```

Generated DDL:
```sql
RATE_PERIODS AS DB.SCHEMA.RATE_PERIODS
    PRIMARY KEY (RATE_ID)
    CONSTRAINT RATE_EFFECTIVE_RANGE DISTINCT RANGE
        BETWEEN EFFECTIVE_START_DATE AND EFFECTIVE_END_DATE EXCLUSIVE
```

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)
