### PR TITLE
[SST-142] Feature: Support BETWEEN...AND...EXCLUSIVE in relationships (range joins)

### DIFF
--- a/snowflake_semantic_tools/core/parsing/join_condition_parser.py
+++ b/snowflake_semantic_tools/core/parsing/join_condition_parser.py
@@ -254,6 +254,10 @@ class JoinConditionParser:
             if parsed.operator == "BETWEEN":
                 if not parsed.right_column_end:
                     return False, (f"BETWEEN condition must include AND <end_column> EXCLUSIVE: {condition}")
+                if not parsed.left_table or not parsed.left_column:
+                    return False, f"Could not extract left table/column from: {parsed.left_expression}"
+                if not parsed.right_table or not parsed.right_column:
+                    return False, f"Could not extract right table/column from: {parsed.right_expression}"
                 return True, ""
 
             # Check for unknown join type
@@ -307,7 +311,15 @@ class JoinConditionParser:
         has_range = any(c.condition_type == JoinType.RANGE for c in parsed_conditions)
 
         if has_range:
-            # Range join: left_table (col) REFERENCES right_table (BETWEEN start AND end EXCLUSIVE)
+            non_range = [c for c in parsed_conditions if c.condition_type != JoinType.RANGE]
+            if non_range:
+                from snowflake_semantic_tools.shared import get_logger
+
+                _logger = get_logger("core.parsing.join_condition_parser")
+                _logger.warning(
+                    f"Range join has {len(non_range)} non-range condition(s) that will be ignored. "
+                    f"Snowflake range joins only support a single BETWEEN condition per relationship."
+                )
             range_cond = next(c for c in parsed_conditions if c.condition_type == JoinType.RANGE)
             sql = (
                 f"{left_table_alias} ({range_cond.left_column}) REFERENCES "

--- a/snowflake_semantic_tools/core/parsing/join_condition_parser.py
+++ b/snowflake_semantic_tools/core/parsing/join_condition_parser.py
@@ -41,7 +41,8 @@ class ParsedCondition:
     left_column: str  # Extracted column name from left
     right_table: str  # Extracted table name from right
     right_column: str  # Extracted column name from right
-    operator: str  # = (equality) or >= (ASOF). Note: BETWEEN, <=, >, < are rejected
+    operator: str  # = (equality), >= (ASOF), or BETWEEN (range)
+    right_column_end: str = ""  # End column for BETWEEN...AND...EXCLUSIVE range joins
 
 
 class JoinConditionParser:
@@ -102,6 +103,15 @@ class JoinConditionParser:
             left_table, left_column = cls._extract_table_column_from_resolved(left_expr)
             right_table, right_column = cls._extract_table_column_from_resolved(right_expr)
 
+        # For BETWEEN range joins, extract the end column
+        right_column_end = ""
+        if operator == "BETWEEN":
+            end_expr, _ = cls._extract_range_end(condition)
+            if is_template_format:
+                _, right_column_end = cls._extract_table_column_from_template(end_expr)
+            else:
+                _, right_column_end = cls._extract_table_column_from_resolved(end_expr)
+
         return ParsedCondition(
             join_condition=condition,
             condition_type=condition_type,
@@ -112,6 +122,7 @@ class JoinConditionParser:
             right_table=right_table,
             right_column=right_column,
             operator=operator,
+            right_column_end=right_column_end,
         )
 
     @classmethod
@@ -155,7 +166,7 @@ class JoinConditionParser:
     def _split_on_operator(cls, condition: str, operator: str) -> Tuple[str, str]:
         """Split condition on operator, handling special cases."""
         if operator == "BETWEEN":
-            # Handle BETWEEN x AND y
+            # Handle BETWEEN x AND y [EXCLUSIVE]
             parts = re.split(r"\s+BETWEEN\s+|\s+AND\s+", condition, flags=re.IGNORECASE)
             if len(parts) >= 2:
                 return parts[0], parts[1]  # Return first two parts
@@ -167,6 +178,15 @@ class JoinConditionParser:
 
         # Fallback
         return condition, ""
+
+    @classmethod
+    def _extract_range_end(cls, condition: str) -> Tuple[str, str]:
+        """Extract the end column from a BETWEEN...AND...EXCLUSIVE condition."""
+        parts = re.split(r"\s+BETWEEN\s+|\s+AND\s+", condition, flags=re.IGNORECASE)
+        if len(parts) >= 3:
+            end_expr = re.sub(r"\s+EXCLUSIVE\s*$", "", parts[2], flags=re.IGNORECASE).strip()
+            return end_expr, end_expr
+        return "", ""
 
     @classmethod
     def _extract_table_column_from_template(cls, expression: str) -> Tuple[str, str]:
@@ -230,13 +250,11 @@ class JoinConditionParser:
                     f"See: https://docs.snowflake.com/en/user-guide/views-semantic/sql"
                 )
 
-            # Reject BETWEEN operator - not supported in semantic view relationships
+            # BETWEEN operator is valid for range joins (preview feature)
             if parsed.operator == "BETWEEN":
-                return False, (
-                    f"BETWEEN operator is not supported in Snowflake semantic view relationships. "
-                    f"Only equality (=) and ASOF (>=) joins are supported. "
-                    f"See: https://docs.snowflake.com/en/user-guide/views-semantic/sql"
-                )
+                if not parsed.right_column_end:
+                    return False, (f"BETWEEN condition must include AND <end_column> EXCLUSIVE: {condition}")
+                return True, ""
 
             # Check for unknown join type
             if parsed.condition_type == JoinType.UNKNOWN:
@@ -284,6 +302,18 @@ class JoinConditionParser:
 
         # Build left column list (all conditions in original order)
         left_cols = [c.left_column for c in parsed_conditions]
+
+        # Check if any condition is a range join
+        has_range = any(c.condition_type == JoinType.RANGE for c in parsed_conditions)
+
+        if has_range:
+            # Range join: left_table (col) REFERENCES right_table (BETWEEN start AND end EXCLUSIVE)
+            range_cond = next(c for c in parsed_conditions if c.condition_type == JoinType.RANGE)
+            sql = (
+                f"{left_table_alias} ({range_cond.left_column}) REFERENCES "
+                f"{right_table_alias} (BETWEEN {range_cond.right_column} AND {range_cond.right_column_end} EXCLUSIVE)"
+            )
+            return sql
 
         # Build right column list maintaining same order as left
         # ASOF columns get the ASOF prefix, equality columns are unchanged

--- a/tests/unit/core/parsing/test_join_condition_parser.py
+++ b/tests/unit/core/parsing/test_join_condition_parser.py
@@ -277,14 +277,21 @@ class TestValidationUnsupportedOperators:
         assert "not supported" in error_msg
         assert ">" in error_msg
 
-    def test_validate_between_operator_rejected(self):
-        """Test that BETWEEN operator is rejected with helpful error message."""
-        condition = "{{ column('orders', 'ordered_at') }} BETWEEN {{ column('orders', 'start_date') }} AND {{ column('orders', 'end_date') }}"
+    def test_validate_between_operator_accepted(self):
+        """Test that BETWEEN operator is accepted for range joins (preview feature)."""
+        condition = "{{ column('orders', 'ordered_at') }} BETWEEN {{ column('rates', 'start_date') }} AND {{ column('rates', 'end_date') }} EXCLUSIVE"
+        is_valid, error_msg = JoinConditionParser.validate_condition(condition)
+
+        assert is_valid is True
+        assert error_msg == ""
+
+    def test_validate_between_without_end_rejected(self):
+        """Test that BETWEEN without proper end column is rejected."""
+        condition = "{{ column('orders', 'ordered_at') }} BETWEEN {{ column('rates', 'start_date') }}"
         is_valid, error_msg = JoinConditionParser.validate_condition(condition)
 
         assert is_valid is False
         assert "BETWEEN" in error_msg
-        assert "not supported" in error_msg
 
     def test_validate_less_than_operator_rejected(self):
         """Test that < operator is rejected with helpful error message."""


### PR DESCRIPTION
## Description

Extends the `JoinConditionParser` to recognize `BETWEEN...AND...EXCLUSIVE` pattern for range-based relationships. This enables temporal lookups like "find the exchange rate active when this transaction occurred."

**Note**: This is a Snowflake Preview Feature (Open). Depends on PR #153 (CONSTRAINT DISTINCT RANGE) being merged first.

## Related Issue

Closes #142

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test improvements
- [ ] Other (please describe):

## Changes Made

- Added `right_column_end` field to `ParsedCondition` dataclass for BETWEEN end column
- Added `_extract_range_end()` method to parse end column from BETWEEN...AND...EXCLUSIVE
- Updated `parse()` to populate `right_column_end` for BETWEEN conditions
- Updated `generate_sql_references()` to emit range syntax: `table (col) REFERENCES table (BETWEEN start AND end EXCLUSIVE)`
- Updated `validate_condition()` to accept BETWEEN (was previously rejected)
- Updated existing test to reflect BETWEEN acceptance + added test for missing end column

## Testing

- [x] Unit tests pass (`pytest tests/unit/`)
- [x] All existing tests pass
- [x] New tests added for new functionality
- [ ] Tested locally with Python 3.9-3.11
- [ ] Manual testing completed (if applicable)
- [x] Test coverage maintained or improved (target: >90%)

### Test Results

```
Updated tests:
- test_validate_between_operator_accepted (was: rejected)
- test_validate_between_without_end_rejected (new)

Full suite: 1280 passed, 4 deselected
```

## Checklist

### Code Quality
- [x] Code follows the project's style guidelines (Black, line length 120)
- [x] Imports sorted with isort (black profile)
- [x] Type hints added for new code
- [x] No linting errors

### Testing & Validation
- [x] All tests pass (`pytest tests/unit/`)
- [x] New functionality has test coverage
- [x] Test results included above

### Documentation & Compatibility
- [x] Backward compatibility maintained - equality and ASOF joins unchanged

### Performance
- [x] Performance impact considered
- [x] No significant performance regressions

## Additional Notes

YAML syntax:
```yaml
snowflake_relationships:
  - name: transactions_to_rates
    left_table: "{{ ref('transactions') }}"
    right_table: "{{ ref('rate_periods') }}"
    relationship_conditions:
      - "{{ ref('transactions', 'transaction_date') }} BETWEEN {{ ref('rate_periods', 'effective_start') }} AND {{ ref('rate_periods', 'effective_end') }} EXCLUSIVE"
```

Generated DDL:
```sql
TRANSACTIONS (TRANSACTION_DATE) REFERENCES RATE_PERIODS (BETWEEN EFFECTIVE_START AND EFFECTIVE_END EXCLUSIVE)
```

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)
