### PR TITLE
[SST-143] Feature: Support window function metrics

### DIFF
--- a/snowflake_semantic_tools/core/generation/semantic_view_builder.py
+++ b/snowflake_semantic_tools/core/generation/semantic_view_builder.py
@@ -1128,6 +1128,9 @@ class SemanticViewBuilder:
                         if isinstance(ob, dict):
                             col = self._resolve_ref_to_column(ob.get("column", ""))
                             direction = ob.get("direction", "ASC").upper()
+                            if direction not in ("ASC", "DESC"):
+                                logger.warning(f"Invalid order_by direction '{direction}' — defaulting to ASC")
+                                direction = "ASC"
                             if col:
                                 order_cols.append(f"{col} {direction}")
                         elif isinstance(ob, str):

--- a/snowflake_semantic_tools/core/generation/semantic_view_builder.py
+++ b/snowflake_semantic_tools/core/generation/semantic_view_builder.py
@@ -1103,6 +1103,46 @@ class SemanticViewBuilder:
 
             metric_def = f"    {primary_table}.{metric_name} AS {expression}"
 
+            # Add OVER clause for window function metrics
+            window_config = self._parse_json_field(metric.get("WINDOW"), "window")
+            if window_config and isinstance(window_config, dict):
+                over_parts = []
+                partition_by = window_config.get("partition_by")
+                partition_by_excluding = window_config.get("partition_by_excluding")
+                order_by = window_config.get("order_by")
+
+                if partition_by_excluding and isinstance(partition_by_excluding, list):
+                    cols = [self._resolve_ref_to_column(c) for c in partition_by_excluding]
+                    cols = [c for c in cols if c]
+                    if cols:
+                        over_parts.append(f"PARTITION BY EXCLUDING {', '.join(cols)}")
+                elif partition_by and isinstance(partition_by, list):
+                    cols = [self._resolve_ref_to_column(c) for c in partition_by]
+                    cols = [c for c in cols if c]
+                    if cols:
+                        over_parts.append(f"PARTITION BY {', '.join(cols)}")
+
+                if order_by and isinstance(order_by, list):
+                    order_cols = []
+                    for ob in order_by:
+                        if isinstance(ob, dict):
+                            col = self._resolve_ref_to_column(ob.get("column", ""))
+                            direction = ob.get("direction", "ASC").upper()
+                            if col:
+                                order_cols.append(f"{col} {direction}")
+                        elif isinstance(ob, str):
+                            col = self._resolve_ref_to_column(ob)
+                            if col:
+                                order_cols.append(f"{col} ASC")
+                    if order_cols:
+                        over_parts.append(f"ORDER BY {', '.join(order_cols)}")
+
+                if over_parts:
+                    over_clause = " ".join(over_parts)
+                    metric_def = (
+                        f"    {primary_table}.{metric_name} AS {expression} OVER (\n        {over_clause}\n    )"
+                    )
+
             # Add comment if available
             if metric.get("DESCRIPTION"):
                 description = metric["DESCRIPTION"].replace("'", "''")
@@ -1118,6 +1158,24 @@ class SemanticViewBuilder:
             )
 
         return ",\n".join(metric_definitions)
+
+    @staticmethod
+    def _resolve_ref_to_column(ref_str: str) -> str:
+        """Resolve a {{ ref('table', 'column') }} template to TABLE.COLUMN format."""
+        if not ref_str:
+            return ""
+        ref_pattern = re.compile(r"{{\s*ref\s*\(\s*['\"]([^'\"]+)['\"]\s*,\s*['\"]([^'\"]+)['\"]\s*\)\s*}}")
+        match = ref_pattern.search(str(ref_str))
+        if match:
+            return f"{match.group(1).upper()}.{match.group(2).upper()}"
+        col_pattern = re.compile(r"{{\s*column\s*\(\s*['\"]([^'\"]+)['\"]\s*,\s*['\"]([^'\"]+)['\"]\s*\)\s*}}")
+        match = col_pattern.search(str(ref_str))
+        if match:
+            return f"{match.group(1).upper()}.{match.group(2).upper()}"
+        cleaned = str(ref_str).strip().upper()
+        if "." in cleaned:
+            return cleaned
+        return cleaned
 
     def _build_ca_extension(self, conn, table_names: List[str]) -> str:
         """

--- a/snowflake_semantic_tools/core/parsing/parsers/semantic_parser.py
+++ b/snowflake_semantic_tools/core/parsing/parsers/semantic_parser.py
@@ -133,6 +133,7 @@ def parse_snowflake_metrics(metrics: List[Dict[str, Any]], file_path: Path) -> L
                 "expr": metric.get("expr", ""),
                 "synonyms": metric.get("synonyms", []),
                 "sample_values": metric.get("sample_values", []),
+                "window": metric.get("window"),
                 "source_file": str(file_path),  # Store the file path for validation errors
             }
             metric_records.append(metric_record)

--- a/tests/unit/core/generation/test_semantic_view_builder.py
+++ b/tests/unit/core/generation/test_semantic_view_builder.py
@@ -1061,6 +1061,65 @@ class TestWindowFunctionMetrics:
         assert builder._resolve_ref_to_column("") == ""
         assert builder._resolve_ref_to_column("ORDERS.AMOUNT") == "ORDERS.AMOUNT"
 
+    def test_invalid_direction_defaults_to_asc(self, builder, monkeypatch, caplog):
+        """Test that invalid direction values default to ASC with a warning."""
+        import logging
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "BAD_WINDOW",
+                    "EXPR": "SUM(ORDERS.AMOUNT)",
+                    "DESCRIPTION": "Bad",
+                    "TABLE_NAME": '["orders"]',
+                    "SYNONYMS": None,
+                    "SAMPLE_VALUES": None,
+                    "WINDOW": '{"partition_by": ["{{ ref(\'orders\', \'customer_id\') }}"], "order_by": [{"column": "{{ ref(\'orders\', \'order_date\') }}", "direction": "INVALID"}]}',
+                }
+            ]
+
+        def mock_noop(conn, t):
+            return []
+
+        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
+        monkeypatch.setattr(builder, "_get_dimensions", mock_noop)
+        monkeypatch.setattr(builder, "_get_facts", mock_noop)
+        monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
+
+        with caplog.at_level(logging.WARNING):
+            result = builder._build_metrics_clause(None, ["orders"])
+
+        assert "ORDER BY ORDERS.ORDER_DATE ASC" in result
+        assert "Invalid order_by direction" in caplog.text
+
+    def test_order_by_string_format(self, builder, monkeypatch):
+        """Test order_by with plain string entries (not dict)."""
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "SIMPLE_WINDOW",
+                    "EXPR": "SUM(ORDERS.AMOUNT)",
+                    "DESCRIPTION": "Simple",
+                    "TABLE_NAME": '["orders"]',
+                    "SYNONYMS": None,
+                    "SAMPLE_VALUES": None,
+                    "WINDOW": '{"partition_by": ["{{ ref(\'orders\', \'customer_id\') }}"], "order_by": ["{{ ref(\'orders\', \'order_date\') }}"]}',
+                }
+            ]
+
+        def mock_noop(conn, t):
+            return []
+
+        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
+        monkeypatch.setattr(builder, "_get_dimensions", mock_noop)
+        monkeypatch.setattr(builder, "_get_facts", mock_noop)
+        monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
+
+        result = builder._build_metrics_clause(None, ["orders"])
+
+        assert "ORDER BY ORDERS.ORDER_DATE ASC" in result
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/core/generation/test_semantic_view_builder.py
+++ b/tests/unit/core/generation/test_semantic_view_builder.py
@@ -958,5 +958,109 @@ class TestTableNotFoundErrorFormatting:
         assert "Original error:" in result
 
 
+class TestWindowFunctionMetrics:
+    """Test cases for window function metric DDL generation."""
+
+    @pytest.fixture
+    def builder(self):
+        config = SnowflakeConfig(
+            account="test", user="test", password="test", role="test", warehouse="test", database="test_db", schema="s"
+        )
+        return SemanticViewBuilder(config)
+
+    def test_standard_partition_by(self, builder, monkeypatch):
+        """Test OVER (PARTITION BY ... ORDER BY ...) emission."""
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "RUNNING_REVENUE",
+                    "EXPR": "SUM(ORDERS.AMOUNT)",
+                    "DESCRIPTION": "Running revenue",
+                    "TABLE_NAME": '["orders"]',
+                    "SYNONYMS": None,
+                    "SAMPLE_VALUES": None,
+                    "WINDOW": '{"partition_by": ["{{ ref(\'customers\', \'customer_id\') }}"], "order_by": [{"column": "{{ ref(\'orders\', \'order_date\') }}", "direction": "ASC"}]}',
+                }
+            ]
+
+        def mock_noop(conn, t):
+            return []
+
+        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
+        monkeypatch.setattr(builder, "_get_dimensions", mock_noop)
+        monkeypatch.setattr(builder, "_get_facts", mock_noop)
+        monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
+
+        result = builder._build_metrics_clause(None, ["orders", "customers"])
+
+        assert "OVER (" in result
+        assert "PARTITION BY CUSTOMERS.CUSTOMER_ID" in result
+        assert "ORDER BY ORDERS.ORDER_DATE ASC" in result
+
+    def test_partition_by_excluding(self, builder, monkeypatch):
+        """Test PARTITION BY EXCLUDING emission."""
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "CUMULATIVE_REVENUE",
+                    "EXPR": "SUM(ORDERS.AMOUNT)",
+                    "DESCRIPTION": "Cumulative revenue",
+                    "TABLE_NAME": '["orders"]',
+                    "SYNONYMS": None,
+                    "SAMPLE_VALUES": None,
+                    "WINDOW": '{"partition_by_excluding": ["{{ ref(\'orders\', \'order_date\') }}"], "order_by": [{"column": "{{ ref(\'orders\', \'order_date\') }}", "direction": "ASC"}]}',
+                }
+            ]
+
+        def mock_noop(conn, t):
+            return []
+
+        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
+        monkeypatch.setattr(builder, "_get_dimensions", mock_noop)
+        monkeypatch.setattr(builder, "_get_facts", mock_noop)
+        monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
+
+        result = builder._build_metrics_clause(None, ["orders"])
+
+        assert "PARTITION BY EXCLUDING ORDERS.ORDER_DATE" in result
+
+    def test_no_window_no_over(self, builder, monkeypatch):
+        """Test that metrics without window config don't emit OVER."""
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "TOTAL",
+                    "EXPR": "SUM(ORDERS.AMOUNT)",
+                    "DESCRIPTION": "Total",
+                    "TABLE_NAME": '["orders"]',
+                    "SYNONYMS": None,
+                    "SAMPLE_VALUES": None,
+                    "WINDOW": None,
+                }
+            ]
+
+        def mock_noop(conn, t):
+            return []
+
+        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
+        monkeypatch.setattr(builder, "_get_dimensions", mock_noop)
+        monkeypatch.setattr(builder, "_get_facts", mock_noop)
+        monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
+
+        result = builder._build_metrics_clause(None, ["orders"])
+
+        assert "OVER" not in result
+
+    def test_resolve_ref_to_column(self, builder):
+        """Test _resolve_ref_to_column helper."""
+        assert builder._resolve_ref_to_column("{{ ref('orders', 'amount') }}") == "ORDERS.AMOUNT"
+        assert builder._resolve_ref_to_column("{{ column('orders', 'amount') }}") == "ORDERS.AMOUNT"
+        assert builder._resolve_ref_to_column("") == ""
+        assert builder._resolve_ref_to_column("ORDERS.AMOUNT") == "ORDERS.AMOUNT"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Description

Adds window configuration to metric definitions for running totals, cumulative sums, rankings, and moving averages. Supports both standard `PARTITION BY` and the semantic-view-specific `PARTITION BY EXCLUDING` (which dynamically adjusts based on query dimensions).

## Related Issue

Closes #143

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test improvements
- [ ] Other (please describe):

## Changes Made

- Added `window` field to metric parsing in `semantic_parser.py`
- Added `_resolve_ref_to_column()` static helper to resolve `{{ ref('table', 'col') }}` templates to `TABLE.COL`
- Builder emits `OVER (PARTITION BY ... ORDER BY ...)` or `OVER (PARTITION BY EXCLUDING ... ORDER BY ...)` syntax
- Supports `partition_by`, `partition_by_excluding` (mutually exclusive), and `order_by` with `direction`

## Testing

- [x] Unit tests pass (`pytest tests/unit/`)
- [x] All existing tests pass
- [x] New tests added for new functionality
- [ ] Tested locally with Python 3.9-3.11
- [ ] Manual testing completed (if applicable)
- [x] Test coverage maintained or improved (target: >90%)

### Test Results

```
4 new tests in TestWindowFunctionMetrics:
- test_standard_partition_by (PARTITION BY + ORDER BY)
- test_partition_by_excluding (EXCLUDING syntax)
- test_no_window_no_over (absent = no OVER)
- test_resolve_ref_to_column (helper unit test)

Full suite: 1281 passed, 4 deselected
```

## Checklist

### Code Quality
- [x] Code follows the project's style guidelines (Black, line length 120)
- [x] Imports sorted with isort (black profile)
- [x] Type hints added for new code
- [x] No linting errors

### Testing & Validation
- [x] All tests pass (`pytest tests/unit/`)
- [x] New functionality has test coverage
- [x] Test results included above

### Documentation & Compatibility
- [x] Backward compatibility maintained - field is optional, existing metrics unchanged

### Performance
- [x] Performance impact considered
- [x] No significant performance regressions

## Additional Notes

YAML syntax:
```yaml
snowflake_metrics:
  - name: running_revenue
    expr: SUM({{ ref('orders', 'amount') }})
    window:
      partition_by:
        - "{{ ref('customers', 'customer_id') }}"
      order_by:
        - column: "{{ ref('orders', 'order_date') }}"
          direction: ASC
```

Generated DDL:
```sql
ORDERS.RUNNING_REVENUE AS SUM(ORDERS.AMOUNT) OVER (
    PARTITION BY CUSTOMERS.CUSTOMER_ID ORDER BY ORDERS.ORDER_DATE ASC
)
```

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)
