### PR TITLE
[SST-146] Feature: Support TAG on semantic view objects

### DIFF
--- a/snowflake_semantic_tools/core/generation/semantic_view_builder.py
+++ b/snowflake_semantic_tools/core/generation/semantic_view_builder.py
@@ -1139,7 +1139,11 @@ class SemanticViewBuilder:
         parsed_tags = self._parse_json_field(tags, "tags")
         if not parsed_tags or not isinstance(parsed_tags, dict):
             return ""
-        tag_parts = [f"{k} = '{v}'" for k, v in parsed_tags.items() if k and v is not None]
+        tag_parts = []
+        for k, v in parsed_tags.items():
+            if k and v is not None:
+                sanitized_value = CharacterSanitizer.sanitize_for_sql_string(str(v))
+                tag_parts.append(f"{k} = '{sanitized_value}'")
         if not tag_parts:
             return ""
         return f"WITH TAG ({', '.join(tag_parts)})"

--- a/snowflake_semantic_tools/core/generation/semantic_view_builder.py
+++ b/snowflake_semantic_tools/core/generation/semantic_view_builder.py
@@ -887,6 +887,11 @@ class SemanticViewBuilder:
             description = self._sanitize_description(description)
             table_def += f"\n      COMMENT = '{description}'"
 
+            # Add tags if available
+            tag_clause = self._build_tag_clause(table_info.get("TAGS"))
+            if tag_clause:
+                table_def += f"\n      {tag_clause}"
+
             table_definitions.append(table_def)
 
         return ",\n".join(table_definitions)
@@ -959,6 +964,11 @@ class SemanticViewBuilder:
                 description = self._sanitize_description(fact["DESCRIPTION"])
                 fact_def += f"\n      COMMENT = '{description}'"
 
+            # Add tags if available
+            tag_clause = self._build_tag_clause(fact.get("TAGS"))
+            if tag_clause:
+                fact_def += f"\n      {tag_clause}"
+
             fact_definitions.append(fact_def)
 
         return ",\n".join(fact_definitions)
@@ -1008,6 +1018,11 @@ class SemanticViewBuilder:
             if dim.get("DESCRIPTION"):
                 description = self._sanitize_description(dim["DESCRIPTION"])
                 dim_def += f"\n      COMMENT = '{description}'"
+
+            # Add tags if available
+            tag_clause = self._build_tag_clause(dim.get("TAGS"))
+            if tag_clause:
+                dim_def += f"\n      {tag_clause}"
 
             dim_definitions.append(dim_def)
 
@@ -1118,6 +1133,16 @@ class SemanticViewBuilder:
             )
 
         return ",\n".join(metric_definitions)
+
+    def _build_tag_clause(self, tags: Any) -> str:
+        """Build WITH TAG (...) clause from a tags dict or JSON string."""
+        parsed_tags = self._parse_json_field(tags, "tags")
+        if not parsed_tags or not isinstance(parsed_tags, dict):
+            return ""
+        tag_parts = [f"{k} = '{v}'" for k, v in parsed_tags.items() if k and v is not None]
+        if not tag_parts:
+            return ""
+        return f"WITH TAG ({', '.join(tag_parts)})"
 
     def _build_ca_extension(self, conn, table_names: List[str]) -> str:
         """

--- a/snowflake_semantic_tools/core/parsing/parsers/data_extractors.py
+++ b/snowflake_semantic_tools/core/parsing/parsers/data_extractors.py
@@ -181,6 +181,7 @@ def extract_table_info(
             "model_name": name,  # Store the original model name
             "source_file": str(file_path),  # Store the file path for validation errors
             "cortex_searchable": sst_meta.get("cortex_searchable", False),
+            "tags": sst_meta.get("tags"),
         }
 
         return table_record
@@ -305,6 +306,7 @@ def extract_column_info(column: Dict[str, Any], table_name: str, file_path: Path
             "synonyms": sst_meta.get("synonyms", []),
             "sample_values": sst_meta.get("sample_values", []),
             "is_enum": sst_meta.get("is_enum", False),
+            "tags": sst_meta.get("tags"),
             "source_file": str(file_path),  # Store the file path for validation errors
         }
 

--- a/tests/unit/core/generation/test_semantic_view_builder.py
+++ b/tests/unit/core/generation/test_semantic_view_builder.py
@@ -958,5 +958,85 @@ class TestTableNotFoundErrorFormatting:
         assert "Original error:" in result
 
 
+class TestTagSupport:
+    """Test cases for WITH TAG clause generation."""
+
+    @pytest.fixture
+    def builder(self):
+        config = SnowflakeConfig(
+            account="test", user="test", password="test", role="test", warehouse="test", database="test_db", schema="s"
+        )
+        return SemanticViewBuilder(config)
+
+    def test_table_tags_emitted(self, builder, monkeypatch):
+        """Test that table-level tags emit WITH TAG clause."""
+
+        def mock_get_table_info(conn, table_name):
+            return {
+                "TABLE_NAME": "ORDERS",
+                "DATABASE": "TEST_DB",
+                "SCHEMA": "TEST_SCHEMA",
+                "PRIMARY_KEY": '["order_id"]',
+                "UNIQUE_KEYS": None,
+                "DESCRIPTION": "Orders",
+                "SYNONYMS": None,
+                "TAGS": '{"data_domain": "sales", "sensitivity": "internal"}',
+            }
+
+        monkeypatch.setattr(builder, "_get_table_info", mock_get_table_info)
+
+        result = builder._build_tables_clause(None, ["orders"])
+
+        assert "WITH TAG (data_domain = 'sales', sensitivity = 'internal')" in result
+
+    def test_fact_tags_emitted(self, builder, monkeypatch):
+        """Test that fact-level tags emit WITH TAG clause."""
+
+        def mock_get_facts(conn, table_name):
+            return [
+                {
+                    "NAME": "amount",
+                    "EXPR": "AMOUNT",
+                    "DESCRIPTION": "Amount",
+                    "SYNONYMS": None,
+                    "SAMPLE_VALUES": None,
+                    "TAGS": '{"pii": "false"}',
+                }
+            ]
+
+        monkeypatch.setattr(builder, "_get_facts", mock_get_facts)
+
+        result = builder._build_facts_clause(None, ["orders"])
+
+        assert "WITH TAG (pii = 'false')" in result
+
+    def test_no_tags_no_clause(self, builder, monkeypatch):
+        """Test that absent tags don't emit WITH TAG."""
+
+        def mock_get_facts(conn, table_name):
+            return [
+                {
+                    "NAME": "amount",
+                    "EXPR": "AMOUNT",
+                    "DESCRIPTION": "Amount",
+                    "SYNONYMS": None,
+                    "SAMPLE_VALUES": None,
+                    "TAGS": None,
+                }
+            ]
+
+        monkeypatch.setattr(builder, "_get_facts", mock_get_facts)
+
+        result = builder._build_facts_clause(None, ["orders"])
+
+        assert "WITH TAG" not in result
+
+    def test_build_tag_clause_helper(self, builder):
+        """Test _build_tag_clause helper directly."""
+        assert builder._build_tag_clause(None) == ""
+        assert builder._build_tag_clause("{}") == ""
+        assert builder._build_tag_clause('{"dept": "finance"}') == "WITH TAG (dept = 'finance')"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Description

Adds `tags` configuration at table and column (fact/dimension) levels, emitting `WITH TAG (tag_name = 'value')` in generated DDL. Tags enable governance metadata, discoverability, cost attribution, and policy-based access control.

## Related Issue

Closes #146

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test improvements
- [ ] Other (please describe):

## Changes Made

- Added `tags` extraction at table-level and column-level in `data_extractors.py`
- Added `_build_tag_clause()` helper method to SemanticViewBuilder
- Emits `WITH TAG (...)` after COMMENT in tables, facts, and dimensions clauses

## Testing

- [x] Unit tests pass (`pytest tests/unit/`)
- [x] All existing tests pass
- [x] New tests added for new functionality
- [ ] Tested locally with Python 3.9-3.11
- [ ] Manual testing completed (if applicable)
- [x] Test coverage maintained or improved (target: >90%)

### Test Results

```
4 new tests in TestTagSupport:
- test_table_tags_emitted
- test_fact_tags_emitted
- test_no_tags_no_clause
- test_build_tag_clause_helper

Full suite: 1281 passed, 4 deselected
```

## Checklist

### Code Quality
- [x] Code follows the project's style guidelines (Black, line length 120)
- [x] Imports sorted with isort (black profile)
- [x] Type hints added for new code
- [x] No linting errors

### Testing & Validation
- [x] All tests pass (`pytest tests/unit/`)
- [x] New functionality has test coverage
- [x] Test results included above

### Documentation & Compatibility
- [x] Backward compatibility maintained - field is optional

### Performance
- [x] Performance impact considered
- [x] No significant performance regressions

## Additional Notes

YAML syntax:
```yaml
models:
  - name: orders
    config:
      meta:
        sst:
          tags:
            data_domain: sales
            sensitivity: internal
    columns:
      - name: email
        config:
          meta:
            sst:
              tags:
                pii_type: email
```

Generated DDL:
```sql
ORDERS AS DB.SCHEMA.ORDERS
    COMMENT = 'Orders table'
    WITH TAG (data_domain = 'sales', sensitivity = 'internal')
```

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)
