### PR TITLE
[SST-136] DDL Parity v0.3.0 — 10 features for full Snowflake semantic view syntax coverage

### DIFF
--- a/.cortex/skills/sst-e2e-test/SKILL.md
+++ b/.cortex/skills/sst-e2e-test/SKILL.md
@@ -7,7 +7,7 @@ description: "End-to-end testing for SST against sst-jaffle-shop. Runs unit test
 
 ## Purpose
 
-This skill validates that SST (snowflake-semantic-tools) works correctly after code changes. It uses [sst-jaffle-shop](https://github.com/mluizzi-whoop/sst-jaffle-shop) — a known-good dbt project with 13 models, 38 metrics, 5 relationships, and 3 semantic views — as a reference integration test. If SST can successfully validate, enrich, extract, and generate semantic views from this project, the code is working.
+This skill validates that SST (snowflake-semantic-tools) works correctly after code changes. It uses [sst-jaffle-shop](https://github.com/WhoopInc/sst-jaffle-shop) — a known-good dbt project with 13 models, 38 metrics, 5 relationships, and 3 semantic views — as a reference integration test. If SST can successfully validate, enrich, extract, and generate semantic views from this project, the code is working.
 
 Use this skill when:
 - You've made changes to SST and want to verify nothing broke
@@ -65,7 +65,7 @@ Locate or clone the test project:
    ```
 2. If not found, clone it next to the SST repo:
    ```bash
-   git clone https://github.com/mluizzi-whoop/sst-jaffle-shop.git "$SST_REPO/../sst-jaffle-shop"
+   git clone https://github.com/WhoopInc/sst-jaffle-shop.git "$SST_REPO/../sst-jaffle-shop"
    ```
 3. Ensure the `complete-project` branch is checked out and up to date:
    ```bash

--- a/.cortex/skills/sst-e2e-test/references/setup-guide.md
+++ b/.cortex/skills/sst-e2e-test/references/setup-guide.md
@@ -31,7 +31,7 @@ If the user has a conda environment, virtualenv, or other Python environment man
 
 | Property | Value |
 |----------|-------|
-| GitHub   | https://github.com/mluizzi-whoop/sst-jaffle-shop |
+| GitHub   | https://github.com/WhoopInc/sst-jaffle-shop |
 | Branch   | `complete-project` |
 | Location | Sibling directory to SST repo, or cloned during setup |
 | Models   | 13 dbt models (6 staging + 7 marts) |

--- a/snowflake_semantic_tools/core/generation/semantic_view_builder.py
+++ b/snowflake_semantic_tools/core/generation/semantic_view_builder.py
@@ -1101,7 +1101,27 @@ class SemanticViewBuilder:
             if not primary_table:
                 primary_table = table_names[0].upper()  # Fallback to first table
 
-            metric_def = f"    {primary_table}.{metric_name} AS {expression}"
+            metric_def = f"    {primary_table}.{metric_name}"
+
+            # Add NON ADDITIVE BY clause for semi-additive metrics
+            non_additive_by = self._parse_json_field(metric.get("NON_ADDITIVE_BY"), "non_additive_by")
+            if non_additive_by and isinstance(non_additive_by, list):
+                nab_parts = []
+                for entry in non_additive_by:
+                    if isinstance(entry, dict):
+                        dim = entry.get("dimension", "").upper()
+                        order = entry.get("order", "").upper()
+                        nulls = entry.get("nulls", "").upper()
+                        part = dim
+                        if order:
+                            part += f" {order}"
+                        if nulls:
+                            part += f" NULLS {nulls}"
+                        nab_parts.append(part)
+                if nab_parts:
+                    metric_def += f"\n      NON ADDITIVE BY ({', '.join(nab_parts)})"
+
+            metric_def += f" AS {expression}"
 
             # Add comment if available
             if metric.get("DESCRIPTION"):

--- a/snowflake_semantic_tools/core/generation/semantic_view_builder.py
+++ b/snowflake_semantic_tools/core/generation/semantic_view_builder.py
@@ -1339,6 +1339,7 @@ class SemanticViewBuilder:
         except (ValueError, TypeError):
             logger.warning(f"Could not parse date '{date_str}' to epoch")
             return None
+
     @staticmethod
     def _resolve_ref_to_column(ref_str: str) -> str:
         """Resolve a {{ ref('table', 'column') }} template to TABLE.COLUMN format."""
@@ -1356,6 +1357,7 @@ class SemanticViewBuilder:
         if "." in cleaned:
             return cleaned
         return cleaned
+
     def _build_tag_clause(self, tags: Any) -> str:
         """Build WITH TAG (...) clause from a tags dict or JSON string."""
         parsed_tags = self._parse_json_field(tags, "tags")

--- a/snowflake_semantic_tools/core/generation/semantic_view_builder.py
+++ b/snowflake_semantic_tools/core/generation/semantic_view_builder.py
@@ -1272,23 +1272,97 @@ class SemanticViewBuilder:
             logger.warning(f"Failed to retrieve custom instructions: {e}")
             return []
 
-    def _build_ai_guidance_clauses(self, conn: Any, custom_instruction_names: Optional[List[str]]) -> str:
+    def _get_filters_for_tables(self, conn: Any, table_names: List[str]) -> List[Dict[str, Any]]:
         """
-        Build AI_QUESTION_CATEGORIZATION and AI_SQL_GENERATION clauses from custom instructions.
+        Retrieve filters from SM_FILTERS for the given tables.
+
+        Args:
+            conn: Database connection
+            table_names: List of table names to get filters for
+
+        Returns:
+            List of filter dictionaries with NAME, TABLE_NAME, DESCRIPTION, EXPR
+        """
+        if not table_names:
+            return []
+
+        try:
+            tlist = ", ".join([f"'{t.upper()}'" for t in table_names])
+            sql = (
+                f"SELECT NAME, TABLE_NAME, DESCRIPTION, EXPR "
+                f"FROM {self.metadata_database}.{self.metadata_schema}.SM_FILTERS "
+                f"WHERE UPPER(TABLE_NAME) IN ({tlist})"
+            )
+            return self._execute_query(conn, sql)
+        except Exception as e:
+            logger.warning(f"Failed to retrieve filters: {e}")
+            return []
+
+    def _build_filters_as_instructions(self, conn: Any, table_names: List[str]) -> str:
+        """
+        Convert filter definitions into AI_SQL_GENERATION instruction text.
+
+        Snowflake's CREATE SEMANTIC VIEW DDL has no native FILTERS clause.
+        This method converts filters into natural language instructions that are
+        appended to the AI_SQL_GENERATION clause, making filters functional.
+
+        Args:
+            conn: Database connection
+            table_names: List of table names in the current semantic view
+
+        Returns:
+            Instruction text for filters, or empty string if no filters found
+        """
+        from snowflake_semantic_tools.shared.config import get_config
+
+        config = get_config()
+        if not config.get("generation.filters_to_instructions", True):
+            return ""
+
+        filters = self._get_filters_for_tables(conn, table_names)
+        if not filters:
+            return ""
+
+        filter_lines = []
+        for f in filters:
+            table_name = f.get("TABLE_NAME", "").upper()
+            expr = f.get("EXPR", "")
+            description = f.get("DESCRIPTION", "")
+            if expr:
+                if description:
+                    filter_lines.append(
+                        f"- When querying {table_name}, apply: {expr} ({description}) "
+                        f"unless the user explicitly requests unfiltered data."
+                    )
+                else:
+                    filter_lines.append(
+                        f"- When querying {table_name}, apply: {expr} "
+                        f"unless the user explicitly requests unfiltered data."
+                    )
+
+        if not filter_lines:
+            return ""
+
+        header = "Default Filters:"
+        return header + "\n" + "\n".join(filter_lines)
+
+    def _build_ai_guidance_clauses(
+        self, conn: Any, custom_instruction_names: Optional[List[str]], table_names: Optional[List[str]] = None
+    ) -> str:
+        """
+        Build AI_QUESTION_CATEGORIZATION and AI_SQL_GENERATION clauses from custom instructions and filters.
 
         Args:
             conn: Database connection
             custom_instruction_names: List of custom instruction names to aggregate
+            table_names: List of table names for filter-to-instruction conversion
 
         Returns:
             String containing AI_QUESTION_CATEGORIZATION and/or AI_SQL_GENERATION clauses, or empty string
         """
-        if not custom_instruction_names:
-            return ""
-
-        instructions = self._get_custom_instructions_for_view(conn, custom_instruction_names)
-        if not instructions:
-            return ""
+        instructions = []
+        if custom_instruction_names:
+            instructions = self._get_custom_instructions_for_view(conn, custom_instruction_names)
 
         # Aggregate fields from all instructions
         question_cat_parts = []
@@ -1298,6 +1372,15 @@ class SemanticViewBuilder:
                 question_cat_parts.append(inst["question_categorization"].strip())
             if inst.get("sql_generation"):
                 sql_gen_parts.append(inst["sql_generation"].strip())
+
+        # Append filter-based instructions to AI_SQL_GENERATION
+        if table_names:
+            filter_instructions = self._build_filters_as_instructions(conn, table_names)
+            if filter_instructions:
+                sql_gen_parts.append(filter_instructions)
+
+        if not sql_gen_parts and not question_cat_parts:
+            return ""
 
         clauses = []
 
@@ -1407,9 +1490,9 @@ class SemanticViewBuilder:
             comment = f"Semantic view generated for tables: {', '.join(table_names)}"
         sql_parts.append(f"  COMMENT = '{comment}'")
 
-        # Build AI guidance clauses from custom instructions
+        # Build AI guidance clauses from custom instructions and filters
         # These come after COMMENT per Snowflake syntax: COMMENT, then AI_SQL_GENERATION, then AI_QUESTION_CATEGORIZATION
-        ai_guidance_clauses = self._build_ai_guidance_clauses(conn, custom_instruction_names)
+        ai_guidance_clauses = self._build_ai_guidance_clauses(conn, custom_instruction_names, table_names=table_names)
         if ai_guidance_clauses:
             sql_parts.append(ai_guidance_clauses)
 

--- a/snowflake_semantic_tools/core/generation/semantic_view_builder.py
+++ b/snowflake_semantic_tools/core/generation/semantic_view_builder.py
@@ -952,7 +952,11 @@ class SemanticViewBuilder:
             fact_name = fact["NAME"].upper()
             expression = fact["EXPR"]
 
-            fact_def = f"    {table_name}.{fact_name} AS {expression}"
+            visibility_prefix = ""
+            if fact.get("VISIBILITY") and fact["VISIBILITY"].upper() == "PRIVATE":
+                visibility_prefix = "PRIVATE "
+
+            fact_def = f"    {visibility_prefix}{table_name}.{fact_name} AS {expression}"
 
             # Add comment if available
             if fact.get("DESCRIPTION"):
@@ -1101,7 +1105,11 @@ class SemanticViewBuilder:
             if not primary_table:
                 primary_table = table_names[0].upper()  # Fallback to first table
 
-            metric_def = f"    {primary_table}.{metric_name} AS {expression}"
+            visibility_prefix = ""
+            if metric.get("VISIBILITY") and metric["VISIBILITY"].upper() == "PRIVATE":
+                visibility_prefix = "PRIVATE "
+
+            metric_def = f"    {visibility_prefix}{primary_table}.{metric_name} AS {expression}"
 
             # Add comment if available
             if metric.get("DESCRIPTION"):

--- a/snowflake_semantic_tools/core/generation/semantic_view_builder.py
+++ b/snowflake_semantic_tools/core/generation/semantic_view_builder.py
@@ -1119,6 +1119,93 @@ class SemanticViewBuilder:
 
         return ",\n".join(metric_definitions)
 
+    def _build_verified_queries_clause(self, conn, table_names: List[str]) -> str:
+        """Build the AI_VERIFIED_QUERIES clause of the CREATE SEMANTIC VIEW statement."""
+        verified_queries = self._get_verified_queries_for_tables(conn, table_names)
+
+        if not verified_queries:
+            return ""
+
+        vq_definitions = []
+
+        for vq in verified_queries:
+            vq_name = vq.get("NAME", "")
+            if not vq_name:
+                continue
+            vq_name = vq_name.upper()
+            question = vq.get("QUESTION", "").replace("'", "''")
+            sql = vq.get("SQL", "").replace("'", "''")
+
+            if not question or not sql:
+                logger.warning(f"Skipping verified query '{vq_name}' - missing question or sql")
+                continue
+
+            parts = [f"    {vq_name} AS ("]
+            parts.append(f"        QUESTION '{question}'")
+
+            # Convert verified_at to epoch seconds
+            verified_at = vq.get("VERIFIED_AT")
+            if verified_at:
+                epoch = self._iso_to_epoch(verified_at)
+                if epoch is not None:
+                    parts.append(f"        VERIFIED_AT {epoch}")
+
+            # Add onboarding question flag
+            onboarding = vq.get("USE_AS_ONBOARDING_QUESTION")
+            if onboarding is True or (isinstance(onboarding, str) and onboarding.lower() == "true"):
+                parts.append("        ONBOARDING_QUESTION TRUE")
+
+            # Add verified_by in contact format
+            verified_by = vq.get("VERIFIED_BY")
+            if verified_by:
+                parts.append(f"        VERIFIED_BY '(data_quality = {verified_by})'")
+
+            parts.append(f"        SQL '{sql}'")
+            parts.append("    )")
+
+            vq_definitions.append("\n".join(parts))
+
+        if not vq_definitions:
+            return ""
+
+        return ",\n".join(vq_definitions)
+
+    def _get_verified_queries_for_tables(self, conn, table_names: List[str]) -> List[Dict]:
+        """Get verified queries relevant to the given tables."""
+        try:
+            sql = f"SELECT * FROM {self.metadata_database}.{self.metadata_schema}.SM_VERIFIED_QUERIES"
+            rows = self._execute_query(conn, sql)
+
+            normalized_table_names = [t.lower() for t in table_names]
+            relevant_queries = []
+            for row in rows:
+                tables = self._parse_table_list(row.get("TABLES"))
+                if self._all_tables_present(tables, normalized_table_names):
+                    relevant_queries.append(row)
+
+            return relevant_queries
+        except Exception as e:
+            logger.warning(f"Failed to retrieve verified queries: {e}")
+            return []
+
+    @staticmethod
+    def _iso_to_epoch(date_str: str) -> Optional[int]:
+        """Convert an ISO date string to Unix epoch seconds."""
+        if not date_str:
+            return None
+        try:
+            from datetime import datetime, timezone
+
+            if "T" in str(date_str):
+                dt = datetime.fromisoformat(str(date_str).replace("Z", "+00:00"))
+            else:
+                dt = datetime.strptime(str(date_str).split(" ")[0], "%Y-%m-%d")
+                dt = dt.replace(tzinfo=timezone.utc)
+            return int(dt.timestamp())
+        except (ValueError, TypeError):
+            logger.warning(f"Could not parse date '{date_str}' to epoch")
+            return None
+
     def _build_ca_extension(self, conn, table_names: List[str]) -> str:
         """
         Build the WITH EXTENSION (CA='...') clause for Cortex Analyst sample_values.
@@ -1412,6 +1499,12 @@ class SemanticViewBuilder:
         ai_guidance_clauses = self._build_ai_guidance_clauses(conn, custom_instruction_names)
         if ai_guidance_clauses:
             sql_parts.append(ai_guidance_clauses)
+
+        # Build AI_VERIFIED_QUERIES clause
+        logger.info("Building AI_VERIFIED_QUERIES clause...")
+        vq_clause = self._build_verified_queries_clause(conn, table_names)
+        if vq_clause:
+            sql_parts.append(f"  AI_VERIFIED_QUERIES (\n{vq_clause}\n  )")
 
         # Build CA extension for sample_values (Cortex Analyst metadata)
         ca_extension = self._build_ca_extension(conn, table_names)

--- a/snowflake_semantic_tools/core/generation/semantic_view_builder.py
+++ b/snowflake_semantic_tools/core/generation/semantic_view_builder.py
@@ -1230,8 +1230,9 @@ class SemanticViewBuilder:
 
                 if over_parts:
                     over_clause = " ".join(over_parts)
-                    metric_def = (
-                        f"    {primary_table}.{metric_name} AS {expression} OVER (\n        {over_clause}\n    )"
+                    metric_def = metric_def.replace(
+                        f"AS {expression}",
+                        f"AS {expression} OVER (\n        {over_clause}\n    )",
                     )
 
             # Add comment if available
@@ -1289,7 +1290,7 @@ class SemanticViewBuilder:
             # Add verified_by in contact format
             verified_by = vq.get("VERIFIED_BY")
             if verified_by:
-                verified_by_escaped = str(verified_by).replace("'", "''")
+                verified_by_escaped = CharacterSanitizer.sanitize_for_sql_string(str(verified_by))
                 parts.append(f"        VERIFIED_BY '(data_quality = {verified_by_escaped})'")
 
             parts.append(f"        SQL '{sql}'")

--- a/snowflake_semantic_tools/core/generation/semantic_view_builder.py
+++ b/snowflake_semantic_tools/core/generation/semantic_view_builder.py
@@ -886,6 +886,17 @@ class SemanticViewBuilder:
                                 f"\n      CONSTRAINT {c_name} DISTINCT RANGE"
                                 f"\n          BETWEEN {start_col} AND {end_col} EXCLUSIVE"
                             )
+                        else:
+                            missing = [f for f in ["name", "start_column", "end_column"] if not constraint.get(f)]
+                            logger.warning(
+                                f"Table '{table_name}' has a distinct_range constraint with missing fields: "
+                                f"{', '.join(missing)}. Constraint will be skipped."
+                            )
+                    elif isinstance(constraint, dict):
+                        logger.warning(
+                            f"Table '{table_name}' has unrecognized constraint type: "
+                            f"'{constraint.get('type', 'unknown')}'. Only 'distinct_range' is supported."
+                        )
 
             # Add synonyms if available
             if table_info.get("SYNONYMS"):

--- a/snowflake_semantic_tools/core/generation/semantic_view_builder.py
+++ b/snowflake_semantic_tools/core/generation/semantic_view_builder.py
@@ -1287,13 +1287,18 @@ class SemanticViewBuilder:
             return []
 
         try:
-            tlist = ", ".join([f"'{t.upper()}'" for t in table_names])
+            cursor = conn.cursor()
+            placeholders = ", ".join(["%s"] * len(table_names))
             sql = (
                 f"SELECT NAME, TABLE_NAME, DESCRIPTION, EXPR "
                 f"FROM {self.metadata_database}.{self.metadata_schema}.SM_FILTERS "
-                f"WHERE UPPER(TABLE_NAME) IN ({tlist})"
+                f"WHERE UPPER(TABLE_NAME) IN ({placeholders})"
             )
-            return self._execute_query(conn, sql)
+            params = [t.upper() for t in table_names]
+            cursor.execute(sql, params)
+            columns = [desc[0] for desc in cursor.description]
+            rows = cursor.fetchall()
+            return [dict(zip(columns, row)) for row in rows]
         except Exception as e:
             logger.warning(f"Failed to retrieve filters: {e}")
             return []

--- a/snowflake_semantic_tools/core/generation/semantic_view_builder.py
+++ b/snowflake_semantic_tools/core/generation/semantic_view_builder.py
@@ -870,8 +870,17 @@ class SemanticViewBuilder:
             if table_info.get("UNIQUE_KEYS"):
                 unique_key_cols = self._parse_json_field(table_info["UNIQUE_KEYS"], "unique_keys")
                 if unique_key_cols and isinstance(unique_key_cols, list):
-                    uk_cols = ", ".join([col.upper() for col in unique_key_cols])
-                    table_def += f"\n      UNIQUE ({uk_cols})"
+                    has_nested = any(isinstance(item, list) for item in unique_key_cols)
+                    if has_nested:
+                        for uk_entry in unique_key_cols:
+                            if isinstance(uk_entry, list):
+                                uk_cols = ", ".join([str(c).upper() for c in uk_entry])
+                            else:
+                                uk_cols = str(uk_entry).upper()
+                            table_def += f"\n      UNIQUE ({uk_cols})"
+                    else:
+                        uk_cols = ", ".join([str(col).upper() for col in unique_key_cols])
+                        table_def += f"\n      UNIQUE ({uk_cols})"
 
             # Add CONSTRAINT DISTINCT RANGE if available (preview feature)
             constraints = self._parse_json_field(table_info.get("CONSTRAINTS"), "constraints")

--- a/snowflake_semantic_tools/core/generation/semantic_view_builder.py
+++ b/snowflake_semantic_tools/core/generation/semantic_view_builder.py
@@ -873,6 +873,20 @@ class SemanticViewBuilder:
                     uk_cols = ", ".join([col.upper() for col in unique_key_cols])
                     table_def += f"\n      UNIQUE ({uk_cols})"
 
+            # Add CONSTRAINT DISTINCT RANGE if available (preview feature)
+            constraints = self._parse_json_field(table_info.get("CONSTRAINTS"), "constraints")
+            if constraints and isinstance(constraints, list):
+                for constraint in constraints:
+                    if isinstance(constraint, dict) and constraint.get("type") == "distinct_range":
+                        c_name = constraint.get("name", "").upper()
+                        start_col = constraint.get("start_column", "").upper()
+                        end_col = constraint.get("end_column", "").upper()
+                        if c_name and start_col and end_col:
+                            table_def += (
+                                f"\n      CONSTRAINT {c_name} DISTINCT RANGE"
+                                f"\n          BETWEEN {start_col} AND {end_col} EXCLUSIVE"
+                            )
+
             # Add synonyms if available
             if table_info.get("SYNONYMS"):
                 synonyms = self._parse_json_field(table_info["SYNONYMS"], "synonyms")

--- a/snowflake_semantic_tools/core/generation/semantic_view_builder.py
+++ b/snowflake_semantic_tools/core/generation/semantic_view_builder.py
@@ -1128,6 +1128,9 @@ class SemanticViewBuilder:
                         if isinstance(ob, dict):
                             col = self._resolve_ref_to_column(ob.get("column", ""))
                             direction = ob.get("direction", "ASC").upper()
+                            if direction not in ("ASC", "DESC"):
+                                logger.warning(f"Invalid order_by direction '{direction}' — defaulting to ASC")
+                                direction = "ASC"
                             if col:
                                 order_cols.append(f"{col} {direction}")
                         elif isinstance(ob, str):

--- a/snowflake_semantic_tools/core/generation/semantic_view_builder.py
+++ b/snowflake_semantic_tools/core/generation/semantic_view_builder.py
@@ -1110,6 +1110,8 @@ class SemanticViewBuilder:
                 for entry in non_additive_by:
                     if isinstance(entry, dict):
                         dim = entry.get("dimension", "").upper()
+                        if not dim:
+                            continue
                         order = entry.get("order", "").upper()
                         nulls = entry.get("nulls", "").upper()
                         part = dim

--- a/snowflake_semantic_tools/core/generation/semantic_view_builder.py
+++ b/snowflake_semantic_tools/core/generation/semantic_view_builder.py
@@ -1266,7 +1266,10 @@ class SemanticViewBuilder:
                 continue
             vq_name = vq_name.upper()
             question = vq.get("QUESTION", "").replace("'", "''")
-            sql = vq.get("SQL", "").replace("'", "''")
+            sql = vq.get("SQL", "")
+
+            sql = self._resolve_templates_in_sql(sql)
+            sql = sql.replace("'", "''")
 
             if not question or not sql:
                 logger.warning(f"Skipping verified query '{vq_name}' - missing question or sql")
@@ -1340,6 +1343,21 @@ class SemanticViewBuilder:
         except (ValueError, TypeError):
             logger.warning(f"Could not parse date '{date_str}' to epoch")
             return None
+
+    @staticmethod
+    def _resolve_templates_in_sql(sql: str) -> str:
+        """Resolve {{ ref() }}, {{ table() }}, {{ column() }} templates in SQL strings."""
+        if not sql or "{{" not in sql:
+            return sql
+        ref2_pattern = re.compile(r"{{\s*ref\s*\(\s*['\"]([^'\"]+)['\"]\s*,\s*['\"]([^'\"]+)['\"]\s*\)\s*}}")
+        sql = ref2_pattern.sub(lambda m: f"{m.group(1).upper()}.{m.group(2).upper()}", sql)
+        ref1_pattern = re.compile(r"{{\s*ref\s*\(\s*['\"]([^'\"]+)['\"]\s*\)\s*}}")
+        sql = ref1_pattern.sub(lambda m: m.group(1).upper(), sql)
+        col_pattern = re.compile(r"{{\s*column\s*\(\s*['\"]([^'\"]+)['\"]\s*,\s*['\"]([^'\"]+)['\"]\s*\)\s*}}")
+        sql = col_pattern.sub(lambda m: f"{m.group(1).upper()}.{m.group(2).upper()}", sql)
+        table_pattern = re.compile(r"{{\s*table\s*\(\s*['\"]([^'\"]+)['\"]\s*\)\s*}}")
+        sql = table_pattern.sub(lambda m: m.group(1).upper(), sql)
+        return sql
 
     @staticmethod
     def _resolve_ref_to_column(ref_str: str) -> str:

--- a/snowflake_semantic_tools/core/generation/semantic_view_builder.py
+++ b/snowflake_semantic_tools/core/generation/semantic_view_builder.py
@@ -1101,7 +1101,16 @@ class SemanticViewBuilder:
             if not primary_table:
                 primary_table = table_names[0].upper()  # Fallback to first table
 
-            metric_def = f"    {primary_table}.{metric_name} AS {expression}"
+            metric_def = f"    {primary_table}.{metric_name}"
+
+            # Add USING clause for relationship path disambiguation
+            using_rels = self._parse_json_field(metric.get("USING_RELATIONSHIPS"), "using_relationships")
+            if using_rels and isinstance(using_rels, list):
+                rel_names = [str(r).upper() for r in using_rels if r]
+                if rel_names:
+                    metric_def += f"\n      USING ({', '.join(rel_names)})"
+
+            metric_def += f" AS {expression}"
 
             # Add comment if available
             if metric.get("DESCRIPTION"):

--- a/snowflake_semantic_tools/core/generation/semantic_view_builder.py
+++ b/snowflake_semantic_tools/core/generation/semantic_view_builder.py
@@ -1139,7 +1139,11 @@ class SemanticViewBuilder:
         parsed_tags = self._parse_json_field(tags, "tags")
         if not parsed_tags or not isinstance(parsed_tags, dict):
             return ""
-        tag_parts = [f"{k} = '{v}'" for k, v in parsed_tags.items() if k and v is not None]
+        tag_parts = []
+        for k, v in parsed_tags.items():
+            if k and v is not None:
+                sanitized_value = CharacterSanitizer.sanitize_for_sql_string(str(v))
+                tag_parts.append(f"{k} = '{sanitized_value}'")
         if not tag_parts:
             return ""
         return f"WITH TAG ({', '.join(tag_parts)})"

--- a/snowflake_semantic_tools/core/generation/semantic_view_builder.py
+++ b/snowflake_semantic_tools/core/generation/semantic_view_builder.py
@@ -1355,15 +1355,11 @@ class SemanticViewBuilder:
 
     @staticmethod
     def _resolve_templates_in_sql(sql: str) -> str:
-        """Resolve {{ ref() }}, {{ table() }}, {{ column() }} templates in SQL strings."""
+        """Resolve {{ ref('table') }} templates in VQR SQL to uppercase table names."""
         if not sql or "{{" not in sql:
             return sql
-        ref2_pattern = re.compile(r"{{\s*ref\s*\(\s*['\"]([^'\"]+)['\"]\s*,\s*['\"]([^'\"]+)['\"]\s*\)\s*}}")
-        sql = ref2_pattern.sub(lambda m: f"{m.group(1).upper()}.{m.group(2).upper()}", sql)
         ref1_pattern = re.compile(r"{{\s*ref\s*\(\s*['\"]([^'\"]+)['\"]\s*\)\s*}}")
         sql = ref1_pattern.sub(lambda m: m.group(1).upper(), sql)
-        col_pattern = re.compile(r"{{\s*column\s*\(\s*['\"]([^'\"]+)['\"]\s*,\s*['\"]([^'\"]+)['\"]\s*\)\s*}}")
-        sql = col_pattern.sub(lambda m: f"{m.group(1).upper()}.{m.group(2).upper()}", sql)
         table_pattern = re.compile(r"{{\s*table\s*\(\s*['\"]([^'\"]+)['\"]\s*\)\s*}}")
         sql = table_pattern.sub(lambda m: m.group(1).upper(), sql)
         return sql

--- a/snowflake_semantic_tools/core/generation/semantic_view_builder.py
+++ b/snowflake_semantic_tools/core/generation/semantic_view_builder.py
@@ -954,6 +954,17 @@ class SemanticViewBuilder:
 
             fact_def = f"    {table_name}.{fact_name} AS {expression}"
 
+            # Add synonyms if available
+            if fact.get("SYNONYMS"):
+                synonyms = self._parse_json_field(fact["SYNONYMS"], "synonyms")
+                if synonyms and isinstance(synonyms, list):
+                    synonyms_filtered = [s for s in synonyms if s is not None]
+                    if synonyms_filtered:
+                        synonyms_cleaned = CharacterSanitizer.sanitize_synonym_list(synonyms_filtered)
+                        if synonyms_cleaned:
+                            synonyms_str = ", ".join([f"'{syn}'" for syn in synonyms_cleaned])
+                            fact_def += f"\n      WITH SYNONYMS = ({synonyms_str})"
+
             # Add comment if available
             if fact.get("DESCRIPTION"):
                 description = self._sanitize_description(fact["DESCRIPTION"])

--- a/snowflake_semantic_tools/core/generation/semantic_view_builder.py
+++ b/snowflake_semantic_tools/core/generation/semantic_view_builder.py
@@ -1160,8 +1160,7 @@ class SemanticViewBuilder:
             if metric.get("VISIBILITY") and metric["VISIBILITY"].upper() == "PRIVATE":
                 visibility_prefix = "PRIVATE "
 
-            metric_def = f"    {visibility_prefix}{primary_table}.{metric_name} AS {expression}"
-            metric_def = f"    {primary_table}.{metric_name}"
+            metric_def = f"    {visibility_prefix}{primary_table}.{metric_name}"
 
             # Add NON ADDITIVE BY clause for semi-additive metrics
             non_additive_by = self._parse_json_field(metric.get("NON_ADDITIVE_BY"), "non_additive_by")
@@ -1182,7 +1181,6 @@ class SemanticViewBuilder:
                         nab_parts.append(part)
                 if nab_parts:
                     metric_def += f"\n      NON ADDITIVE BY ({', '.join(nab_parts)})"
-            metric_def = f"    {primary_table}.{metric_name}"
 
             # Add USING clause for relationship path disambiguation
             using_rels = self._parse_json_field(metric.get("USING_RELATIONSHIPS"), "using_relationships")

--- a/snowflake_semantic_tools/core/generation/semantic_view_builder.py
+++ b/snowflake_semantic_tools/core/generation/semantic_view_builder.py
@@ -887,6 +887,11 @@ class SemanticViewBuilder:
             description = self._sanitize_description(description)
             table_def += f"\n      COMMENT = '{description}'"
 
+            # Add tags if available
+            tag_clause = self._build_tag_clause(table_info.get("TAGS"))
+            if tag_clause:
+                table_def += f"\n      {tag_clause}"
+
             table_definitions.append(table_def)
 
         return ",\n".join(table_definitions)
@@ -959,6 +964,11 @@ class SemanticViewBuilder:
                 description = self._sanitize_description(fact["DESCRIPTION"])
                 fact_def += f"\n      COMMENT = '{description}'"
 
+            # Add tags if available
+            tag_clause = self._build_tag_clause(fact.get("TAGS"))
+            if tag_clause:
+                fact_def += f"\n      {tag_clause}"
+
             fact_definitions.append(fact_def)
 
         return ",\n".join(fact_definitions)
@@ -1008,6 +1018,11 @@ class SemanticViewBuilder:
             if dim.get("DESCRIPTION"):
                 description = self._sanitize_description(dim["DESCRIPTION"])
                 dim_def += f"\n      COMMENT = '{description}'"
+
+            # Add tags if available
+            tag_clause = self._build_tag_clause(dim.get("TAGS"))
+            if tag_clause:
+                dim_def += f"\n      {tag_clause}"
 
             dim_definitions.append(dim_def)
 
@@ -1118,6 +1133,16 @@ class SemanticViewBuilder:
             )
 
         return ",\n".join(metric_definitions)
+
+    def _build_tag_clause(self, tags: Any) -> str:
+        """Build WITH TAG (...) clause from a tags dict or JSON string."""
+        parsed_tags = self._parse_json_field(tags, "tags")
+        if not parsed_tags or not isinstance(parsed_tags, dict):
+            return ""
+        tag_parts = [f"{k} = '{v}'" for k, v in parsed_tags.items() if k and v is not None]
+        if not tag_parts:
+            return ""
+        return f"WITH TAG ({', '.join(tag_parts)})"
 
     def _build_ca_extension(self, conn, table_names: List[str]) -> str:
         """

--- a/snowflake_semantic_tools/core/generation/semantic_view_builder.py
+++ b/snowflake_semantic_tools/core/generation/semantic_view_builder.py
@@ -1103,6 +1103,46 @@ class SemanticViewBuilder:
 
             metric_def = f"    {primary_table}.{metric_name} AS {expression}"
 
+            # Add OVER clause for window function metrics
+            window_config = self._parse_json_field(metric.get("WINDOW"), "window")
+            if window_config and isinstance(window_config, dict):
+                over_parts = []
+                partition_by = window_config.get("partition_by")
+                partition_by_excluding = window_config.get("partition_by_excluding")
+                order_by = window_config.get("order_by")
+
+                if partition_by_excluding and isinstance(partition_by_excluding, list):
+                    cols = [self._resolve_ref_to_column(c) for c in partition_by_excluding]
+                    cols = [c for c in cols if c]
+                    if cols:
+                        over_parts.append(f"PARTITION BY EXCLUDING {', '.join(cols)}")
+                elif partition_by and isinstance(partition_by, list):
+                    cols = [self._resolve_ref_to_column(c) for c in partition_by]
+                    cols = [c for c in cols if c]
+                    if cols:
+                        over_parts.append(f"PARTITION BY {', '.join(cols)}")
+
+                if order_by and isinstance(order_by, list):
+                    order_cols = []
+                    for ob in order_by:
+                        if isinstance(ob, dict):
+                            col = self._resolve_ref_to_column(ob.get("column", ""))
+                            direction = ob.get("direction", "ASC").upper()
+                            if col:
+                                order_cols.append(f"{col} {direction}")
+                        elif isinstance(ob, str):
+                            col = self._resolve_ref_to_column(ob)
+                            if col:
+                                order_cols.append(f"{col} ASC")
+                    if order_cols:
+                        over_parts.append(f"ORDER BY {', '.join(order_cols)}")
+
+                if over_parts:
+                    over_clause = " ".join(over_parts)
+                    metric_def = (
+                        f"    {primary_table}.{metric_name} AS {expression} OVER (\n        {over_clause}\n    )"
+                    )
+
             # Add comment if available
             if metric.get("DESCRIPTION"):
                 description = metric["DESCRIPTION"].replace("'", "''")
@@ -1118,6 +1158,24 @@ class SemanticViewBuilder:
             )
 
         return ",\n".join(metric_definitions)
+
+    @staticmethod
+    def _resolve_ref_to_column(ref_str: str) -> str:
+        """Resolve a {{ ref('table', 'column') }} template to TABLE.COLUMN format."""
+        if not ref_str:
+            return ""
+        ref_pattern = re.compile(r"{{\s*ref\s*\(\s*['\"]([^'\"]+)['\"]\s*,\s*['\"]([^'\"]+)['\"]\s*\)\s*}}")
+        match = ref_pattern.search(str(ref_str))
+        if match:
+            return f"{match.group(1).upper()}.{match.group(2).upper()}"
+        col_pattern = re.compile(r"{{\s*column\s*\(\s*['\"]([^'\"]+)['\"]\s*,\s*['\"]([^'\"]+)['\"]\s*\)\s*}}")
+        match = col_pattern.search(str(ref_str))
+        if match:
+            return f"{match.group(1).upper()}.{match.group(2).upper()}"
+        cleaned = str(ref_str).strip().upper()
+        if "." in cleaned:
+            return cleaned
+        return cleaned
 
     def _build_ca_extension(self, conn, table_names: List[str]) -> str:
         """

--- a/snowflake_semantic_tools/core/generation/semantic_view_builder.py
+++ b/snowflake_semantic_tools/core/generation/semantic_view_builder.py
@@ -1158,7 +1158,8 @@ class SemanticViewBuilder:
             # Add verified_by in contact format
             verified_by = vq.get("VERIFIED_BY")
             if verified_by:
-                parts.append(f"        VERIFIED_BY '(data_quality = {verified_by})'")
+                verified_by_escaped = str(verified_by).replace("'", "''")
+                parts.append(f"        VERIFIED_BY '(data_quality = {verified_by_escaped})'")
 
             parts.append(f"        SQL '{sql}'")
             parts.append("    )")
@@ -1180,6 +1181,8 @@ class SemanticViewBuilder:
             relevant_queries = []
             for row in rows:
                 tables = self._parse_table_list(row.get("TABLES"))
+                if not tables:
+                    continue
                 if self._all_tables_present(tables, normalized_table_names):
                     relevant_queries.append(row)
 

--- a/snowflake_semantic_tools/core/generation/semantic_view_builder.py
+++ b/snowflake_semantic_tools/core/generation/semantic_view_builder.py
@@ -1367,8 +1367,11 @@ class SemanticViewBuilder:
         tag_parts = []
         for k, v in parsed_tags.items():
             if k and v is not None:
+                sanitized_key = re.sub(r"[^A-Za-z0-9_.]", "", str(k))
+                if not sanitized_key:
+                    continue
                 sanitized_value = CharacterSanitizer.sanitize_for_sql_string(str(v))
-                tag_parts.append(f"{k} = '{sanitized_value}'")
+                tag_parts.append(f"{sanitized_key} = '{sanitized_value}'")
         if not tag_parts:
             return ""
         return f"WITH TAG ({', '.join(tag_parts)})"

--- a/snowflake_semantic_tools/core/models/schemas.py
+++ b/snowflake_semantic_tools/core/models/schemas.py
@@ -261,6 +261,11 @@ class SemanticTableSchemas:
                     description="Alternative terms users might use (e.g., 'total revenue' vs 'gross sales')",
                 ),
                 Column("sample_values", ColumnType.ARRAY, description="Example calculated values for reference"),
+                Column(
+                    "non_additive_by",
+                    ColumnType.ARRAY,
+                    description="Semi-additive dimensions: list of {dimension, order, nulls} for NON ADDITIVE BY clause",
+                ),
             ],
         )
 

--- a/snowflake_semantic_tools/core/models/schemas.py
+++ b/snowflake_semantic_tools/core/models/schemas.py
@@ -122,6 +122,11 @@ class SemanticTableSchemas:
                     ColumnType.BOOLEAN,
                     description="Whether to include this table in Cortex Analyst queries",
                 ),
+                Column(
+                    "constraints",
+                    ColumnType.ARRAY,
+                    description="Table constraints (e.g., DISTINCT RANGE for range joins). Preview feature.",
+                ),
             ],
         )
 

--- a/snowflake_semantic_tools/core/models/schemas.py
+++ b/snowflake_semantic_tools/core/models/schemas.py
@@ -275,9 +275,13 @@ class SemanticTableSchemas:
                     "visibility",
                     ColumnType.VARCHAR,
                     description="Visibility control: 'private' hides from end users, 'public' (default) is queryable",
+                ),
+                Column(
                     "non_additive_by",
                     ColumnType.ARRAY,
                     description="Semi-additive dimensions: list of {dimension, order, nulls} for NON ADDITIVE BY clause",
+                ),
+                Column(
                     "using_relationships",
                     ColumnType.ARRAY,
                     description="Relationship names to use for join path disambiguation (USING clause)",

--- a/snowflake_semantic_tools/core/models/schemas.py
+++ b/snowflake_semantic_tools/core/models/schemas.py
@@ -286,6 +286,11 @@ class SemanticTableSchemas:
                     ColumnType.ARRAY,
                     description="Relationship names to use for join path disambiguation (USING clause)",
                 ),
+                Column(
+                    "window",
+                    ColumnType.ARRAY,
+                    description="Window function config: {partition_by, partition_by_excluding, order_by} for OVER clause",
+                ),
             ],
         )
 

--- a/snowflake_semantic_tools/core/models/schemas.py
+++ b/snowflake_semantic_tools/core/models/schemas.py
@@ -261,6 +261,11 @@ class SemanticTableSchemas:
                     description="Alternative terms users might use (e.g., 'total revenue' vs 'gross sales')",
                 ),
                 Column("sample_values", ColumnType.ARRAY, description="Example calculated values for reference"),
+                Column(
+                    "using_relationships",
+                    ColumnType.ARRAY,
+                    description="Relationship names to use for join path disambiguation (USING clause)",
+                ),
             ],
         )
 

--- a/snowflake_semantic_tools/core/models/schemas.py
+++ b/snowflake_semantic_tools/core/models/schemas.py
@@ -212,6 +212,11 @@ class SemanticTableSchemas:
                     description="Alternative terms users might use (e.g., 'revenue' vs 'sales amount')",
                 ),
                 Column("sample_values", ColumnType.ARRAY, description="Example numeric values for reference"),
+                Column(
+                    "visibility",
+                    ColumnType.VARCHAR,
+                    description="Visibility control: 'private' hides from end users, 'public' (default) is queryable",
+                ),
             ],
         )
 
@@ -261,6 +266,11 @@ class SemanticTableSchemas:
                     description="Alternative terms users might use (e.g., 'total revenue' vs 'gross sales')",
                 ),
                 Column("sample_values", ColumnType.ARRAY, description="Example calculated values for reference"),
+                Column(
+                    "visibility",
+                    ColumnType.VARCHAR,
+                    description="Visibility control: 'private' hides from end users, 'public' (default) is queryable",
+                ),
             ],
         )
 

--- a/snowflake_semantic_tools/core/parsing/join_condition_parser.py
+++ b/snowflake_semantic_tools/core/parsing/join_condition_parser.py
@@ -254,6 +254,10 @@ class JoinConditionParser:
             if parsed.operator == "BETWEEN":
                 if not parsed.right_column_end:
                     return False, (f"BETWEEN condition must include AND <end_column> EXCLUSIVE: {condition}")
+                if not parsed.left_table or not parsed.left_column:
+                    return False, f"Could not extract left table/column from: {parsed.left_expression}"
+                if not parsed.right_table or not parsed.right_column:
+                    return False, f"Could not extract right table/column from: {parsed.right_expression}"
                 return True, ""
 
             # Check for unknown join type
@@ -307,7 +311,15 @@ class JoinConditionParser:
         has_range = any(c.condition_type == JoinType.RANGE for c in parsed_conditions)
 
         if has_range:
-            # Range join: left_table (col) REFERENCES right_table (BETWEEN start AND end EXCLUSIVE)
+            non_range = [c for c in parsed_conditions if c.condition_type != JoinType.RANGE]
+            if non_range:
+                from snowflake_semantic_tools.shared import get_logger
+
+                _logger = get_logger("core.parsing.join_condition_parser")
+                _logger.warning(
+                    f"Range join has {len(non_range)} non-range condition(s) that will be ignored. "
+                    f"Snowflake range joins only support a single BETWEEN condition per relationship."
+                )
             range_cond = next(c for c in parsed_conditions if c.condition_type == JoinType.RANGE)
             sql = (
                 f"{left_table_alias} ({range_cond.left_column}) REFERENCES "

--- a/snowflake_semantic_tools/core/parsing/join_condition_parser.py
+++ b/snowflake_semantic_tools/core/parsing/join_condition_parser.py
@@ -41,7 +41,8 @@ class ParsedCondition:
     left_column: str  # Extracted column name from left
     right_table: str  # Extracted table name from right
     right_column: str  # Extracted column name from right
-    operator: str  # = (equality) or >= (ASOF). Note: BETWEEN, <=, >, < are rejected
+    operator: str  # = (equality), >= (ASOF), or BETWEEN (range)
+    right_column_end: str = ""  # End column for BETWEEN...AND...EXCLUSIVE range joins
 
 
 class JoinConditionParser:
@@ -102,6 +103,15 @@ class JoinConditionParser:
             left_table, left_column = cls._extract_table_column_from_resolved(left_expr)
             right_table, right_column = cls._extract_table_column_from_resolved(right_expr)
 
+        # For BETWEEN range joins, extract the end column
+        right_column_end = ""
+        if operator == "BETWEEN":
+            end_expr, _ = cls._extract_range_end(condition)
+            if is_template_format:
+                _, right_column_end = cls._extract_table_column_from_template(end_expr)
+            else:
+                _, right_column_end = cls._extract_table_column_from_resolved(end_expr)
+
         return ParsedCondition(
             join_condition=condition,
             condition_type=condition_type,
@@ -112,6 +122,7 @@ class JoinConditionParser:
             right_table=right_table,
             right_column=right_column,
             operator=operator,
+            right_column_end=right_column_end,
         )
 
     @classmethod
@@ -155,7 +166,7 @@ class JoinConditionParser:
     def _split_on_operator(cls, condition: str, operator: str) -> Tuple[str, str]:
         """Split condition on operator, handling special cases."""
         if operator == "BETWEEN":
-            # Handle BETWEEN x AND y
+            # Handle BETWEEN x AND y [EXCLUSIVE]
             parts = re.split(r"\s+BETWEEN\s+|\s+AND\s+", condition, flags=re.IGNORECASE)
             if len(parts) >= 2:
                 return parts[0], parts[1]  # Return first two parts
@@ -167,6 +178,15 @@ class JoinConditionParser:
 
         # Fallback
         return condition, ""
+
+    @classmethod
+    def _extract_range_end(cls, condition: str) -> Tuple[str, str]:
+        """Extract the end column from a BETWEEN...AND...EXCLUSIVE condition."""
+        parts = re.split(r"\s+BETWEEN\s+|\s+AND\s+", condition, flags=re.IGNORECASE)
+        if len(parts) >= 3:
+            end_expr = re.sub(r"\s+EXCLUSIVE\s*$", "", parts[2], flags=re.IGNORECASE).strip()
+            return end_expr, end_expr
+        return "", ""
 
     @classmethod
     def _extract_table_column_from_template(cls, expression: str) -> Tuple[str, str]:
@@ -230,13 +250,11 @@ class JoinConditionParser:
                     f"See: https://docs.snowflake.com/en/user-guide/views-semantic/sql"
                 )
 
-            # Reject BETWEEN operator - not supported in semantic view relationships
+            # BETWEEN operator is valid for range joins (preview feature)
             if parsed.operator == "BETWEEN":
-                return False, (
-                    f"BETWEEN operator is not supported in Snowflake semantic view relationships. "
-                    f"Only equality (=) and ASOF (>=) joins are supported. "
-                    f"See: https://docs.snowflake.com/en/user-guide/views-semantic/sql"
-                )
+                if not parsed.right_column_end:
+                    return False, (f"BETWEEN condition must include AND <end_column> EXCLUSIVE: {condition}")
+                return True, ""
 
             # Check for unknown join type
             if parsed.condition_type == JoinType.UNKNOWN:
@@ -284,6 +302,18 @@ class JoinConditionParser:
 
         # Build left column list (all conditions in original order)
         left_cols = [c.left_column for c in parsed_conditions]
+
+        # Check if any condition is a range join
+        has_range = any(c.condition_type == JoinType.RANGE for c in parsed_conditions)
+
+        if has_range:
+            # Range join: left_table (col) REFERENCES right_table (BETWEEN start AND end EXCLUSIVE)
+            range_cond = next(c for c in parsed_conditions if c.condition_type == JoinType.RANGE)
+            sql = (
+                f"{left_table_alias} ({range_cond.left_column}) REFERENCES "
+                f"{right_table_alias} (BETWEEN {range_cond.right_column} AND {range_cond.right_column_end} EXCLUSIVE)"
+            )
+            return sql
 
         # Build right column list maintaining same order as left
         # ASOF columns get the ASOF prefix, equality columns are unchanged

--- a/snowflake_semantic_tools/core/parsing/parsers/data_extractors.py
+++ b/snowflake_semantic_tools/core/parsing/parsers/data_extractors.py
@@ -181,6 +181,7 @@ def extract_table_info(
             "model_name": name,  # Store the original model name
             "source_file": str(file_path),  # Store the file path for validation errors
             "cortex_searchable": sst_meta.get("cortex_searchable", False),
+            "tags": sst_meta.get("tags"),
         }
 
         return table_record
@@ -305,6 +306,7 @@ def extract_column_info(column: Dict[str, Any], table_name: str, file_path: Path
             "synonyms": sst_meta.get("synonyms", []),
             "sample_values": sst_meta.get("sample_values", []),
             "is_enum": sst_meta.get("is_enum", False),
+            "tags": sst_meta.get("tags"),
             "source_file": str(file_path),  # Store the file path for validation errors
         }
 

--- a/snowflake_semantic_tools/core/parsing/parsers/data_extractors.py
+++ b/snowflake_semantic_tools/core/parsing/parsers/data_extractors.py
@@ -128,7 +128,7 @@ def extract_table_info(
 
         # Extract unique keys and apply upper case formatting
         unique_keys = extract_unique_keys(sst_meta)
-        unique_keys_upper = [uk.upper() if isinstance(uk, str) else uk for uk in unique_keys]
+        unique_keys_upper = [[c.upper() for c in uk] if isinstance(uk, list) else uk.upper() for uk in unique_keys]
 
         # Database and Schema Resolution:
         # ONLY source: manifest.json (dbt's compiled output)
@@ -245,8 +245,13 @@ def extract_unique_keys(sst_meta: Dict[str, Any]) -> List[str]:
             else:
                 return [uk_from_sst.strip()]
         elif isinstance(uk_from_sst, list):
-            # Ensure each item is stripped of whitespace
-            return [str(key).strip() for key in uk_from_sst]
+            result = []
+            for key in uk_from_sst:
+                if isinstance(key, list):
+                    result.append([str(k).strip() for k in key])
+                else:
+                    result.append(str(key).strip())
+            return result
     return []
 
 

--- a/snowflake_semantic_tools/core/parsing/parsers/data_extractors.py
+++ b/snowflake_semantic_tools/core/parsing/parsers/data_extractors.py
@@ -177,6 +177,7 @@ def extract_table_info(
             "description": description,
             "primary_key": primary_keys_upper,
             "unique_keys": unique_keys_upper,
+            "constraints": sst_meta.get("constraints", []),
             "synonyms": sst_meta.get("synonyms", []),
             "model_name": name,  # Store the original model name
             "source_file": str(file_path),  # Store the file path for validation errors

--- a/snowflake_semantic_tools/core/parsing/parsers/data_extractors.py
+++ b/snowflake_semantic_tools/core/parsing/parsers/data_extractors.py
@@ -305,6 +305,7 @@ def extract_column_info(column: Dict[str, Any], table_name: str, file_path: Path
             "synonyms": sst_meta.get("synonyms", []),
             "sample_values": sst_meta.get("sample_values", []),
             "is_enum": sst_meta.get("is_enum", False),
+            "visibility": sst_meta.get("visibility"),
             "source_file": str(file_path),  # Store the file path for validation errors
         }
 

--- a/snowflake_semantic_tools/core/parsing/parsers/semantic_parser.py
+++ b/snowflake_semantic_tools/core/parsing/parsers/semantic_parser.py
@@ -133,10 +133,11 @@ def parse_snowflake_metrics(metrics: List[Dict[str, Any]], file_path: Path) -> L
                 "expr": metric.get("expr", ""),
                 "synonyms": metric.get("synonyms", []),
                 "sample_values": metric.get("sample_values", []),
+                "visibility": metric.get("visibility"),
                 "non_additive_by": metric.get("non_additive_by", []),
                 "using_relationships": metric.get("using_relationships", []),
                 "window": metric.get("window"),
-                "source_file": str(file_path),  # Store the file path for validation errors
+                "source_file": str(file_path),
             }
             metric_records.append(metric_record)
 

--- a/snowflake_semantic_tools/core/parsing/parsers/semantic_parser.py
+++ b/snowflake_semantic_tools/core/parsing/parsers/semantic_parser.py
@@ -133,6 +133,7 @@ def parse_snowflake_metrics(metrics: List[Dict[str, Any]], file_path: Path) -> L
                 "expr": metric.get("expr", ""),
                 "synonyms": metric.get("synonyms", []),
                 "sample_values": metric.get("sample_values", []),
+                "non_additive_by": metric.get("non_additive_by", []),
                 "source_file": str(file_path),  # Store the file path for validation errors
             }
             metric_records.append(metric_record)

--- a/snowflake_semantic_tools/core/parsing/parsers/semantic_parser.py
+++ b/snowflake_semantic_tools/core/parsing/parsers/semantic_parser.py
@@ -342,17 +342,24 @@ def parse_snowflake_verified_queries(queries: List[Dict[str, Any]], file_path: P
 
     for query in queries:
         try:
-            # Keep tables as list for verified queries since they might reference multiple tables
+            sql = query.get("sql", "")
+            sql_file = query.get("sql_file", "")
+            if sql_file and not sql:
+                sql_file_path = file_path.parent / sql_file
+                if sql_file_path.exists():
+                    sql = sql_file_path.read_text().strip()
+                else:
+                    logger.warning(f"sql_file '{sql_file}' not found relative to {file_path}")
+
             query_record = {
                 "name": query.get("name", "").upper(),
                 "question": query.get("question", ""),
                 "tables": query.get("tables", []),
                 "verified_at": query.get("verified_at", ""),
                 "verified_by": query.get("verified_by", ""),
-                "sql": query.get("sql", ""),
-                "source_file": str(file_path),  # Store the file path for validation errors
+                "sql": sql,
+                "source_file": str(file_path),
             }
-            # Only include onboarding fields if they are present in the source
             if "use_as_onboarding_question" in query:
                 query_record["use_as_onboarding_question"] = query["use_as_onboarding_question"]
             if "use_as_onboarding" in query:

--- a/snowflake_semantic_tools/core/parsing/parsers/semantic_parser.py
+++ b/snowflake_semantic_tools/core/parsing/parsers/semantic_parser.py
@@ -133,6 +133,7 @@ def parse_snowflake_metrics(metrics: List[Dict[str, Any]], file_path: Path) -> L
                 "expr": metric.get("expr", ""),
                 "synonyms": metric.get("synonyms", []),
                 "sample_values": metric.get("sample_values", []),
+                "using_relationships": metric.get("using_relationships", []),
                 "source_file": str(file_path),  # Store the file path for validation errors
             }
             metric_records.append(metric_record)

--- a/snowflake_semantic_tools/core/parsing/parsers/semantic_parser.py
+++ b/snowflake_semantic_tools/core/parsing/parsers/semantic_parser.py
@@ -133,6 +133,7 @@ def parse_snowflake_metrics(metrics: List[Dict[str, Any]], file_path: Path) -> L
                 "expr": metric.get("expr", ""),
                 "synonyms": metric.get("synonyms", []),
                 "sample_values": metric.get("sample_values", []),
+                "window": metric.get("window"),
                 "source_file": str(file_path),  # Store the file path for validation errors
             }
             metric_records.append(metric_record)

--- a/snowflake_semantic_tools/core/validation/rules/dbt_models.py
+++ b/snowflake_semantic_tools/core/validation/rules/dbt_models.py
@@ -240,6 +240,15 @@ class DbtModelValidator:
         # Check for best practices
         self._check_table_best_practices(table, table_name, result)
 
+        # Validate constraints (DISTINCT RANGE)
+        self._check_constraints(table, table_name, dimensions, facts, time_dimensions, result)
+
+        # Validate tags
+        if table.get("tags"):
+            from snowflake_semantic_tools.core.validation.rules.semantic_models import SemanticModelValidator
+            validator = SemanticModelValidator()
+            validator._validate_tags(table["tags"], f"Table '{table_name}'", table.get("source_file"), result)
+
         # Validate columns
         all_columns = dimensions + facts + time_dimensions
         table_columns = [c for c in all_columns if c.get("table_name", "").upper() == table_name.upper()]
@@ -407,6 +416,63 @@ class DbtModelValidator:
                 file_path=source_file,
                 context={"table": table_name, "model_name": model_name, "level": "table"},
             )
+
+    def _check_constraints(
+        self,
+        table: Dict[str, Any],
+        table_name: str,
+        dimensions: List[Dict[str, Any]],
+        facts: List[Dict[str, Any]],
+        time_dimensions: List[Dict[str, Any]],
+        result: ValidationResult,
+    ):
+        constraints = table.get("constraints", [])
+        if not constraints:
+            return
+        source_file = table.get("source_file")
+        all_columns = dimensions + facts + time_dimensions
+        table_col_names = {
+            c.get("column_name", "").upper()
+            for c in all_columns
+            if c.get("table_name", "").upper() == table_name.upper()
+        }
+        for constraint in constraints:
+            if not isinstance(constraint, dict):
+                continue
+            if constraint.get("type") == "distinct_range":
+                start_col = constraint.get("start_column", "").upper()
+                end_col = constraint.get("end_column", "").upper()
+                c_name = constraint.get("name", "unnamed")
+                if not start_col:
+                    result.add_error(
+                        f"Table '{table_name}' constraint '{c_name}' missing required 'start_column'",
+                        file_path=source_file,
+                        context={"table": table_name, "constraint": c_name},
+                    )
+                elif table_col_names and start_col not in table_col_names:
+                    result.add_warning(
+                        f"Table '{table_name}' constraint '{c_name}' start_column '{start_col}' not found in table columns",
+                        file_path=source_file,
+                        context={"table": table_name, "constraint": c_name, "column": start_col},
+                    )
+                if not end_col:
+                    result.add_error(
+                        f"Table '{table_name}' constraint '{c_name}' missing required 'end_column'",
+                        file_path=source_file,
+                        context={"table": table_name, "constraint": c_name},
+                    )
+                elif table_col_names and end_col not in table_col_names:
+                    result.add_warning(
+                        f"Table '{table_name}' constraint '{c_name}' end_column '{end_col}' not found in table columns",
+                        file_path=source_file,
+                        context={"table": table_name, "constraint": c_name, "column": end_col},
+                    )
+                if start_col and end_col and start_col == end_col:
+                    result.add_error(
+                        f"Table '{table_name}' constraint '{c_name}' start_column and end_column cannot be the same",
+                        file_path=source_file,
+                        context={"table": table_name, "constraint": c_name},
+                    )
 
     def _validate_column(self, column: Dict[str, Any], table_name: str, result: ValidationResult):
         """Validate a single column."""

--- a/snowflake_semantic_tools/core/validation/rules/dbt_models.py
+++ b/snowflake_semantic_tools/core/validation/rules/dbt_models.py
@@ -246,6 +246,7 @@ class DbtModelValidator:
         # Validate tags
         if table.get("tags"):
             from snowflake_semantic_tools.core.validation.rules.semantic_models import SemanticModelValidator
+
             validator = SemanticModelValidator()
             validator._validate_tags(table["tags"], f"Table '{table_name}'", table.get("source_file"), result)
 

--- a/snowflake_semantic_tools/core/validation/rules/dbt_models.py
+++ b/snowflake_semantic_tools/core/validation/rules/dbt_models.py
@@ -480,6 +480,22 @@ class DbtModelValidator:
                 context={"table": table_name, "column": column_name, "field": "description", "level": "column"},
             )
 
+        # Visibility validation: only facts and metrics can be private
+        visibility = column.get("visibility")
+        if visibility:
+            if visibility.lower() not in ("public", "private"):
+                result.add_error(
+                    f"Column '{column_name}' in table '{table_name}' has invalid visibility: '{visibility}'. Must be 'public' or 'private'",
+                    file_path=source_file,
+                    context={"table": table_name, "column": column_name, "field": "visibility", "level": "column"},
+                )
+            elif visibility.lower() == "private" and column_type in ("dimension", "time_dimension"):
+                result.add_error(
+                    f"Column '{column_name}' in table '{table_name}' cannot be PRIVATE: only facts and metrics support visibility control (Snowflake restriction)",
+                    file_path=source_file,
+                    context={"table": table_name, "column": column_name, "field": "visibility", "level": "column"},
+                )
+
     def _determine_column_type(self, column: Dict[str, Any]) -> str:
         """Get the column type from metadata (no longer defaults or infers)."""
         # Column type must be explicitly set now - no defaults

--- a/snowflake_semantic_tools/core/validation/rules/references.py
+++ b/snowflake_semantic_tools/core/validation/rules/references.py
@@ -166,7 +166,7 @@ class ReferenceValidator:
                 using_rels = metric.get("using_relationships", [])
                 if using_rels and isinstance(using_rels, list):
                     all_relationship_names = set()
-                    rel_data = self._semantic_data.get("relationships", {}) if hasattr(self, '_semantic_data') else {}
+                    rel_data = self._semantic_data.get("relationships", {}) if hasattr(self, "_semantic_data") else {}
                     rel_items = rel_data.get("items", []) if isinstance(rel_data, dict) else []
                     for rel in rel_items:
                         if isinstance(rel, dict):
@@ -174,7 +174,11 @@ class ReferenceValidator:
                             if rn:
                                 all_relationship_names.add(rn.upper())
                     for rel_name in using_rels:
-                        if isinstance(rel_name, str) and rel_name.upper() not in all_relationship_names and all_relationship_names:
+                        if (
+                            isinstance(rel_name, str)
+                            and rel_name.upper() not in all_relationship_names
+                            and all_relationship_names
+                        ):
                             result.add_warning(
                                 f"Metric '{name}' references relationship '{rel_name}' in using_relationships which was not found in defined relationships",
                                 file_path=source_file,

--- a/snowflake_semantic_tools/core/validation/rules/references.py
+++ b/snowflake_semantic_tools/core/validation/rules/references.py
@@ -57,6 +57,7 @@ class ReferenceValidator:
             ValidationResult with reference issues
         """
         result = ValidationResult()
+        self._semantic_data = semantic_data
 
         # Validate metrics
         metrics_data = semantic_data.get("metrics", {})
@@ -161,6 +162,24 @@ class ReferenceValidator:
                     self._validate_column_references_in_expr(
                         name, expr, tables, dbt_catalog, result, "Metric", source_file
                     )
+
+                using_rels = metric.get("using_relationships", [])
+                if using_rels and isinstance(using_rels, list):
+                    all_relationship_names = set()
+                    rel_data = self._semantic_data.get("relationships", {}) if hasattr(self, '_semantic_data') else {}
+                    rel_items = rel_data.get("items", []) if isinstance(rel_data, dict) else []
+                    for rel in rel_items:
+                        if isinstance(rel, dict):
+                            rn = rel.get("name") or rel.get("relationship_name", "")
+                            if rn:
+                                all_relationship_names.add(rn.upper())
+                    for rel_name in using_rels:
+                        if isinstance(rel_name, str) and rel_name.upper() not in all_relationship_names and all_relationship_names:
+                            result.add_warning(
+                                f"Metric '{name}' references relationship '{rel_name}' in using_relationships which was not found in defined relationships",
+                                file_path=source_file,
+                                context={"metric": name, "relationship": rel_name},
+                            )
 
     def _validate_relationship_references(self, relationships_data: Dict, dbt_catalog: Dict, result: ValidationResult):
         """Validate table and column references in relationships."""

--- a/snowflake_semantic_tools/core/validation/rules/semantic_models.py
+++ b/snowflake_semantic_tools/core/validation/rules/semantic_models.py
@@ -70,6 +70,15 @@ class SemanticModelValidator:
 
         if "filters" in semantic_data:
             self._validate_filters(semantic_data["filters"], result)
+            filter_items = semantic_data["filters"].get("items", [])
+            if filter_items:
+                result.add_warning(
+                    "snowflake_filters is deprecated and will be removed in a future major version. "
+                    "Filters are auto-converted to AI_SQL_GENERATION instructions at generation time, "
+                    "but for full control over instruction wording, migrate to snowflake_custom_instructions "
+                    "with sql_generation text.",
+                    context={"type": "DEPRECATION"},
+                )
 
         if "custom_instructions" in semantic_data:
             self._validate_custom_instructions(semantic_data["custom_instructions"], result)

--- a/snowflake_semantic_tools/core/validation/rules/semantic_models.py
+++ b/snowflake_semantic_tools/core/validation/rules/semantic_models.py
@@ -588,6 +588,7 @@ class SemanticModelValidator:
                 sql_file_path = query["sql_file"]
                 if source_file:
                     from pathlib import Path
+
                     resolved = Path(source_file).parent / sql_file_path
                     if not resolved.exists():
                         result.add_error(
@@ -1301,6 +1302,7 @@ class SemanticModelValidator:
 
     def _validate_tags(self, tags: Any, context_name: str, source_file: Optional[str], result: ValidationResult):
         import re
+
         if not isinstance(tags, dict):
             result.add_error(
                 f"{context_name} 'tags' must be a mapping of tag_name: tag_value",
@@ -1312,6 +1314,14 @@ class SemanticModelValidator:
             if not re.match(r"^[A-Za-z_][A-Za-z0-9_.]*$", str(key)):
                 result.add_error(
                     f"{context_name} tag name '{key}' is not a valid identifier (must be alphanumeric/underscores/dots, starting with letter or underscore)",
+                    file_path=source_file,
+                    context={"type": "tags", "tag_name": str(key)},
+                )
+            elif "." not in str(key):
+                result.add_warning(
+                    f"{context_name} tag '{key}' is not fully-qualified. "
+                    f"Snowflake requires tags to reference existing tag objects "
+                    f"(e.g., 'DB.SCHEMA.TAG_NAME')",
                     file_path=source_file,
                     context={"type": "tags", "tag_name": str(key)},
                 )

--- a/snowflake_semantic_tools/core/validation/rules/semantic_models.py
+++ b/snowflake_semantic_tools/core/validation/rules/semantic_models.py
@@ -174,6 +174,70 @@ class SemanticModelValidator:
                     context={"metric": metric_name, "field": "synonyms", "type": "metric"},
                 )
 
+            if "non_additive_by" in metric and metric["non_additive_by"]:
+                nab = metric["non_additive_by"]
+                if not isinstance(nab, list):
+                    result.add_error(
+                        f"Metric '{metric_name}' field 'non_additive_by' must be a list of dimension configs",
+                        file_path=source_file,
+                        context={"metric": metric_name, "field": "non_additive_by", "type": "metric"},
+                    )
+                else:
+                    for item in nab:
+                        if isinstance(item, dict):
+                            if not item.get("dimension"):
+                                result.add_error(
+                                    f"Metric '{metric_name}' non_additive_by entry missing required 'dimension' field",
+                                    file_path=source_file,
+                                    context={"metric": metric_name, "type": "metric"},
+                                )
+                            order = item.get("order", "ASC").upper()
+                            if order not in ("ASC", "DESC"):
+                                result.add_error(
+                                    f"Metric '{metric_name}' non_additive_by order must be ASC or DESC, got '{order}'",
+                                    file_path=source_file,
+                                    context={"metric": metric_name, "type": "metric"},
+                                )
+
+            if "using_relationships" in metric and metric["using_relationships"]:
+                using = metric["using_relationships"]
+                if not isinstance(using, list):
+                    result.add_error(
+                        f"Metric '{metric_name}' field 'using_relationships' must be a list of relationship names",
+                        file_path=source_file,
+                        context={"metric": metric_name, "field": "using_relationships", "type": "metric"},
+                    )
+
+            if "window" in metric and metric["window"]:
+                window = metric["window"]
+                if not isinstance(window, dict):
+                    result.add_error(
+                        f"Metric '{metric_name}' field 'window' must be a dict with partition_by/partition_by_excluding/order_by",
+                        file_path=source_file,
+                        context={"metric": metric_name, "field": "window", "type": "metric"},
+                    )
+                else:
+                    has_pb = bool(window.get("partition_by"))
+                    has_pbe = bool(window.get("partition_by_excluding"))
+                    if has_pb and has_pbe:
+                        result.add_error(
+                            f"Metric '{metric_name}' window config specifies both 'partition_by' and 'partition_by_excluding' — use exactly one",
+                            file_path=source_file,
+                            context={"metric": metric_name, "field": "window", "type": "metric"},
+                        )
+
+            if "visibility" in metric:
+                vis = metric["visibility"]
+                if vis and vis.lower() not in ("private", "public"):
+                    result.add_error(
+                        f"Metric '{metric_name}' visibility must be 'private' or 'public', got '{vis}'",
+                        file_path=source_file,
+                        context={"metric": metric_name, "field": "visibility", "type": "metric"},
+                    )
+
+            if "tags" in metric and metric["tags"]:
+                self._validate_tags(metric["tags"], f"Metric '{metric_name}'", source_file, result)
+
     def _validate_relationships(self, relationships_data: Dict, result: ValidationResult):
         """Validate relationship definitions."""
         items = relationships_data.get("items", [])
@@ -505,7 +569,32 @@ class SemanticModelValidator:
             # Required fields
             self._check_required_field(query, "name", query_name, "verified_query", source_file, result)
             self._check_required_field(query, "question", query_name, "verified_query", source_file, result)
-            self._check_required_field(query, "sql", query_name, "verified_query", source_file, result)
+
+            has_sql = bool(query.get("sql"))
+            has_sql_file = bool(query.get("sql_file"))
+            if has_sql and has_sql_file:
+                result.add_error(
+                    f"Verified query '{query_name}' specifies both 'sql' and 'sql_file' — use exactly one",
+                    file_path=source_file,
+                    context={"verified_query": query_name, "type": "verified_query"},
+                )
+            elif not has_sql and not has_sql_file:
+                result.add_error(
+                    f"Verified query '{query_name}' is missing required field: sql (or sql_file)",
+                    file_path=source_file,
+                    context={"verified_query": query_name, "field": "sql", "type": "verified_query"},
+                )
+            elif has_sql_file:
+                sql_file_path = query["sql_file"]
+                if source_file:
+                    from pathlib import Path
+                    resolved = Path(source_file).parent / sql_file_path
+                    if not resolved.exists():
+                        result.add_error(
+                            f"Verified query '{query_name}' references sql_file '{sql_file_path}' which does not exist (resolved to {resolved})",
+                            file_path=source_file,
+                            context={"verified_query": query_name, "field": "sql_file", "type": "verified_query"},
+                        )
 
             # Validate identifier (length, characters, reserved keywords)
             self._validate_identifier(query_name, "Verified query", result, source_file=source_file)
@@ -1209,6 +1298,30 @@ class SemanticModelValidator:
                     "type": "verified_query",
                 },
             )
+
+    def _validate_tags(self, tags: Any, context_name: str, source_file: Optional[str], result: ValidationResult):
+        import re
+        if not isinstance(tags, dict):
+            result.add_error(
+                f"{context_name} 'tags' must be a mapping of tag_name: tag_value",
+                file_path=source_file,
+                context={"type": "tags"},
+            )
+            return
+        for key, value in tags.items():
+            if not re.match(r"^[A-Za-z_][A-Za-z0-9_.]*$", str(key)):
+                result.add_error(
+                    f"{context_name} tag name '{key}' is not a valid identifier (must be alphanumeric/underscores/dots, starting with letter or underscore)",
+                    file_path=source_file,
+                    context={"type": "tags", "tag_name": str(key)},
+                )
+            value_str = str(value)
+            if len(value_str) > 256:
+                result.add_error(
+                    f"{context_name} tag '{key}' value exceeds 256 characters ({len(value_str)} chars)",
+                    file_path=source_file,
+                    context={"type": "tags", "tag_name": str(key), "value_length": len(value_str)},
+                )
 
     def _check_duplicate_names(self, items: List[Dict], entity_type: str, result: ValidationResult):
         """

--- a/snowflake_semantic_tools/infrastructure/snowflake/data_loader.py
+++ b/snowflake_semantic_tools/infrastructure/snowflake/data_loader.py
@@ -657,8 +657,8 @@ class DataLoader:
                             return str(obj)
 
                     for col in df.columns:
-                        if col in ["sample_values", "synonyms", "primary_key", "unique_keys", "foreign_keys"]:
-                            # Convert lists/arrays to JSON strings
+                        if col in ["sample_values", "synonyms", "primary_key", "unique_keys", "foreign_keys",
+                                   "non_additive_by", "using_relationships", "window"]:
                             df[col] = df[col].apply(safe_json_dumps)
 
                     # Add sm_ prefix if not already present

--- a/snowflake_semantic_tools/infrastructure/snowflake/data_loader.py
+++ b/snowflake_semantic_tools/infrastructure/snowflake/data_loader.py
@@ -657,8 +657,16 @@ class DataLoader:
                             return str(obj)
 
                     for col in df.columns:
-                        if col in ["sample_values", "synonyms", "primary_key", "unique_keys", "foreign_keys",
-                                   "non_additive_by", "using_relationships", "window"]:
+                        if col in [
+                            "sample_values",
+                            "synonyms",
+                            "primary_key",
+                            "unique_keys",
+                            "foreign_keys",
+                            "non_additive_by",
+                            "using_relationships",
+                            "window",
+                        ]:
                             df[col] = df[col].apply(safe_json_dumps)
 
                     # Add sm_ prefix if not already present

--- a/snowflake_semantic_tools/shared/config.py
+++ b/snowflake_semantic_tools/shared/config.py
@@ -76,6 +76,9 @@ class Config:
                 "state_path": None,  # Path to state artifacts directory
                 "auto_compile": False,  # Auto-compile manifest if not found (dbt Core only)
             },
+            "generation": {
+                "filters_to_instructions": True,  # Convert filters to AI_SQL_GENERATION instructions
+            },
             "logging": {"level": "INFO", "format": "%(asctime)s - %(name)s - %(levelname)s - %(message)s"},
         }
 

--- a/tests/unit/core/enrichment/test_metadata_enricher.py
+++ b/tests/unit/core/enrichment/test_metadata_enricher.py
@@ -127,7 +127,9 @@ class TestEnrichColumnTypes:
     def test_enrich_column_types_both(self, enricher):
         """Both types set when both components requested."""
         column_sst = {}
-        enricher._enrich_column_types(column_sst, "test_col", "VARCHAR(100)", {}, components=["data-types", "column-types"])
+        enricher._enrich_column_types(
+            column_sst, "test_col", "VARCHAR(100)", {}, components=["data-types", "column-types"]
+        )
         assert column_sst["data_type"] == "TEXT"  # Snowflake type mapping
         assert column_sst["column_type"] == "dimension"
 
@@ -141,7 +143,9 @@ class TestEnrichColumnTypes:
     def test_enrich_column_types_preserves_existing(self, enricher):
         """Existing values are preserved even when component is requested."""
         column_sst = {"data_type": "text", "column_type": "fact"}
-        enricher._enrich_column_types(column_sst, "test_col", "VARCHAR(100)", {}, components=["data-types", "column-types"])
+        enricher._enrich_column_types(
+            column_sst, "test_col", "VARCHAR(100)", {}, components=["data-types", "column-types"]
+        )
         # Should preserve existing values
         assert column_sst["data_type"] == "text"
         assert column_sst["column_type"] == "fact"
@@ -151,9 +155,7 @@ class TestEnrichColumnTypes:
         column_sst = {}  # No existing SST data_type
         column = {"data_type": "NUMBER"}  # Native dbt contract on the column
 
-        enricher._enrich_column_types(
-            column_sst, "price", "VARCHAR(100)", column, components=["data-types"]
-        )
+        enricher._enrich_column_types(column_sst, "price", "VARCHAR(100)", column, components=["data-types"])
 
         # data_type should NOT be overwritten by Snowflake-mapped TEXT
         assert "data_type" not in column_sst

--- a/tests/unit/core/generation/test_semantic_view_builder.py
+++ b/tests/unit/core/generation/test_semantic_view_builder.py
@@ -958,5 +958,123 @@ class TestTableNotFoundErrorFormatting:
         assert "Original error:" in result
 
 
+class TestVisibility:
+    """Test cases for PRIVATE/PUBLIC visibility on facts and metrics."""
+
+    @pytest.fixture
+    def builder(self):
+        """Create a SemanticViewBuilder instance for testing."""
+        config = SnowflakeConfig(
+            account="test",
+            user="test",
+            password="test",
+            role="test",
+            warehouse="test",
+            database="test_db",
+            schema="test_schema",
+        )
+        return SemanticViewBuilder(config)
+
+    def test_private_fact_emits_keyword(self, builder, monkeypatch):
+        """Test that a private fact emits PRIVATE keyword in DDL."""
+
+        def mock_get_facts(conn, table_name):
+            return [
+                {
+                    "NAME": "raw_discount",
+                    "EXPR": "RAW_DISCOUNT",
+                    "DESCRIPTION": "Internal discount",
+                    "SYNONYMS": None,
+                    "VISIBILITY": "private",
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        monkeypatch.setattr(builder, "_get_facts", mock_get_facts)
+
+        result = builder._build_facts_clause(None, ["orders"])
+
+        assert "PRIVATE ORDERS.RAW_DISCOUNT AS RAW_DISCOUNT" in result
+
+    def test_public_fact_no_keyword(self, builder, monkeypatch):
+        """Test that a public fact does not emit visibility keyword."""
+
+        def mock_get_facts(conn, table_name):
+            return [
+                {
+                    "NAME": "amount",
+                    "EXPR": "AMOUNT",
+                    "DESCRIPTION": "Order amount",
+                    "SYNONYMS": None,
+                    "VISIBILITY": "public",
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        monkeypatch.setattr(builder, "_get_facts", mock_get_facts)
+
+        result = builder._build_facts_clause(None, ["orders"])
+
+        assert "PRIVATE" not in result
+        assert "PUBLIC" not in result
+        assert "ORDERS.AMOUNT AS AMOUNT" in result
+
+    def test_null_visibility_no_keyword(self, builder, monkeypatch):
+        """Test that null visibility does not emit any keyword."""
+
+        def mock_get_facts(conn, table_name):
+            return [
+                {
+                    "NAME": "quantity",
+                    "EXPR": "QUANTITY",
+                    "DESCRIPTION": "Quantity",
+                    "SYNONYMS": None,
+                    "VISIBILITY": None,
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        monkeypatch.setattr(builder, "_get_facts", mock_get_facts)
+
+        result = builder._build_facts_clause(None, ["orders"])
+
+        assert "PRIVATE" not in result
+        assert "ORDERS.QUANTITY AS QUANTITY" in result
+
+    def test_private_metric_emits_keyword(self, builder, monkeypatch):
+        """Test that a private metric emits PRIVATE keyword in DDL."""
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "INTERMEDIATE_SUM",
+                    "EXPR": "SUM(ORDERS.AMOUNT)",
+                    "DESCRIPTION": "Internal intermediate calc",
+                    "TABLE_NAME": '["orders"]',
+                    "SYNONYMS": None,
+                    "VISIBILITY": "private",
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        def mock_get_dims(conn, t):
+            return []
+
+        def mock_get_facts(conn, t):
+            return []
+
+        def mock_get_time_dims(conn, t):
+            return []
+
+        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
+        monkeypatch.setattr(builder, "_get_dimensions", mock_get_dims)
+        monkeypatch.setattr(builder, "_get_facts", mock_get_facts)
+        monkeypatch.setattr(builder, "_get_time_dimensions", mock_get_time_dims)
+
+        result = builder._build_metrics_clause(None, ["orders"])
+
+        assert "PRIVATE ORDERS.INTERMEDIATE_SUM AS SUM(ORDERS.AMOUNT)" in result
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/core/generation/test_semantic_view_builder.py
+++ b/tests/unit/core/generation/test_semantic_view_builder.py
@@ -958,5 +958,110 @@ class TestTableNotFoundErrorFormatting:
         assert "Original error:" in result
 
 
+class TestNonAdditiveBy:
+    """Test cases for NON ADDITIVE BY clause on metrics."""
+
+    @pytest.fixture
+    def builder(self):
+        """Create a SemanticViewBuilder instance for testing."""
+        config = SnowflakeConfig(
+            account="test",
+            user="test",
+            password="test",
+            role="test",
+            warehouse="test",
+            database="test_db",
+            schema="test_schema",
+        )
+        return SemanticViewBuilder(config)
+
+    def test_non_additive_by_emitted(self, builder, monkeypatch):
+        """Test that NON ADDITIVE BY clause is emitted for semi-additive metrics."""
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "CURRENT_BALANCE",
+                    "EXPR": "BALANCE",
+                    "DESCRIPTION": "Account balance",
+                    "TABLE_NAME": '["accounts"]',
+                    "SYNONYMS": None,
+                    "NON_ADDITIVE_BY": '[{"dimension": "snapshot_date", "order": "DESC", "nulls": "LAST"}]',
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        def mock_noop(conn, t):
+            return []
+
+        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
+        monkeypatch.setattr(builder, "_get_dimensions", mock_noop)
+        monkeypatch.setattr(builder, "_get_facts", mock_noop)
+        monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
+
+        result = builder._build_metrics_clause(None, ["accounts"])
+
+        assert "NON ADDITIVE BY (SNAPSHOT_DATE DESC NULLS LAST)" in result
+        assert "AS BALANCE" in result
+
+    def test_non_additive_by_without_nulls(self, builder, monkeypatch):
+        """Test NON ADDITIVE BY with only dimension and order."""
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "HEADCOUNT",
+                    "EXPR": "HEAD_COUNT",
+                    "DESCRIPTION": "Headcount",
+                    "TABLE_NAME": '["hr_snapshots"]',
+                    "SYNONYMS": None,
+                    "NON_ADDITIVE_BY": '[{"dimension": "snapshot_date", "order": "DESC"}]',
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        def mock_noop(conn, t):
+            return []
+
+        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
+        monkeypatch.setattr(builder, "_get_dimensions", mock_noop)
+        monkeypatch.setattr(builder, "_get_facts", mock_noop)
+        monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
+
+        result = builder._build_metrics_clause(None, ["hr_snapshots"])
+
+        assert "NON ADDITIVE BY (SNAPSHOT_DATE DESC)" in result
+        assert "NULLS" not in result
+
+    def test_no_non_additive_by(self, builder, monkeypatch):
+        """Test that metrics without non_additive_by don't emit the clause."""
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "TOTAL_REVENUE",
+                    "EXPR": "SUM(ORDERS.AMOUNT)",
+                    "DESCRIPTION": "Total revenue",
+                    "TABLE_NAME": '["orders"]',
+                    "SYNONYMS": None,
+                    "NON_ADDITIVE_BY": None,
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        def mock_noop(conn, t):
+            return []
+
+        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
+        monkeypatch.setattr(builder, "_get_dimensions", mock_noop)
+        monkeypatch.setattr(builder, "_get_facts", mock_noop)
+        monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
+
+        result = builder._build_metrics_clause(None, ["orders"])
+
+        assert "NON ADDITIVE BY" not in result
+        assert "ORDERS.TOTAL_REVENUE AS SUM(ORDERS.AMOUNT)" in result
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/core/generation/test_semantic_view_builder.py
+++ b/tests/unit/core/generation/test_semantic_view_builder.py
@@ -958,5 +958,125 @@ class TestTableNotFoundErrorFormatting:
         assert "Original error:" in result
 
 
+class TestFactSynonyms:
+    """Test cases for synonym emission in the FACTS clause."""
+
+    @pytest.fixture
+    def builder(self):
+        """Create a SemanticViewBuilder instance for testing."""
+        config = SnowflakeConfig(
+            account="test",
+            user="test",
+            password="test",
+            role="test",
+            warehouse="test",
+            database="test_db",
+            schema="test_schema",
+        )
+        return SemanticViewBuilder(config)
+
+    def test_fact_synonyms_emitted_in_ddl(self, builder, monkeypatch):
+        """Test that facts with synonyms emit WITH SYNONYMS clause."""
+
+        def mock_get_facts(conn, table_name):
+            return [
+                {
+                    "NAME": "subtotal_cents",
+                    "EXPR": "SUBTOTAL_CENTS",
+                    "DESCRIPTION": "Subtotal in cents",
+                    "SYNONYMS": '["subtotal in cents", "subtotal amount"]',
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        monkeypatch.setattr(builder, "_get_facts", mock_get_facts)
+
+        result = builder._build_facts_clause(None, ["orders"])
+
+        assert "WITH SYNONYMS = ('subtotal in cents', 'subtotal amount')" in result
+        assert "ORDERS.SUBTOTAL_CENTS AS SUBTOTAL_CENTS" in result
+
+    def test_fact_without_synonyms_no_clause(self, builder, monkeypatch):
+        """Test that facts without synonyms don't emit WITH SYNONYMS clause."""
+
+        def mock_get_facts(conn, table_name):
+            return [
+                {
+                    "NAME": "amount",
+                    "EXPR": "AMOUNT",
+                    "DESCRIPTION": "Order amount",
+                    "SYNONYMS": None,
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        monkeypatch.setattr(builder, "_get_facts", mock_get_facts)
+
+        result = builder._build_facts_clause(None, ["orders"])
+
+        assert "WITH SYNONYMS" not in result
+        assert "ORDERS.AMOUNT AS AMOUNT" in result
+
+    def test_fact_synonyms_empty_list(self, builder, monkeypatch):
+        """Test that empty synonym list doesn't emit WITH SYNONYMS clause."""
+
+        def mock_get_facts(conn, table_name):
+            return [
+                {
+                    "NAME": "quantity",
+                    "EXPR": "QUANTITY",
+                    "DESCRIPTION": "Item quantity",
+                    "SYNONYMS": "[]",
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        monkeypatch.setattr(builder, "_get_facts", mock_get_facts)
+
+        result = builder._build_facts_clause(None, ["orders"])
+
+        assert "WITH SYNONYMS" not in result
+
+    def test_fact_synonyms_null_values_filtered(self, builder, monkeypatch):
+        """Test that None values in synonym list are filtered out."""
+
+        def mock_get_facts(conn, table_name):
+            return [
+                {
+                    "NAME": "cost",
+                    "EXPR": "COST",
+                    "DESCRIPTION": "Item cost",
+                    "SYNONYMS": '[null, null]',
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        monkeypatch.setattr(builder, "_get_facts", mock_get_facts)
+
+        result = builder._build_facts_clause(None, ["orders"])
+
+        assert "WITH SYNONYMS" not in result
+
+    def test_fact_synonyms_mixed_null_and_valid(self, builder, monkeypatch):
+        """Test that valid synonyms are kept when mixed with None values."""
+
+        def mock_get_facts(conn, table_name):
+            return [
+                {
+                    "NAME": "price",
+                    "EXPR": "PRICE",
+                    "DESCRIPTION": "Item price",
+                    "SYNONYMS": '[null, "unit price", null, "cost per item"]',
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        monkeypatch.setattr(builder, "_get_facts", mock_get_facts)
+
+        result = builder._build_facts_clause(None, ["orders"])
+
+        assert "WITH SYNONYMS = ('unit price', 'cost per item')" in result
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/core/generation/test_semantic_view_builder.py
+++ b/tests/unit/core/generation/test_semantic_view_builder.py
@@ -958,5 +958,120 @@ class TestTableNotFoundErrorFormatting:
         assert "Original error:" in result
 
 
+class TestVerifiedQueriesDDL:
+    """Test cases for AI_VERIFIED_QUERIES clause generation."""
+
+    @pytest.fixture
+    def builder(self):
+        """Create a SemanticViewBuilder instance for testing."""
+        config = SnowflakeConfig(
+            account="test",
+            user="test",
+            password="test",
+            role="test",
+            warehouse="test",
+            database="test_db",
+            schema="test_schema",
+        )
+        builder = SemanticViewBuilder(config)
+        builder.metadata_database = "TEST_DB"
+        builder.metadata_schema = "TEST_SCHEMA"
+        return builder
+
+    def test_verified_query_emitted(self, builder, monkeypatch):
+        """Test that verified queries are emitted in DDL."""
+
+        def mock_get_vqs(conn, table_names):
+            return [
+                {
+                    "NAME": "MONTHLY_REVENUE",
+                    "QUESTION": "What is monthly revenue?",
+                    "TABLES": '["orders"]',
+                    "VERIFIED_AT": "2026-01-15",
+                    "VERIFIED_BY": "analytics-team@company.com",
+                    "USE_AS_ONBOARDING_QUESTION": True,
+                    "SQL": "SELECT DATE_TRUNC('MONTH', ordered_at), SUM(amount) FROM ANALYTICS.CORE.ORDERS GROUP BY 1",
+                }
+            ]
+
+        monkeypatch.setattr(builder, "_get_verified_queries_for_tables", mock_get_vqs)
+
+        result = builder._build_verified_queries_clause(None, ["orders"])
+
+        assert "MONTHLY_REVENUE AS (" in result
+        assert "QUESTION 'What is monthly revenue?'" in result
+        assert "VERIFIED_AT 1768435200" in result
+        assert "ONBOARDING_QUESTION TRUE" in result
+        assert "VERIFIED_BY '(data_quality = analytics-team@company.com)'" in result
+        assert "SQL 'SELECT DATE_TRUNC(" in result
+
+    def test_sql_single_quotes_escaped(self, builder, monkeypatch):
+        """Test that single quotes in SQL are properly escaped."""
+
+        def mock_get_vqs(conn, table_names):
+            return [
+                {
+                    "NAME": "STATUS_FILTER",
+                    "QUESTION": "How many active users?",
+                    "TABLES": '["users"]',
+                    "VERIFIED_AT": None,
+                    "VERIFIED_BY": None,
+                    "USE_AS_ONBOARDING_QUESTION": None,
+                    "SQL": "SELECT COUNT(*) FROM USERS WHERE status = 'active'",
+                }
+            ]
+
+        monkeypatch.setattr(builder, "_get_verified_queries_for_tables", mock_get_vqs)
+
+        result = builder._build_verified_queries_clause(None, ["users"])
+
+        assert "status = ''active''" in result
+
+    def test_no_verified_queries_returns_empty(self, builder, monkeypatch):
+        """Test that no verified queries returns empty string."""
+
+        def mock_get_vqs(conn, table_names):
+            return []
+
+        monkeypatch.setattr(builder, "_get_verified_queries_for_tables", mock_get_vqs)
+
+        result = builder._build_verified_queries_clause(None, ["orders"])
+
+        assert result == ""
+
+    def test_iso_to_epoch_conversion(self, builder):
+        """Test ISO date to epoch conversion."""
+        assert builder._iso_to_epoch("2026-01-15") == 1768435200
+        assert builder._iso_to_epoch("2026-01-15T00:00:00Z") == 1768435200
+        assert builder._iso_to_epoch(None) is None
+        assert builder._iso_to_epoch("") is None
+        assert builder._iso_to_epoch("invalid") is None
+
+    def test_optional_fields_omitted(self, builder, monkeypatch):
+        """Test that optional fields are omitted when not present."""
+
+        def mock_get_vqs(conn, table_names):
+            return [
+                {
+                    "NAME": "SIMPLE_QUERY",
+                    "QUESTION": "Total orders?",
+                    "TABLES": '["orders"]',
+                    "VERIFIED_AT": None,
+                    "VERIFIED_BY": None,
+                    "USE_AS_ONBOARDING_QUESTION": None,
+                    "SQL": "SELECT COUNT(*) FROM ORDERS",
+                }
+            ]
+
+        monkeypatch.setattr(builder, "_get_verified_queries_for_tables", mock_get_vqs)
+
+        result = builder._build_verified_queries_clause(None, ["orders"])
+
+        assert "SIMPLE_QUERY AS (" in result
+        assert "VERIFIED_AT" not in result
+        assert "ONBOARDING_QUESTION" not in result
+        assert "VERIFIED_BY" not in result
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/core/generation/test_semantic_view_builder.py
+++ b/tests/unit/core/generation/test_semantic_view_builder.py
@@ -1019,6 +1019,54 @@ class TestConstraintDistinctRange:
         assert "CONSTRAINT" not in result
         assert "DISTINCT RANGE" not in result
 
+    def test_constraint_missing_fields_warns(self, builder, monkeypatch, caplog):
+        """Test that missing constraint fields log a warning and skip."""
+        import logging
+
+        def mock_get_table_info(conn, table_name):
+            return {
+                "TABLE_NAME": "RATES",
+                "DATABASE": "TEST_DB",
+                "SCHEMA": "TEST_SCHEMA",
+                "PRIMARY_KEY": '["rate_id"]',
+                "UNIQUE_KEYS": None,
+                "CONSTRAINTS": '[{"type": "distinct_range", "name": "", "start_column": "start_date", "end_column": "end_date"}]',
+                "DESCRIPTION": "Rates",
+                "SYNONYMS": None,
+            }
+
+        monkeypatch.setattr(builder, "_get_table_info", mock_get_table_info)
+
+        with caplog.at_level(logging.WARNING):
+            result = builder._build_tables_clause(None, ["rates"])
+
+        assert "CONSTRAINT" not in result
+        assert "missing fields" in caplog.text
+
+    def test_constraint_unrecognized_type_warns(self, builder, monkeypatch, caplog):
+        """Test that unrecognized constraint type logs a warning."""
+        import logging
+
+        def mock_get_table_info(conn, table_name):
+            return {
+                "TABLE_NAME": "ORDERS",
+                "DATABASE": "TEST_DB",
+                "SCHEMA": "TEST_SCHEMA",
+                "PRIMARY_KEY": '["order_id"]',
+                "UNIQUE_KEYS": None,
+                "CONSTRAINTS": '[{"type": "unknown_type", "name": "foo"}]',
+                "DESCRIPTION": "Orders",
+                "SYNONYMS": None,
+            }
+
+        monkeypatch.setattr(builder, "_get_table_info", mock_get_table_info)
+
+        with caplog.at_level(logging.WARNING):
+            result = builder._build_tables_clause(None, ["orders"])
+
+        assert "CONSTRAINT" not in result
+        assert "unrecognized constraint type" in caplog.text
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/core/generation/test_semantic_view_builder.py
+++ b/tests/unit/core/generation/test_semantic_view_builder.py
@@ -1061,6 +1061,65 @@ class TestWindowFunctionMetrics:
         assert builder._resolve_ref_to_column("") == ""
         assert builder._resolve_ref_to_column("ORDERS.AMOUNT") == "ORDERS.AMOUNT"
 
+    def test_invalid_direction_defaults_to_asc(self, builder, monkeypatch, caplog):
+        """Test that invalid direction values default to ASC with a warning."""
+        import logging
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "BAD_WINDOW",
+                    "EXPR": "SUM(ORDERS.AMOUNT)",
+                    "DESCRIPTION": "Bad",
+                    "TABLE_NAME": '["orders"]',
+                    "SYNONYMS": None,
+                    "SAMPLE_VALUES": None,
+                    "WINDOW": '{"partition_by": ["{{ ref(\'orders\', \'customer_id\') }}"], "order_by": [{"column": "{{ ref(\'orders\', \'order_date\') }}", "direction": "INVALID"}]}',
+                }
+            ]
+
+        def mock_noop(conn, t):
+            return []
+
+        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
+        monkeypatch.setattr(builder, "_get_dimensions", mock_noop)
+        monkeypatch.setattr(builder, "_get_facts", mock_noop)
+        monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
+
+        with caplog.at_level(logging.WARNING):
+            result = builder._build_metrics_clause(None, ["orders"])
+
+        assert "ORDER BY ORDERS.ORDER_DATE ASC" in result
+        assert "Invalid order_by direction" in caplog.text
+
+    def test_order_by_string_format(self, builder, monkeypatch):
+        """Test order_by with plain string entries (not dict)."""
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "SIMPLE_WINDOW",
+                    "EXPR": "SUM(ORDERS.AMOUNT)",
+                    "DESCRIPTION": "Simple",
+                    "TABLE_NAME": '["orders"]',
+                    "SYNONYMS": None,
+                    "SAMPLE_VALUES": None,
+                    "WINDOW": '{"partition_by": ["{{ ref(\'orders\', \'customer_id\') }}"], "order_by": ["{{ ref(\'orders\', \'order_date\') }}"]}',
+                }
+            ]
+
+        def mock_noop(conn, t):
+            return []
+
+        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
+        monkeypatch.setattr(builder, "_get_dimensions", mock_noop)
+        monkeypatch.setattr(builder, "_get_facts", mock_noop)
+        monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
+
+        result = builder._build_metrics_clause(None, ["orders"])
+
+        assert "ORDER BY ORDERS.ORDER_DATE ASC" in result
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/core/generation/test_semantic_view_builder.py
+++ b/tests/unit/core/generation/test_semantic_view_builder.py
@@ -1003,6 +1003,9 @@ class TestUsingRelationships:
 
         assert "USING (ORDERS_TO_SHIPPING_ADDRESS)" in result
         assert "AS SUM(ORDERS.AMOUNT)" in result
+        using_pos = result.index("USING")
+        as_pos = result.index("AS SUM")
+        assert using_pos < as_pos, "USING must come before AS"
 
     def test_using_multiple_relationships(self, builder, monkeypatch):
         """Test USING clause with multiple relationships."""
@@ -1044,6 +1047,34 @@ class TestUsingRelationships:
                     "TABLE_NAME": '["orders"]',
                     "SYNONYMS": None,
                     "USING_RELATIONSHIPS": None,
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        def mock_noop(conn, t):
+            return []
+
+        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
+        monkeypatch.setattr(builder, "_get_dimensions", mock_noop)
+        monkeypatch.setattr(builder, "_get_facts", mock_noop)
+        monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
+
+        result = builder._build_metrics_clause(None, ["orders"])
+
+        assert "USING" not in result
+
+    def test_using_relationships_empty_list(self, builder, monkeypatch):
+        """Test that empty using_relationships list doesn't emit USING."""
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "METRIC",
+                    "EXPR": "SUM(ORDERS.AMOUNT)",
+                    "DESCRIPTION": "Metric",
+                    "TABLE_NAME": '["orders"]',
+                    "SYNONYMS": None,
+                    "USING_RELATIONSHIPS": "[]",
                     "SAMPLE_VALUES": None,
                 }
             ]

--- a/tests/unit/core/generation/test_semantic_view_builder.py
+++ b/tests/unit/core/generation/test_semantic_view_builder.py
@@ -958,5 +958,67 @@ class TestTableNotFoundErrorFormatting:
         assert "Original error:" in result
 
 
+class TestConstraintDistinctRange:
+    """Test cases for CONSTRAINT DISTINCT RANGE on tables."""
+
+    @pytest.fixture
+    def builder(self):
+        """Create a SemanticViewBuilder instance for testing."""
+        config = SnowflakeConfig(
+            account="test",
+            user="test",
+            password="test",
+            role="test",
+            warehouse="test",
+            database="test_db",
+            schema="test_schema",
+        )
+        return SemanticViewBuilder(config)
+
+    def test_constraint_emitted(self, builder, monkeypatch):
+        """Test that CONSTRAINT DISTINCT RANGE is emitted in table DDL."""
+
+        def mock_get_table_info(conn, table_name):
+            return {
+                "TABLE_NAME": "RATE_PERIODS",
+                "DATABASE": "TEST_DB",
+                "SCHEMA": "TEST_SCHEMA",
+                "PRIMARY_KEY": '["rate_id"]',
+                "UNIQUE_KEYS": None,
+                "CONSTRAINTS": '[{"type": "distinct_range", "name": "rate_date_range", "start_column": "effective_start", "end_column": "effective_end"}]',
+                "DESCRIPTION": "Rate periods",
+                "SYNONYMS": None,
+            }
+
+        monkeypatch.setattr(builder, "_get_table_info", mock_get_table_info)
+
+        result = builder._build_tables_clause(None, ["rate_periods"])
+
+        assert "CONSTRAINT RATE_DATE_RANGE DISTINCT RANGE" in result
+        assert "BETWEEN EFFECTIVE_START AND EFFECTIVE_END EXCLUSIVE" in result
+
+    def test_no_constraint_when_absent(self, builder, monkeypatch):
+        """Test that no CONSTRAINT clause when constraints not defined."""
+
+        def mock_get_table_info(conn, table_name):
+            return {
+                "TABLE_NAME": "ORDERS",
+                "DATABASE": "TEST_DB",
+                "SCHEMA": "TEST_SCHEMA",
+                "PRIMARY_KEY": '["order_id"]',
+                "UNIQUE_KEYS": None,
+                "CONSTRAINTS": None,
+                "DESCRIPTION": "Orders",
+                "SYNONYMS": None,
+            }
+
+        monkeypatch.setattr(builder, "_get_table_info", mock_get_table_info)
+
+        result = builder._build_tables_clause(None, ["orders"])
+
+        assert "CONSTRAINT" not in result
+        assert "DISTINCT RANGE" not in result
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/core/generation/test_semantic_view_builder.py
+++ b/tests/unit/core/generation/test_semantic_view_builder.py
@@ -1003,6 +1003,9 @@ class TestNonAdditiveBy:
 
         assert "NON ADDITIVE BY (SNAPSHOT_DATE DESC NULLS LAST)" in result
         assert "AS BALANCE" in result
+        nab_pos = result.index("NON ADDITIVE BY")
+        as_pos = result.index("AS BALANCE")
+        assert nab_pos < as_pos, "NON ADDITIVE BY must come before AS"
 
     def test_non_additive_by_without_nulls(self, builder, monkeypatch):
         """Test NON ADDITIVE BY with only dimension and order."""
@@ -1061,6 +1064,62 @@ class TestNonAdditiveBy:
 
         assert "NON ADDITIVE BY" not in result
         assert "ORDERS.TOTAL_REVENUE AS SUM(ORDERS.AMOUNT)" in result
+
+    def test_non_additive_by_empty_list(self, builder, monkeypatch):
+        """Test that empty non_additive_by list doesn't emit clause."""
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "REVENUE",
+                    "EXPR": "SUM(ORDERS.AMOUNT)",
+                    "DESCRIPTION": "Revenue",
+                    "TABLE_NAME": '["orders"]',
+                    "SYNONYMS": None,
+                    "NON_ADDITIVE_BY": "[]",
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        def mock_noop(conn, t):
+            return []
+
+        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
+        monkeypatch.setattr(builder, "_get_dimensions", mock_noop)
+        monkeypatch.setattr(builder, "_get_facts", mock_noop)
+        monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
+
+        result = builder._build_metrics_clause(None, ["orders"])
+
+        assert "NON ADDITIVE BY" not in result
+
+    def test_non_additive_by_missing_dimension(self, builder, monkeypatch):
+        """Test that entries with missing dimension field are skipped."""
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "BAD_METRIC",
+                    "EXPR": "SUM(ORDERS.AMOUNT)",
+                    "DESCRIPTION": "Bad",
+                    "TABLE_NAME": '["orders"]',
+                    "SYNONYMS": None,
+                    "NON_ADDITIVE_BY": '[{"order": "DESC"}]',
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        def mock_noop(conn, t):
+            return []
+
+        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
+        monkeypatch.setattr(builder, "_get_dimensions", mock_noop)
+        monkeypatch.setattr(builder, "_get_facts", mock_noop)
+        monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
+
+        result = builder._build_metrics_clause(None, ["orders"])
+
+        assert "NON ADDITIVE BY" not in result
 
 
 if __name__ == "__main__":

--- a/tests/unit/core/generation/test_semantic_view_builder.py
+++ b/tests/unit/core/generation/test_semantic_view_builder.py
@@ -958,5 +958,108 @@ class TestTableNotFoundErrorFormatting:
         assert "Original error:" in result
 
 
+class TestUsingRelationships:
+    """Test cases for USING (relationship_name) on metrics."""
+
+    @pytest.fixture
+    def builder(self):
+        """Create a SemanticViewBuilder instance for testing."""
+        config = SnowflakeConfig(
+            account="test",
+            user="test",
+            password="test",
+            role="test",
+            warehouse="test",
+            database="test_db",
+            schema="test_schema",
+        )
+        return SemanticViewBuilder(config)
+
+    def test_using_single_relationship(self, builder, monkeypatch):
+        """Test USING clause with a single relationship."""
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "REVENUE_BY_SHIPPING",
+                    "EXPR": "SUM(ORDERS.AMOUNT)",
+                    "DESCRIPTION": "Revenue by shipping",
+                    "TABLE_NAME": '["orders"]',
+                    "SYNONYMS": None,
+                    "USING_RELATIONSHIPS": '["orders_to_shipping_address"]',
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        def mock_noop(conn, t):
+            return []
+
+        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
+        monkeypatch.setattr(builder, "_get_dimensions", mock_noop)
+        monkeypatch.setattr(builder, "_get_facts", mock_noop)
+        monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
+
+        result = builder._build_metrics_clause(None, ["orders"])
+
+        assert "USING (ORDERS_TO_SHIPPING_ADDRESS)" in result
+        assert "AS SUM(ORDERS.AMOUNT)" in result
+
+    def test_using_multiple_relationships(self, builder, monkeypatch):
+        """Test USING clause with multiple relationships."""
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "COMPLEX_METRIC",
+                    "EXPR": "COUNT(*)",
+                    "DESCRIPTION": "Complex",
+                    "TABLE_NAME": '["orders"]',
+                    "SYNONYMS": None,
+                    "USING_RELATIONSHIPS": '["rel_a", "rel_b"]',
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        def mock_noop(conn, t):
+            return []
+
+        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
+        monkeypatch.setattr(builder, "_get_dimensions", mock_noop)
+        monkeypatch.setattr(builder, "_get_facts", mock_noop)
+        monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
+
+        result = builder._build_metrics_clause(None, ["orders"])
+
+        assert "USING (REL_A, REL_B)" in result
+
+    def test_no_using_relationships(self, builder, monkeypatch):
+        """Test that metrics without using_relationships don't emit USING."""
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "TOTAL_REVENUE",
+                    "EXPR": "SUM(ORDERS.AMOUNT)",
+                    "DESCRIPTION": "Total revenue",
+                    "TABLE_NAME": '["orders"]',
+                    "SYNONYMS": None,
+                    "USING_RELATIONSHIPS": None,
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        def mock_noop(conn, t):
+            return []
+
+        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
+        monkeypatch.setattr(builder, "_get_dimensions", mock_noop)
+        monkeypatch.setattr(builder, "_get_facts", mock_noop)
+        monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
+
+        result = builder._build_metrics_clause(None, ["orders"])
+
+        assert "USING" not in result
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/core/generation/test_semantic_view_builder.py
+++ b/tests/unit/core/generation/test_semantic_view_builder.py
@@ -960,18 +960,6 @@ class TestTableNotFoundErrorFormatting:
 
 class TestFactSynonyms:
     """Test cases for synonym emission in the FACTS clause."""
-class TestFiltersToInstructions:
-    """Test cases for filter-to-AI_SQL_GENERATION instruction conversion."""
-class TestVisibility:
-    """Test cases for PRIVATE/PUBLIC visibility on facts and metrics."""
-class TestNonAdditiveBy:
-    """Test cases for NON ADDITIVE BY clause on metrics."""
-class TestUsingRelationships:
-    """Test cases for USING (relationship_name) on metrics."""
-class TestVerifiedQueriesDDL:
-    """Test cases for AI_VERIFIED_QUERIES clause generation."""
-class TestConstraintDistinctRange:
-    """Test cases for CONSTRAINT DISTINCT RANGE on tables."""
 
     @pytest.fixture
     def builder(self):
@@ -989,8 +977,6 @@ class TestConstraintDistinctRange:
 
     def test_fact_synonyms_emitted_in_ddl(self, builder, monkeypatch):
         """Test that facts with synonyms emit WITH SYNONYMS clause."""
-    def test_private_fact_emits_keyword(self, builder, monkeypatch):
-        """Test that a private fact emits PRIVATE keyword in DDL."""
 
         def mock_get_facts(conn, table_name):
             return [
@@ -999,11 +985,6 @@ class TestConstraintDistinctRange:
                     "EXPR": "SUBTOTAL_CENTS",
                     "DESCRIPTION": "Subtotal in cents",
                     "SYNONYMS": '["subtotal in cents", "subtotal amount"]',
-                    "NAME": "raw_discount",
-                    "EXPR": "RAW_DISCOUNT",
-                    "DESCRIPTION": "Internal discount",
-                    "SYNONYMS": None,
-                    "VISIBILITY": "private",
                     "SAMPLE_VALUES": None,
                 }
             ]
@@ -1017,10 +998,6 @@ class TestConstraintDistinctRange:
 
     def test_fact_without_synonyms_no_clause(self, builder, monkeypatch):
         """Test that facts without synonyms don't emit WITH SYNONYMS clause."""
-        assert "PRIVATE ORDERS.RAW_DISCOUNT AS RAW_DISCOUNT" in result
-
-    def test_public_fact_no_keyword(self, builder, monkeypatch):
-        """Test that a public fact does not emit visibility keyword."""
 
         def mock_get_facts(conn, table_name):
             return [
@@ -1029,7 +1006,6 @@ class TestConstraintDistinctRange:
                     "EXPR": "AMOUNT",
                     "DESCRIPTION": "Order amount",
                     "SYNONYMS": None,
-                    "VISIBILITY": "public",
                     "SAMPLE_VALUES": None,
                 }
             ]
@@ -1043,12 +1019,6 @@ class TestConstraintDistinctRange:
 
     def test_fact_synonyms_empty_list(self, builder, monkeypatch):
         """Test that empty synonym list doesn't emit WITH SYNONYMS clause."""
-        assert "PRIVATE" not in result
-        assert "PUBLIC" not in result
-        assert "ORDERS.AMOUNT AS AMOUNT" in result
-
-    def test_null_visibility_no_keyword(self, builder, monkeypatch):
-        """Test that null visibility does not emit any keyword."""
 
         def mock_get_facts(conn, table_name):
             return [
@@ -1057,9 +1027,6 @@ class TestConstraintDistinctRange:
                     "EXPR": "QUANTITY",
                     "DESCRIPTION": "Item quantity",
                     "SYNONYMS": "[]",
-                    "DESCRIPTION": "Quantity",
-                    "SYNONYMS": None,
-                    "VISIBILITY": None,
                     "SAMPLE_VALUES": None,
                 }
             ]
@@ -1080,51 +1047,6 @@ class TestConstraintDistinctRange:
                     "EXPR": "COST",
                     "DESCRIPTION": "Item cost",
                     "SYNONYMS": '[null, null]',
-        assert "PRIVATE" not in result
-        assert "ORDERS.QUANTITY AS QUANTITY" in result
-
-    def test_private_metric_emits_keyword(self, builder, monkeypatch):
-        """Test that a private metric emits PRIVATE keyword in DDL."""
-    def test_non_additive_by_emitted(self, builder, monkeypatch):
-        """Test that NON ADDITIVE BY clause is emitted for semi-additive metrics."""
-    def test_using_single_relationship(self, builder, monkeypatch):
-        """Test USING clause with a single relationship."""
-class TestWindowFunctionMetrics:
-    """Test cases for window function metric DDL generation."""
-class TestTagSupport:
-    """Test cases for WITH TAG clause generation."""
-
-    @pytest.fixture
-    def builder(self):
-        config = SnowflakeConfig(
-            account="test", user="test", password="test", role="test", warehouse="test", database="test_db", schema="s"
-        )
-        return SemanticViewBuilder(config)
-
-    def test_standard_partition_by(self, builder, monkeypatch):
-        """Test OVER (PARTITION BY ... ORDER BY ...) emission."""
-
-        def mock_get_metrics(conn, table_names):
-            return [
-                {
-                    "NAME": "INTERMEDIATE_SUM",
-                    "EXPR": "SUM(ORDERS.AMOUNT)",
-                    "DESCRIPTION": "Internal intermediate calc",
-                    "TABLE_NAME": '["orders"]',
-                    "SYNONYMS": None,
-                    "VISIBILITY": "private",
-                    "NAME": "CURRENT_BALANCE",
-                    "EXPR": "BALANCE",
-                    "DESCRIPTION": "Account balance",
-                    "TABLE_NAME": '["accounts"]',
-                    "SYNONYMS": None,
-                    "NON_ADDITIVE_BY": '[{"dimension": "snapshot_date", "order": "DESC", "nulls": "LAST"}]',
-                    "NAME": "REVENUE_BY_SHIPPING",
-                    "EXPR": "SUM(ORDERS.AMOUNT)",
-                    "DESCRIPTION": "Revenue by shipping",
-                    "TABLE_NAME": '["orders"]',
-                    "SYNONYMS": None,
-                    "USING_RELATIONSHIPS": '["orders_to_shipping_address"]',
                     "SAMPLE_VALUES": None,
                 }
             ]
@@ -1154,6 +1076,23 @@ class TestTagSupport:
         result = builder._build_facts_clause(None, ["orders"])
 
         assert "WITH SYNONYMS = ('unit price', 'cost per item')" in result
+
+
+class TestFiltersToInstructions:
+    """Test cases for filter-to-AI_SQL_GENERATION instruction conversion."""
+
+    @pytest.fixture
+    def builder(self):
+        """Create a SemanticViewBuilder instance for testing."""
+        config = SnowflakeConfig(
+            account="test",
+            user="test",
+            password="test",
+            role="test",
+            warehouse="test",
+            database="test_db",
+            schema="test_schema",
+        )
         builder = SemanticViewBuilder(config)
         builder.metadata_database = "TEST_DB"
         builder.metadata_schema = "TEST_SCHEMA"
@@ -1299,6 +1238,107 @@ class TestTagSupport:
         assert "fiscal year calendar" in result
         assert "CUSTOMERS.STATUS" in result
         assert "Default Filters:" in result
+
+
+class TestVisibility:
+    """Test cases for PRIVATE/PUBLIC visibility on facts and metrics."""
+
+    @pytest.fixture
+    def builder(self):
+        """Create a SemanticViewBuilder instance for testing."""
+        config = SnowflakeConfig(
+            account="test",
+            user="test",
+            password="test",
+            role="test",
+            warehouse="test",
+            database="test_db",
+            schema="test_schema",
+        )
+        return SemanticViewBuilder(config)
+
+    def test_private_fact_emits_keyword(self, builder, monkeypatch):
+        """Test that a private fact emits PRIVATE keyword in DDL."""
+
+        def mock_get_facts(conn, table_name):
+            return [
+                {
+                    "NAME": "raw_discount",
+                    "EXPR": "RAW_DISCOUNT",
+                    "DESCRIPTION": "Internal discount",
+                    "SYNONYMS": None,
+                    "VISIBILITY": "private",
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        monkeypatch.setattr(builder, "_get_facts", mock_get_facts)
+
+        result = builder._build_facts_clause(None, ["orders"])
+
+        assert "PRIVATE ORDERS.RAW_DISCOUNT AS RAW_DISCOUNT" in result
+
+    def test_public_fact_no_keyword(self, builder, monkeypatch):
+        """Test that a public fact does not emit visibility keyword."""
+
+        def mock_get_facts(conn, table_name):
+            return [
+                {
+                    "NAME": "amount",
+                    "EXPR": "AMOUNT",
+                    "DESCRIPTION": "Order amount",
+                    "SYNONYMS": None,
+                    "VISIBILITY": "public",
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        monkeypatch.setattr(builder, "_get_facts", mock_get_facts)
+
+        result = builder._build_facts_clause(None, ["orders"])
+
+        assert "PRIVATE" not in result
+        assert "PUBLIC" not in result
+        assert "ORDERS.AMOUNT AS AMOUNT" in result
+
+    def test_null_visibility_no_keyword(self, builder, monkeypatch):
+        """Test that null visibility does not emit any keyword."""
+
+        def mock_get_facts(conn, table_name):
+            return [
+                {
+                    "NAME": "quantity",
+                    "EXPR": "QUANTITY",
+                    "DESCRIPTION": "Quantity",
+                    "SYNONYMS": None,
+                    "VISIBILITY": None,
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        monkeypatch.setattr(builder, "_get_facts", mock_get_facts)
+
+        result = builder._build_facts_clause(None, ["orders"])
+
+        assert "PRIVATE" not in result
+        assert "ORDERS.QUANTITY AS QUANTITY" in result
+
+    def test_private_metric_emits_keyword(self, builder, monkeypatch):
+        """Test that a private metric emits PRIVATE keyword in DDL."""
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "INTERMEDIATE_SUM",
+                    "EXPR": "SUM(ORDERS.AMOUNT)",
+                    "DESCRIPTION": "Internal intermediate calc",
+                    "TABLE_NAME": '["orders"]',
+                    "SYNONYMS": None,
+                    "VISIBILITY": "private",
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
         def mock_get_dims(conn, t):
             return []
 
@@ -1316,6 +1356,41 @@ class TestTagSupport:
         result = builder._build_metrics_clause(None, ["orders"])
 
         assert "PRIVATE ORDERS.INTERMEDIATE_SUM AS SUM(ORDERS.AMOUNT)" in result
+
+
+class TestNonAdditiveBy:
+    """Test cases for NON ADDITIVE BY clause on metrics."""
+
+    @pytest.fixture
+    def builder(self):
+        """Create a SemanticViewBuilder instance for testing."""
+        config = SnowflakeConfig(
+            account="test",
+            user="test",
+            password="test",
+            role="test",
+            warehouse="test",
+            database="test_db",
+            schema="test_schema",
+        )
+        return SemanticViewBuilder(config)
+
+    def test_non_additive_by_emitted(self, builder, monkeypatch):
+        """Test that NON ADDITIVE BY clause is emitted for semi-additive metrics."""
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "CURRENT_BALANCE",
+                    "EXPR": "BALANCE",
+                    "DESCRIPTION": "Account balance",
+                    "TABLE_NAME": '["accounts"]',
+                    "SYNONYMS": None,
+                    "NON_ADDITIVE_BY": '[{"dimension": "snapshot_date", "order": "DESC", "nulls": "LAST"}]',
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
         def mock_noop(conn, t):
             return []
 
@@ -1334,6 +1409,152 @@ class TestTagSupport:
 
     def test_non_additive_by_without_nulls(self, builder, monkeypatch):
         """Test NON ADDITIVE BY with only dimension and order."""
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "HEADCOUNT",
+                    "EXPR": "HEAD_COUNT",
+                    "DESCRIPTION": "Headcount",
+                    "TABLE_NAME": '["hr_snapshots"]',
+                    "SYNONYMS": None,
+                    "NON_ADDITIVE_BY": '[{"dimension": "snapshot_date", "order": "DESC"}]',
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        def mock_noop(conn, t):
+            return []
+
+        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
+        monkeypatch.setattr(builder, "_get_dimensions", mock_noop)
+        monkeypatch.setattr(builder, "_get_facts", mock_noop)
+        monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
+
+        result = builder._build_metrics_clause(None, ["hr_snapshots"])
+
+        assert "NON ADDITIVE BY (SNAPSHOT_DATE DESC)" in result
+        assert "NULLS" not in result
+
+    def test_no_non_additive_by(self, builder, monkeypatch):
+        """Test that metrics without non_additive_by don't emit the clause."""
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "TOTAL_REVENUE",
+                    "EXPR": "SUM(ORDERS.AMOUNT)",
+                    "DESCRIPTION": "Total revenue",
+                    "TABLE_NAME": '["orders"]',
+                    "SYNONYMS": None,
+                    "NON_ADDITIVE_BY": None,
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        def mock_noop(conn, t):
+            return []
+
+        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
+        monkeypatch.setattr(builder, "_get_dimensions", mock_noop)
+        monkeypatch.setattr(builder, "_get_facts", mock_noop)
+        monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
+
+        result = builder._build_metrics_clause(None, ["orders"])
+
+        assert "NON ADDITIVE BY" not in result
+        assert "ORDERS.TOTAL_REVENUE AS SUM(ORDERS.AMOUNT)" in result
+
+    def test_non_additive_by_empty_list(self, builder, monkeypatch):
+        """Test that empty non_additive_by list doesn't emit clause."""
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "REVENUE",
+                    "EXPR": "SUM(ORDERS.AMOUNT)",
+                    "DESCRIPTION": "Revenue",
+                    "TABLE_NAME": '["orders"]',
+                    "SYNONYMS": None,
+                    "NON_ADDITIVE_BY": "[]",
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        def mock_noop(conn, t):
+            return []
+
+        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
+        monkeypatch.setattr(builder, "_get_dimensions", mock_noop)
+        monkeypatch.setattr(builder, "_get_facts", mock_noop)
+        monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
+
+        result = builder._build_metrics_clause(None, ["orders"])
+
+        assert "NON ADDITIVE BY" not in result
+
+    def test_non_additive_by_missing_dimension(self, builder, monkeypatch):
+        """Test that entries with missing dimension field are skipped."""
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "BAD_METRIC",
+                    "EXPR": "SUM(ORDERS.AMOUNT)",
+                    "DESCRIPTION": "Bad",
+                    "TABLE_NAME": '["orders"]',
+                    "SYNONYMS": None,
+                    "NON_ADDITIVE_BY": '[{"order": "DESC"}]',
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
+        def mock_noop(conn, t):
+            return []
+
+        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
+        monkeypatch.setattr(builder, "_get_dimensions", mock_noop)
+        monkeypatch.setattr(builder, "_get_facts", mock_noop)
+        monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
+
+        result = builder._build_metrics_clause(None, ["orders"])
+
+        assert "NON ADDITIVE BY" not in result
+
+
+class TestUsingRelationships:
+    """Test cases for USING (relationship_name) on metrics."""
+
+    @pytest.fixture
+    def builder(self):
+        """Create a SemanticViewBuilder instance for testing."""
+        config = SnowflakeConfig(
+            account="test",
+            user="test",
+            password="test",
+            role="test",
+            warehouse="test",
+            database="test_db",
+            schema="test_schema",
+        )
+        return SemanticViewBuilder(config)
+
+    def test_using_single_relationship(self, builder, monkeypatch):
+        """Test USING clause with a single relationship."""
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "REVENUE_BY_SHIPPING",
+                    "EXPR": "SUM(ORDERS.AMOUNT)",
+                    "DESCRIPTION": "Revenue by shipping",
+                    "TABLE_NAME": '["orders"]',
+                    "SYNONYMS": None,
+                    "USING_RELATIONSHIPS": '["orders_to_shipping_address"]',
+                    "SAMPLE_VALUES": None,
+                }
+            ]
+
         def mock_noop(conn, t):
             return []
 
@@ -1356,12 +1577,6 @@ class TestTagSupport:
         def mock_get_metrics(conn, table_names):
             return [
                 {
-                    "NAME": "HEADCOUNT",
-                    "EXPR": "HEAD_COUNT",
-                    "DESCRIPTION": "Headcount",
-                    "TABLE_NAME": '["hr_snapshots"]',
-                    "SYNONYMS": None,
-                    "NON_ADDITIVE_BY": '[{"dimension": "snapshot_date", "order": "DESC"}]',
                     "NAME": "COMPLEX_METRIC",
                     "EXPR": "COUNT(*)",
                     "DESCRIPTION": "Complex",
@@ -1369,13 +1584,6 @@ class TestTagSupport:
                     "SYNONYMS": None,
                     "USING_RELATIONSHIPS": '["rel_a", "rel_b"]',
                     "SAMPLE_VALUES": None,
-                    "NAME": "RUNNING_REVENUE",
-                    "EXPR": "SUM(ORDERS.AMOUNT)",
-                    "DESCRIPTION": "Running revenue",
-                    "TABLE_NAME": '["orders"]',
-                    "SYNONYMS": None,
-                    "SAMPLE_VALUES": None,
-                    "WINDOW": '{"partition_by": ["{{ ref(\'customers\', \'customer_id\') }}"], "order_by": [{"column": "{{ ref(\'orders\', \'order_date\') }}", "direction": "ASC"}]}',
                 }
             ]
 
@@ -1387,27 +1595,12 @@ class TestTagSupport:
         monkeypatch.setattr(builder, "_get_facts", mock_noop)
         monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
 
-        result = builder._build_metrics_clause(None, ["hr_snapshots"])
-
-        assert "NON ADDITIVE BY (SNAPSHOT_DATE DESC)" in result
-        assert "NULLS" not in result
-
-    def test_no_non_additive_by(self, builder, monkeypatch):
-        """Test that metrics without non_additive_by don't emit the clause."""
         result = builder._build_metrics_clause(None, ["orders"])
 
         assert "USING (REL_A, REL_B)" in result
 
     def test_no_using_relationships(self, builder, monkeypatch):
         """Test that metrics without using_relationships don't emit USING."""
-        result = builder._build_metrics_clause(None, ["orders", "customers"])
-
-        assert "OVER (" in result
-        assert "PARTITION BY CUSTOMERS.CUSTOMER_ID" in result
-        assert "ORDER BY ORDERS.ORDER_DATE ASC" in result
-
-    def test_partition_by_excluding(self, builder, monkeypatch):
-        """Test PARTITION BY EXCLUDING emission."""
 
         def mock_get_metrics(conn, table_names):
             return [
@@ -1417,16 +1610,8 @@ class TestTagSupport:
                     "DESCRIPTION": "Total revenue",
                     "TABLE_NAME": '["orders"]',
                     "SYNONYMS": None,
-                    "NON_ADDITIVE_BY": None,
                     "USING_RELATIONSHIPS": None,
                     "SAMPLE_VALUES": None,
-                    "NAME": "CUMULATIVE_REVENUE",
-                    "EXPR": "SUM(ORDERS.AMOUNT)",
-                    "DESCRIPTION": "Cumulative revenue",
-                    "TABLE_NAME": '["orders"]',
-                    "SYNONYMS": None,
-                    "SAMPLE_VALUES": None,
-                    "WINDOW": '{"partition_by_excluding": ["{{ ref(\'orders\', \'order_date\') }}"], "order_by": [{"column": "{{ ref(\'orders\', \'order_date\') }}", "direction": "ASC"}]}',
                 }
             ]
 
@@ -1440,29 +1625,14 @@ class TestTagSupport:
 
         result = builder._build_metrics_clause(None, ["orders"])
 
-        assert "NON ADDITIVE BY" not in result
-        assert "ORDERS.TOTAL_REVENUE AS SUM(ORDERS.AMOUNT)" in result
-
-    def test_non_additive_by_empty_list(self, builder, monkeypatch):
-        """Test that empty non_additive_by list doesn't emit clause."""
         assert "USING" not in result
 
     def test_using_relationships_empty_list(self, builder, monkeypatch):
         """Test that empty using_relationships list doesn't emit USING."""
-        assert "PARTITION BY EXCLUDING ORDERS.ORDER_DATE" in result
-
-    def test_no_window_no_over(self, builder, monkeypatch):
-        """Test that metrics without window config don't emit OVER."""
 
         def mock_get_metrics(conn, table_names):
             return [
                 {
-                    "NAME": "REVENUE",
-                    "EXPR": "SUM(ORDERS.AMOUNT)",
-                    "DESCRIPTION": "Revenue",
-                    "TABLE_NAME": '["orders"]',
-                    "SYNONYMS": None,
-                    "NON_ADDITIVE_BY": "[]",
                     "NAME": "METRIC",
                     "EXPR": "SUM(ORDERS.AMOUNT)",
                     "DESCRIPTION": "Metric",
@@ -1470,13 +1640,6 @@ class TestTagSupport:
                     "SYNONYMS": None,
                     "USING_RELATIONSHIPS": "[]",
                     "SAMPLE_VALUES": None,
-                    "NAME": "TOTAL",
-                    "EXPR": "SUM(ORDERS.AMOUNT)",
-                    "DESCRIPTION": "Total",
-                    "TABLE_NAME": '["orders"]',
-                    "SYNONYMS": None,
-                    "SAMPLE_VALUES": None,
-                    "WINDOW": None,
                 }
             ]
 
@@ -1490,81 +1653,29 @@ class TestTagSupport:
 
         result = builder._build_metrics_clause(None, ["orders"])
 
-        assert "NON ADDITIVE BY" not in result
-
-    def test_non_additive_by_missing_dimension(self, builder, monkeypatch):
-        """Test that entries with missing dimension field are skipped."""
-        assert "OVER" not in result
-
-    def test_resolve_ref_to_column(self, builder):
-        """Test _resolve_ref_to_column helper."""
-        assert builder._resolve_ref_to_column("{{ ref('orders', 'amount') }}") == "ORDERS.AMOUNT"
-        assert builder._resolve_ref_to_column("{{ column('orders', 'amount') }}") == "ORDERS.AMOUNT"
-        assert builder._resolve_ref_to_column("") == ""
-        assert builder._resolve_ref_to_column("ORDERS.AMOUNT") == "ORDERS.AMOUNT"
-
-    def test_invalid_direction_defaults_to_asc(self, builder, monkeypatch, caplog):
-        """Test that invalid direction values default to ASC with a warning."""
-        import logging
-
-        def mock_get_metrics(conn, table_names):
-            return [
-                {
-                    "NAME": "BAD_METRIC",
-                    "NAME": "BAD_WINDOW",
-                    "EXPR": "SUM(ORDERS.AMOUNT)",
-                    "DESCRIPTION": "Bad",
-                    "TABLE_NAME": '["orders"]',
-                    "SYNONYMS": None,
-                    "NON_ADDITIVE_BY": '[{"order": "DESC"}]',
-                    "SAMPLE_VALUES": None,
-                    "SAMPLE_VALUES": None,
-                    "WINDOW": '{"partition_by": ["{{ ref(\'orders\', \'customer_id\') }}"], "order_by": [{"column": "{{ ref(\'orders\', \'order_date\') }}", "direction": "INVALID"}]}',
-                }
-            ]
-
-        def mock_noop(conn, t):
-            return []
-
-        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
-        monkeypatch.setattr(builder, "_get_dimensions", mock_noop)
-        monkeypatch.setattr(builder, "_get_facts", mock_noop)
-        monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
-
-        with caplog.at_level(logging.WARNING):
-            result = builder._build_metrics_clause(None, ["orders"])
-
-        assert "ORDER BY ORDERS.ORDER_DATE ASC" in result
-        assert "Invalid order_by direction" in caplog.text
-
-    def test_order_by_string_format(self, builder, monkeypatch):
-        """Test order_by with plain string entries (not dict)."""
-
-        def mock_get_metrics(conn, table_names):
-            return [
-                {
-                    "NAME": "SIMPLE_WINDOW",
-                    "EXPR": "SUM(ORDERS.AMOUNT)",
-                    "DESCRIPTION": "Simple",
-                    "TABLE_NAME": '["orders"]',
-                    "SYNONYMS": None,
-                    "SAMPLE_VALUES": None,
-                    "WINDOW": '{"partition_by": ["{{ ref(\'orders\', \'customer_id\') }}"], "order_by": ["{{ ref(\'orders\', \'order_date\') }}"]}',
-                }
-            ]
-
-        def mock_noop(conn, t):
-            return []
-
-        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
-        monkeypatch.setattr(builder, "_get_dimensions", mock_noop)
-        monkeypatch.setattr(builder, "_get_facts", mock_noop)
-        monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
-
-        result = builder._build_metrics_clause(None, ["orders"])
-
-        assert "NON ADDITIVE BY" not in result
         assert "USING" not in result
+
+
+class TestVerifiedQueriesDDL:
+    """Test cases for AI_VERIFIED_QUERIES clause generation."""
+
+    @pytest.fixture
+    def builder(self):
+        """Create a SemanticViewBuilder instance for testing."""
+        config = SnowflakeConfig(
+            account="test",
+            user="test",
+            password="test",
+            role="test",
+            warehouse="test",
+            database="test_db",
+            schema="test_schema",
+        )
+        builder = SemanticViewBuilder(config)
+        builder.metadata_database = "TEST_DB"
+        builder.metadata_schema = "TEST_SCHEMA"
+        return builder
+
     def test_verified_query_emitted(self, builder, monkeypatch):
         """Test that verified queries are emitted in DDL."""
 
@@ -1658,6 +1769,25 @@ class TestTagSupport:
         assert "VERIFIED_AT" not in result
         assert "ONBOARDING_QUESTION" not in result
         assert "VERIFIED_BY" not in result
+
+
+class TestConstraintDistinctRange:
+    """Test cases for CONSTRAINT DISTINCT RANGE on tables."""
+
+    @pytest.fixture
+    def builder(self):
+        """Create a SemanticViewBuilder instance for testing."""
+        config = SnowflakeConfig(
+            account="test",
+            user="test",
+            password="test",
+            role="test",
+            warehouse="test",
+            database="test_db",
+            schema="test_schema",
+        )
+        return SemanticViewBuilder(config)
+
     def test_constraint_emitted(self, builder, monkeypatch):
         """Test that CONSTRAINT DISTINCT RANGE is emitted in table DDL."""
 
@@ -1682,8 +1812,6 @@ class TestTagSupport:
 
     def test_no_constraint_when_absent(self, builder, monkeypatch):
         """Test that no CONSTRAINT clause when constraints not defined."""
-    def test_table_tags_emitted(self, builder, monkeypatch):
-        """Test that table-level tags emit WITH TAG clause."""
 
         def mock_get_table_info(conn, table_name):
             return {
@@ -1695,9 +1823,6 @@ class TestTagSupport:
                 "CONSTRAINTS": None,
                 "DESCRIPTION": "Orders",
                 "SYNONYMS": None,
-                "DESCRIPTION": "Orders",
-                "SYNONYMS": None,
-                "TAGS": '{"data_domain": "sales", "sensitivity": "internal"}',
             }
 
         monkeypatch.setattr(builder, "_get_table_info", mock_get_table_info)
@@ -1754,7 +1879,200 @@ class TestTagSupport:
 
         assert "CONSTRAINT" not in result
         assert "unrecognized constraint type" in caplog.text
+
+
+class TestWindowFunctionMetrics:
+    """Test cases for window function metric DDL generation."""
+
+    @pytest.fixture
+    def builder(self):
+        config = SnowflakeConfig(
+            account="test", user="test", password="test", role="test", warehouse="test", database="test_db", schema="s"
+        )
+        return SemanticViewBuilder(config)
+
+    def test_standard_partition_by(self, builder, monkeypatch):
+        """Test OVER (PARTITION BY ... ORDER BY ...) emission."""
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "RUNNING_REVENUE",
+                    "EXPR": "SUM(ORDERS.AMOUNT)",
+                    "DESCRIPTION": "Running revenue",
+                    "TABLE_NAME": '["orders"]',
+                    "SYNONYMS": None,
+                    "SAMPLE_VALUES": None,
+                    "WINDOW": '{"partition_by": ["{{ ref(\'customers\', \'customer_id\') }}"], "order_by": [{"column": "{{ ref(\'orders\', \'order_date\') }}", "direction": "ASC"}]}',
+                }
+            ]
+
+        def mock_noop(conn, t):
+            return []
+
+        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
+        monkeypatch.setattr(builder, "_get_dimensions", mock_noop)
+        monkeypatch.setattr(builder, "_get_facts", mock_noop)
+        monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
+
+        result = builder._build_metrics_clause(None, ["orders", "customers"])
+
+        assert "OVER (" in result
+        assert "PARTITION BY CUSTOMERS.CUSTOMER_ID" in result
         assert "ORDER BY ORDERS.ORDER_DATE ASC" in result
+
+    def test_partition_by_excluding(self, builder, monkeypatch):
+        """Test PARTITION BY EXCLUDING emission."""
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "CUMULATIVE_REVENUE",
+                    "EXPR": "SUM(ORDERS.AMOUNT)",
+                    "DESCRIPTION": "Cumulative revenue",
+                    "TABLE_NAME": '["orders"]',
+                    "SYNONYMS": None,
+                    "SAMPLE_VALUES": None,
+                    "WINDOW": '{"partition_by_excluding": ["{{ ref(\'orders\', \'order_date\') }}"], "order_by": [{"column": "{{ ref(\'orders\', \'order_date\') }}", "direction": "ASC"}]}',
+                }
+            ]
+
+        def mock_noop(conn, t):
+            return []
+
+        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
+        monkeypatch.setattr(builder, "_get_dimensions", mock_noop)
+        monkeypatch.setattr(builder, "_get_facts", mock_noop)
+        monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
+
+        result = builder._build_metrics_clause(None, ["orders"])
+
+        assert "PARTITION BY EXCLUDING ORDERS.ORDER_DATE" in result
+
+    def test_no_window_no_over(self, builder, monkeypatch):
+        """Test that metrics without window config don't emit OVER."""
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "TOTAL",
+                    "EXPR": "SUM(ORDERS.AMOUNT)",
+                    "DESCRIPTION": "Total",
+                    "TABLE_NAME": '["orders"]',
+                    "SYNONYMS": None,
+                    "SAMPLE_VALUES": None,
+                    "WINDOW": None,
+                }
+            ]
+
+        def mock_noop(conn, t):
+            return []
+
+        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
+        monkeypatch.setattr(builder, "_get_dimensions", mock_noop)
+        monkeypatch.setattr(builder, "_get_facts", mock_noop)
+        monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
+
+        result = builder._build_metrics_clause(None, ["orders"])
+
+        assert "OVER" not in result
+
+    def test_resolve_ref_to_column(self, builder):
+        """Test _resolve_ref_to_column helper."""
+        assert builder._resolve_ref_to_column("{{ ref('orders', 'amount') }}") == "ORDERS.AMOUNT"
+        assert builder._resolve_ref_to_column("{{ column('orders', 'amount') }}") == "ORDERS.AMOUNT"
+        assert builder._resolve_ref_to_column("") == ""
+        assert builder._resolve_ref_to_column("ORDERS.AMOUNT") == "ORDERS.AMOUNT"
+
+    def test_invalid_direction_defaults_to_asc(self, builder, monkeypatch, caplog):
+        """Test that invalid direction values default to ASC with a warning."""
+        import logging
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "BAD_WINDOW",
+                    "EXPR": "SUM(ORDERS.AMOUNT)",
+                    "DESCRIPTION": "Bad",
+                    "TABLE_NAME": '["orders"]',
+                    "SYNONYMS": None,
+                    "SAMPLE_VALUES": None,
+                    "WINDOW": '{"partition_by": ["{{ ref(\'orders\', \'customer_id\') }}"], "order_by": [{"column": "{{ ref(\'orders\', \'order_date\') }}", "direction": "INVALID"}]}',
+                }
+            ]
+
+        def mock_noop(conn, t):
+            return []
+
+        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
+        monkeypatch.setattr(builder, "_get_dimensions", mock_noop)
+        monkeypatch.setattr(builder, "_get_facts", mock_noop)
+        monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
+
+        with caplog.at_level(logging.WARNING):
+            result = builder._build_metrics_clause(None, ["orders"])
+
+        assert "ORDER BY ORDERS.ORDER_DATE ASC" in result
+        assert "Invalid order_by direction" in caplog.text
+
+    def test_order_by_string_format(self, builder, monkeypatch):
+        """Test order_by with plain string entries (not dict)."""
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "SIMPLE_WINDOW",
+                    "EXPR": "SUM(ORDERS.AMOUNT)",
+                    "DESCRIPTION": "Simple",
+                    "TABLE_NAME": '["orders"]',
+                    "SYNONYMS": None,
+                    "SAMPLE_VALUES": None,
+                    "WINDOW": '{"partition_by": ["{{ ref(\'orders\', \'customer_id\') }}"], "order_by": ["{{ ref(\'orders\', \'order_date\') }}"]}',
+                }
+            ]
+
+        def mock_noop(conn, t):
+            return []
+
+        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
+        monkeypatch.setattr(builder, "_get_dimensions", mock_noop)
+        monkeypatch.setattr(builder, "_get_facts", mock_noop)
+        monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
+
+        result = builder._build_metrics_clause(None, ["orders"])
+
+        assert "ORDER BY ORDERS.ORDER_DATE ASC" in result
+
+
+class TestTagSupport:
+    """Test cases for WITH TAG clause generation."""
+
+    @pytest.fixture
+    def builder(self):
+        config = SnowflakeConfig(
+            account="test", user="test", password="test", role="test", warehouse="test", database="test_db", schema="s"
+        )
+        return SemanticViewBuilder(config)
+
+    def test_table_tags_emitted(self, builder, monkeypatch):
+        """Test that table-level tags emit WITH TAG clause."""
+
+        def mock_get_table_info(conn, table_name):
+            return {
+                "TABLE_NAME": "ORDERS",
+                "DATABASE": "TEST_DB",
+                "SCHEMA": "TEST_SCHEMA",
+                "PRIMARY_KEY": '["order_id"]',
+                "UNIQUE_KEYS": None,
+                "DESCRIPTION": "Orders",
+                "SYNONYMS": None,
+                "TAGS": '{"data_domain": "sales", "sensitivity": "internal"}',
+            }
+
+        monkeypatch.setattr(builder, "_get_table_info", mock_get_table_info)
+
+        result = builder._build_tables_clause(None, ["orders"])
+
         assert "WITH TAG (data_domain = 'sales', sensitivity = 'internal')" in result
 
     def test_fact_tags_emitted(self, builder, monkeypatch):

--- a/tests/unit/core/generation/test_semantic_view_builder.py
+++ b/tests/unit/core/generation/test_semantic_view_builder.py
@@ -958,5 +958,109 @@ class TestTableNotFoundErrorFormatting:
         assert "Original error:" in result
 
 
+class TestWindowFunctionMetrics:
+    """Test cases for window function metric DDL generation."""
+
+    @pytest.fixture
+    def builder(self):
+        config = SnowflakeConfig(
+            account="test", user="test", password="test", role="test", warehouse="test", database="test_db", schema="s"
+        )
+        return SemanticViewBuilder(config)
+
+    def test_standard_partition_by(self, builder, monkeypatch):
+        """Test OVER (PARTITION BY ... ORDER BY ...) emission."""
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "RUNNING_REVENUE",
+                    "EXPR": "SUM(ORDERS.AMOUNT)",
+                    "DESCRIPTION": "Running revenue",
+                    "TABLE_NAME": '["orders"]',
+                    "SYNONYMS": None,
+                    "SAMPLE_VALUES": None,
+                    "WINDOW": '{"partition_by": ["{{ ref(\'customers\', \'customer_id\') }}"], "order_by": [{"column": "{{ ref(\'orders\', \'order_date\') }}", "direction": "ASC"}]}',
+                }
+            ]
+
+        def mock_noop(conn, t):
+            return []
+
+        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
+        monkeypatch.setattr(builder, "_get_dimensions", mock_noop)
+        monkeypatch.setattr(builder, "_get_facts", mock_noop)
+        monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
+
+        result = builder._build_metrics_clause(None, ["orders", "customers"])
+
+        assert "OVER (" in result
+        assert "PARTITION BY CUSTOMERS.CUSTOMER_ID" in result
+        assert "ORDER BY ORDERS.ORDER_DATE ASC" in result
+
+    def test_partition_by_excluding(self, builder, monkeypatch):
+        """Test PARTITION BY EXCLUDING emission."""
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "CUMULATIVE_REVENUE",
+                    "EXPR": "SUM(ORDERS.AMOUNT)",
+                    "DESCRIPTION": "Cumulative revenue",
+                    "TABLE_NAME": '["orders"]',
+                    "SYNONYMS": None,
+                    "SAMPLE_VALUES": None,
+                    "WINDOW": '{"partition_by_excluding": ["{{ ref(\'orders\', \'order_date\') }}"], "order_by": [{"column": "{{ ref(\'orders\', \'order_date\') }}", "direction": "ASC"}]}',
+                }
+            ]
+
+        def mock_noop(conn, t):
+            return []
+
+        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
+        monkeypatch.setattr(builder, "_get_dimensions", mock_noop)
+        monkeypatch.setattr(builder, "_get_facts", mock_noop)
+        monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
+
+        result = builder._build_metrics_clause(None, ["orders"])
+
+        assert "PARTITION BY EXCLUDING ORDERS.ORDER_DATE" in result
+
+    def test_no_window_no_over(self, builder, monkeypatch):
+        """Test that metrics without window config don't emit OVER."""
+
+        def mock_get_metrics(conn, table_names):
+            return [
+                {
+                    "NAME": "TOTAL",
+                    "EXPR": "SUM(ORDERS.AMOUNT)",
+                    "DESCRIPTION": "Total",
+                    "TABLE_NAME": '["orders"]',
+                    "SYNONYMS": None,
+                    "SAMPLE_VALUES": None,
+                    "WINDOW": None,
+                }
+            ]
+
+        def mock_noop(conn, t):
+            return []
+
+        monkeypatch.setattr(builder, "_get_metrics_for_selected_tables", mock_get_metrics)
+        monkeypatch.setattr(builder, "_get_dimensions", mock_noop)
+        monkeypatch.setattr(builder, "_get_facts", mock_noop)
+        monkeypatch.setattr(builder, "_get_time_dimensions", mock_noop)
+
+        result = builder._build_metrics_clause(None, ["orders"])
+
+        assert "OVER" not in result
+
+    def test_resolve_ref_to_column(self, builder):
+        """Test _resolve_ref_to_column helper."""
+        assert builder._resolve_ref_to_column("{{ ref('orders', 'amount') }}") == "ORDERS.AMOUNT"
+        assert builder._resolve_ref_to_column("{{ column('orders', 'amount') }}") == "ORDERS.AMOUNT"
+        assert builder._resolve_ref_to_column("") == ""
+        assert builder._resolve_ref_to_column("ORDERS.AMOUNT") == "ORDERS.AMOUNT"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/core/generation/test_semantic_view_builder.py
+++ b/tests/unit/core/generation/test_semantic_view_builder.py
@@ -958,5 +958,167 @@ class TestTableNotFoundErrorFormatting:
         assert "Original error:" in result
 
 
+class TestFiltersToInstructions:
+    """Test cases for filter-to-AI_SQL_GENERATION instruction conversion."""
+
+    @pytest.fixture
+    def builder(self):
+        """Create a SemanticViewBuilder instance for testing."""
+        config = SnowflakeConfig(
+            account="test",
+            user="test",
+            password="test",
+            role="test",
+            warehouse="test",
+            database="test_db",
+            schema="test_schema",
+        )
+        builder = SemanticViewBuilder(config)
+        builder.metadata_database = "TEST_DB"
+        builder.metadata_schema = "TEST_SCHEMA"
+        return builder
+
+    def test_filters_converted_to_instructions(self, builder, monkeypatch):
+        """Test that filters are converted to AI_SQL_GENERATION instruction text."""
+
+        def mock_get_filters(conn, table_names):
+            return [
+                {
+                    "NAME": "ACTIVE_CUSTOMERS_ONLY",
+                    "TABLE_NAME": "CUSTOMERS",
+                    "DESCRIPTION": "Only include active customers",
+                    "EXPR": "CUSTOMERS.STATUS = 'Active'",
+                }
+            ]
+
+        monkeypatch.setattr(builder, "_get_filters_for_tables", mock_get_filters)
+
+        result = builder._build_filters_as_instructions(None, ["customers"])
+
+        assert "Default Filters:" in result
+        assert "CUSTOMERS.STATUS = 'Active'" in result
+        assert "Only include active customers" in result
+        assert "unless the user explicitly requests unfiltered data" in result
+
+    def test_multiple_filters_all_included(self, builder, monkeypatch):
+        """Test that multiple filters are all included in instructions."""
+
+        def mock_get_filters(conn, table_names):
+            return [
+                {
+                    "NAME": "ACTIVE_ONLY",
+                    "TABLE_NAME": "CUSTOMERS",
+                    "DESCRIPTION": "Active customers",
+                    "EXPR": "CUSTOMERS.STATUS = 'Active'",
+                },
+                {
+                    "NAME": "LAST_90_DAYS",
+                    "TABLE_NAME": "ORDERS",
+                    "DESCRIPTION": "Recent orders",
+                    "EXPR": "ORDERS.ORDERED_AT >= DATEADD('day', -90, CURRENT_DATE())",
+                },
+            ]
+
+        monkeypatch.setattr(builder, "_get_filters_for_tables", mock_get_filters)
+
+        result = builder._build_filters_as_instructions(None, ["customers", "orders"])
+
+        assert "CUSTOMERS.STATUS = 'Active'" in result
+        assert "ORDERS.ORDERED_AT >= DATEADD" in result
+
+    def test_no_filters_returns_empty(self, builder, monkeypatch):
+        """Test that no filters returns empty string."""
+
+        def mock_get_filters(conn, table_names):
+            return []
+
+        monkeypatch.setattr(builder, "_get_filters_for_tables", mock_get_filters)
+
+        result = builder._build_filters_as_instructions(None, ["customers"])
+
+        assert result == ""
+
+    def test_filter_without_description(self, builder, monkeypatch):
+        """Test that filters without description still work."""
+
+        def mock_get_filters(conn, table_names):
+            return [
+                {
+                    "NAME": "ACTIVE_ONLY",
+                    "TABLE_NAME": "CUSTOMERS",
+                    "DESCRIPTION": "",
+                    "EXPR": "CUSTOMERS.IS_ACTIVE = TRUE",
+                }
+            ]
+
+        monkeypatch.setattr(builder, "_get_filters_for_tables", mock_get_filters)
+
+        result = builder._build_filters_as_instructions(None, ["customers"])
+
+        assert "CUSTOMERS.IS_ACTIVE = TRUE" in result
+        assert "unless the user explicitly requests unfiltered data" in result
+
+    def test_filters_disabled_via_config(self, builder, monkeypatch):
+        """Test that filters_to_instructions=false skips conversion."""
+        from snowflake_semantic_tools.shared.config import Config
+
+        def mock_get_filters(conn, table_names):
+            return [
+                {
+                    "NAME": "ACTIVE_ONLY",
+                    "TABLE_NAME": "CUSTOMERS",
+                    "DESCRIPTION": "Active only",
+                    "EXPR": "CUSTOMERS.STATUS = 'Active'",
+                }
+            ]
+
+        monkeypatch.setattr(builder, "_get_filters_for_tables", mock_get_filters)
+
+        original_get = Config.get
+
+        def mock_config_get(self, key_path, default=None):
+            if key_path == "generation.filters_to_instructions":
+                return False
+            return original_get(self, key_path, default)
+
+        monkeypatch.setattr(Config, "get", mock_config_get)
+
+        result = builder._build_filters_as_instructions(None, ["customers"])
+
+        assert result == ""
+
+    def test_filters_appended_to_ai_sql_generation(self, builder, monkeypatch):
+        """Test that filters are appended to existing AI_SQL_GENERATION content."""
+
+        def mock_get_custom_instructions(conn, names):
+            return [
+                {
+                    "name": "BUSINESS_RULES",
+                    "question_categorization": None,
+                    "sql_generation": "Always use fiscal year calendar.",
+                }
+            ]
+
+        def mock_get_filters(conn, table_names):
+            return [
+                {
+                    "NAME": "ACTIVE_ONLY",
+                    "TABLE_NAME": "CUSTOMERS",
+                    "DESCRIPTION": "Active only",
+                    "EXPR": "CUSTOMERS.STATUS = 'Active'",
+                }
+            ]
+
+        monkeypatch.setattr(builder, "_get_custom_instructions_for_view", mock_get_custom_instructions)
+        monkeypatch.setattr(builder, "_get_filters_for_tables", mock_get_filters)
+
+        result = builder._build_ai_guidance_clauses(None, ["business_rules"], table_names=["customers"])
+
+        assert "AI_SQL_GENERATION" in result
+        assert "fiscal year calendar" in result
+        assert "CUSTOMERS.STATUS" in result
+        assert "Default Filters:" in result
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/core/generation/test_semantic_view_builder.py
+++ b/tests/unit/core/generation/test_semantic_view_builder.py
@@ -1046,7 +1046,7 @@ class TestFactSynonyms:
                     "NAME": "cost",
                     "EXPR": "COST",
                     "DESCRIPTION": "Item cost",
-                    "SYNONYMS": '[null, null]',
+                    "SYNONYMS": "[null, null]",
                     "SAMPLE_VALUES": None,
                 }
             ]
@@ -2027,7 +2027,7 @@ class TestWindowFunctionMetrics:
                     "TABLE_NAME": '["orders"]',
                     "SYNONYMS": None,
                     "SAMPLE_VALUES": None,
-                    "WINDOW": '{"partition_by": ["{{ ref(\'orders\', \'customer_id\') }}"], "order_by": ["{{ ref(\'orders\', \'order_date\') }}"]}',
+                    "WINDOW": "{\"partition_by\": [\"{{ ref('orders', 'customer_id') }}\"], \"order_by\": [\"{{ ref('orders', 'order_date') }}\"]}",
                 }
             ]
 

--- a/tests/unit/core/generation/test_semantic_view_builder.py
+++ b/tests/unit/core/generation/test_semantic_view_builder.py
@@ -958,5 +958,85 @@ class TestTableNotFoundErrorFormatting:
         assert "Original error:" in result
 
 
+class TestTagSupport:
+    """Test cases for WITH TAG clause generation."""
+
+    @pytest.fixture
+    def builder(self):
+        config = SnowflakeConfig(
+            account="test", user="test", password="test", role="test", warehouse="test", database="test_db", schema="s"
+        )
+        return SemanticViewBuilder(config)
+
+    def test_table_tags_emitted(self, builder, monkeypatch):
+        """Test that table-level tags emit WITH TAG clause."""
+
+        def mock_get_table_info(conn, table_name):
+            return {
+                "TABLE_NAME": "ORDERS",
+                "DATABASE": "TEST_DB",
+                "SCHEMA": "TEST_SCHEMA",
+                "PRIMARY_KEY": '["order_id"]',
+                "UNIQUE_KEYS": None,
+                "DESCRIPTION": "Orders",
+                "SYNONYMS": None,
+                "TAGS": '{"data_domain": "sales", "sensitivity": "internal"}',
+            }
+
+        monkeypatch.setattr(builder, "_get_table_info", mock_get_table_info)
+
+        result = builder._build_tables_clause(None, ["orders"])
+
+        assert "WITH TAG (data_domain = 'sales', sensitivity = 'internal')" in result
+
+    def test_fact_tags_emitted(self, builder, monkeypatch):
+        """Test that fact-level tags emit WITH TAG clause."""
+
+        def mock_get_facts(conn, table_name):
+            return [
+                {
+                    "NAME": "amount",
+                    "EXPR": "AMOUNT",
+                    "DESCRIPTION": "Amount",
+                    "SYNONYMS": None,
+                    "SAMPLE_VALUES": None,
+                    "TAGS": '{"pii": "false"}',
+                }
+            ]
+
+        monkeypatch.setattr(builder, "_get_facts", mock_get_facts)
+
+        result = builder._build_facts_clause(None, ["orders"])
+
+        assert "WITH TAG (pii = 'false')" in result
+
+    def test_no_tags_no_clause(self, builder, monkeypatch):
+        """Test that absent tags don't emit WITH TAG."""
+
+        def mock_get_facts(conn, table_name):
+            return [
+                {
+                    "NAME": "amount",
+                    "EXPR": "AMOUNT",
+                    "DESCRIPTION": "Amount",
+                    "SYNONYMS": None,
+                    "SAMPLE_VALUES": None,
+                    "TAGS": None,
+                }
+            ]
+
+        monkeypatch.setattr(builder, "_get_facts", mock_get_facts)
+
+        result = builder._build_facts_clause(None, ["orders"])
+
+        assert "WITH TAG" not in result
+
+    def test_build_tag_clause_helper(self, builder):
+        """Test _build_tag_clause helper directly."""
+        assert builder._build_tag_clause(None) == ""
+        assert builder._build_tag_clause("{}") == ""
+        assert builder._build_tag_clause('{"dept": "finance"}') == "WITH TAG (dept = 'finance')"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/core/parsing/test_join_condition_parser.py
+++ b/tests/unit/core/parsing/test_join_condition_parser.py
@@ -277,14 +277,21 @@ class TestValidationUnsupportedOperators:
         assert "not supported" in error_msg
         assert ">" in error_msg
 
-    def test_validate_between_operator_rejected(self):
-        """Test that BETWEEN operator is rejected with helpful error message."""
-        condition = "{{ column('orders', 'ordered_at') }} BETWEEN {{ column('orders', 'start_date') }} AND {{ column('orders', 'end_date') }}"
+    def test_validate_between_operator_accepted(self):
+        """Test that BETWEEN operator is accepted for range joins (preview feature)."""
+        condition = "{{ column('orders', 'ordered_at') }} BETWEEN {{ column('rates', 'start_date') }} AND {{ column('rates', 'end_date') }} EXCLUSIVE"
+        is_valid, error_msg = JoinConditionParser.validate_condition(condition)
+
+        assert is_valid is True
+        assert error_msg == ""
+
+    def test_validate_between_without_end_rejected(self):
+        """Test that BETWEEN without proper end column is rejected."""
+        condition = "{{ column('orders', 'ordered_at') }} BETWEEN {{ column('rates', 'start_date') }}"
         is_valid, error_msg = JoinConditionParser.validate_condition(condition)
 
         assert is_valid is False
         assert "BETWEEN" in error_msg
-        assert "not supported" in error_msg
 
     def test_validate_less_than_operator_rejected(self):
         """Test that < operator is rejected with helpful error message."""

--- a/tests/unit/core/validation/test_dbt_model_validator.py
+++ b/tests/unit/core/validation/test_dbt_model_validator.py
@@ -223,3 +223,72 @@ class TestDbtModelValidator:
         assert error.context["column"] == "my_column"
         assert error.context["column_type"] == "invalid_type"
         assert error.context["level"] == "column"
+
+    def test_private_dimension_rejected(self):
+        """Test that a dimension with visibility: private produces an error."""
+        dbt_data = {
+            "sm_tables": [
+                {
+                    "table_name": "CUSTOMERS",
+                    "database": "ANALYTICS",
+                    "schema": "PUBLIC",
+                    "primary_key": ["customer_id"],
+                }
+            ],
+            "sm_dimensions": {
+                "items": [
+                    {
+                        "table_name": "CUSTOMERS",
+                        "name": "status",
+                        "column_type": "dimension",
+                        "data_type": "TEXT",
+                        "description": "Customer status",
+                        "visibility": "private",
+                    }
+                ]
+            },
+        }
+
+        result = self.validator.validate(dbt_data)
+
+        visibility_errors = [
+            issue
+            for issue in result.issues
+            if issue.severity == ValidationSeverity.ERROR and "PRIVATE" in issue.message
+        ]
+        assert len(visibility_errors) == 1
+        assert "only facts and metrics" in visibility_errors[0].message
+
+    def test_private_fact_accepted(self):
+        """Test that a fact with visibility: private does not produce an error."""
+        dbt_data = {
+            "sm_tables": [
+                {
+                    "table_name": "ORDERS",
+                    "database": "ANALYTICS",
+                    "schema": "PUBLIC",
+                    "primary_key": ["order_id"],
+                }
+            ],
+            "sm_facts": {
+                "items": [
+                    {
+                        "table_name": "ORDERS",
+                        "name": "raw_discount",
+                        "column_type": "fact",
+                        "data_type": "NUMBER",
+                        "description": "Internal discount amount",
+                        "visibility": "private",
+                    }
+                ]
+            },
+        }
+
+        result = self.validator.validate(dbt_data)
+
+        visibility_errors = [
+            issue
+            for issue in result.issues
+            if issue.severity == ValidationSeverity.ERROR and "visibility" in issue.message.lower()
+        ]
+        assert len(visibility_errors) == 0

--- a/tests/unit/core/validation/test_semantic_models.py
+++ b/tests/unit/core/validation/test_semantic_models.py
@@ -361,6 +361,25 @@ class TestFilterValidation:
         errors = [i.message for i in result.issues if i.severity.name == "ERROR"]
         assert any("missing required field: expr" in e for e in errors)
 
+    def test_filter_deprecation_warning(self, validator):
+        """Test that filters emit a deprecation warning."""
+        semantic_data = {
+            "filters": {
+                "items": [
+                    {
+                        "name": "active_users",
+                        "description": "Active users only",
+                        "expr": "status = 'active'",
+                    }
+                ]
+            }
+        }
+
+        result = validator.validate(semantic_data)
+        warnings = [i.message for i in result.issues if i.severity.name == "WARNING"]
+        assert any("deprecated" in w.lower() for w in warnings)
+        assert any("snowflake_custom_instructions" in w for w in warnings)
+
 
 class TestCustomInstructionValidation:
     """Test custom instruction validation rules."""

--- a/tests/unit/core/validation/test_semantic_models.py
+++ b/tests/unit/core/validation/test_semantic_models.py
@@ -1515,3 +1515,176 @@ class TestRelationshipStructureValidation:
         validator._validate_relationship_structure(relationship, result)
         warnings = [i for i in result.issues if i.severity.name == "WARNING"]
         assert len(warnings) == 2
+
+
+class TestDDLParityValidation:
+    """Tests for DDL parity validation rules (v0.3.0)."""
+
+    @pytest.fixture
+    def validator(self):
+        return SemanticModelValidator()
+
+    def test_vqr_both_sql_and_sql_file_errors(self, validator):
+        semantic_data = {
+            "verified_queries": {
+                "items": [
+                    {
+                        "name": "TEST_QUERY",
+                        "question": "test?",
+                        "sql": "SELECT 1",
+                        "sql_file": "test.sql",
+                        "source_file": "/tmp/test.yml",
+                    }
+                ]
+            }
+        }
+        result = validator.validate(semantic_data)
+        errors = [i for i in result.issues if i.severity.name == "ERROR"]
+        assert any("both" in str(e.message).lower() for e in errors)
+
+    def test_vqr_neither_sql_nor_sql_file_errors(self, validator):
+        semantic_data = {
+            "verified_queries": {
+                "items": [
+                    {
+                        "name": "TEST_QUERY",
+                        "question": "test?",
+                        "source_file": "/tmp/test.yml",
+                    }
+                ]
+            }
+        }
+        result = validator.validate(semantic_data)
+        errors = [i for i in result.issues if i.severity.name == "ERROR"]
+        assert any("sql" in str(e.message).lower() for e in errors)
+
+    def test_vqr_sql_file_not_found_errors(self, validator):
+        semantic_data = {
+            "verified_queries": {
+                "items": [
+                    {
+                        "name": "TEST_QUERY",
+                        "question": "test?",
+                        "sql_file": "nonexistent.sql",
+                        "source_file": "/tmp/test.yml",
+                    }
+                ]
+            }
+        }
+        result = validator.validate(semantic_data)
+        errors = [i for i in result.issues if i.severity.name == "ERROR"]
+        assert any("does not exist" in str(e.message) for e in errors)
+
+    def test_metric_non_additive_by_missing_dimension_errors(self, validator):
+        semantic_data = {
+            "metrics": {
+                "items": [
+                    {
+                        "name": "test_metric",
+                        "expr": "MAX(col)",
+                        "tables": ["orders"],
+                        "non_additive_by": [{"order": "DESC"}],
+                    }
+                ]
+            }
+        }
+        result = validator.validate(semantic_data)
+        errors = [i for i in result.issues if i.severity.name == "ERROR"]
+        assert any("dimension" in str(e.message).lower() for e in errors)
+
+    def test_metric_non_additive_by_invalid_order_errors(self, validator):
+        semantic_data = {
+            "metrics": {
+                "items": [
+                    {
+                        "name": "test_metric",
+                        "expr": "MAX(col)",
+                        "tables": ["orders"],
+                        "non_additive_by": [{"dimension": "date_col", "order": "INVALID"}],
+                    }
+                ]
+            }
+        }
+        result = validator.validate(semantic_data)
+        errors = [i for i in result.issues if i.severity.name == "ERROR"]
+        assert any("ASC or DESC" in str(e.message) for e in errors)
+
+    def test_metric_window_both_partition_modes_errors(self, validator):
+        semantic_data = {
+            "metrics": {
+                "items": [
+                    {
+                        "name": "test_metric",
+                        "expr": "SUM(col)",
+                        "tables": ["orders"],
+                        "window": {
+                            "partition_by": ["col1"],
+                            "partition_by_excluding": ["col2"],
+                        },
+                    }
+                ]
+            }
+        }
+        result = validator.validate(semantic_data)
+        errors = [i for i in result.issues if i.severity.name == "ERROR"]
+        assert any("partition_by" in str(e.message) for e in errors)
+
+    def test_metric_visibility_invalid_value_errors(self, validator):
+        semantic_data = {
+            "metrics": {
+                "items": [
+                    {
+                        "name": "test_metric",
+                        "expr": "SUM(col)",
+                        "tables": ["orders"],
+                        "visibility": "hidden",
+                    }
+                ]
+            }
+        }
+        result = validator.validate(semantic_data)
+        errors = [i for i in result.issues if i.severity.name == "ERROR"]
+        assert any("private" in str(e.message).lower() for e in errors)
+
+    def test_tags_invalid_identifier_errors(self, validator):
+        result = ValidationResult()
+        validator._validate_tags({"invalid name!": "value"}, "Test", "/tmp/test.yml", result)
+        errors = [i for i in result.issues if i.severity.name == "ERROR"]
+        assert len(errors) == 1
+
+    def test_tags_value_exceeds_256_chars_errors(self, validator):
+        result = ValidationResult()
+        validator._validate_tags({"valid_tag": "x" * 257}, "Test", "/tmp/test.yml", result)
+        errors = [i for i in result.issues if i.severity.name == "ERROR"]
+        assert len(errors) == 1
+        assert "256" in str(errors[0].message)
+
+    def test_tags_unqualified_name_warns(self, validator):
+        result = ValidationResult()
+        validator._validate_tags({"bare_tag": "value"}, "Test", "/tmp/test.yml", result)
+        warnings = [i for i in result.issues if i.severity.name == "WARNING"]
+        assert len(warnings) == 1
+        assert "fully-qualified" in str(warnings[0].message)
+
+    def test_tags_qualified_name_no_warning(self, validator):
+        result = ValidationResult()
+        validator._validate_tags({"db.schema.tag_name": "value"}, "Test", "/tmp/test.yml", result)
+        warnings = [i for i in result.issues if i.severity.name == "WARNING"]
+        assert len(warnings) == 0
+
+    def test_metric_using_relationships_not_list_errors(self, validator):
+        semantic_data = {
+            "metrics": {
+                "items": [
+                    {
+                        "name": "test_metric",
+                        "expr": "SUM(col)",
+                        "tables": ["orders"],
+                        "using_relationships": "not_a_list",
+                    }
+                ]
+            }
+        }
+        result = validator.validate(semantic_data)
+        errors = [i for i in result.issues if i.severity.name == "ERROR"]
+        assert any("list" in str(e.message).lower() for e in errors)


### PR DESCRIPTION
## Description

Implements 10 DDL parity features bringing SST's semantic view generation to full parity with Snowflake's CREATE SEMANTIC VIEW DDL syntax (v0.3.0). This is a combined PR for the complete DDL parity effort.

## Related Issue

Closes #136, Closes #137, Closes #138, Closes #139, Closes #140, Closes #141, Closes #142, Closes #143, Closes #144, Closes #146

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test improvements
- [ ] Other (please describe):

## Changes Made

**DDL Generation (semantic_view_builder.py):**
1. Fact synonyms — WITH SYNONYMS on facts
2. Filters to instructions — converts filters to AI_SQL_GENERATION content
3. Private/Public visibility — PRIVATE prefix on facts and metrics
4. Non-additive-by — NON ADDITIVE BY clause for semi-additive metrics
5. Using relationships — USING clause for join path disambiguation
6. Verified queries DDL — AI_VERIFIED_QUERIES clause with sql_file support
7. Constraint distinct range — CONSTRAINT DISTINCT RANGE on tables
8. Range join relationships — BETWEEN...AND...EXCLUSIVE in REFERENCES
9. Window function metrics — OVER (PARTITION BY / EXCLUDING) clause
10. Tag support — WITH TAG at view, table, and column levels

**Parsing (semantic_parser.py, data_extractors.py):**
- Metric visibility field extraction
- sql_file loading for verified queries
- Composite unique_keys nested list support
- Window config JSON serialization

**Validation (semantic_models.py, dbt_models.py, references.py):**
- VQR: mutual exclusivity of sql/sql_file + file existence check
- Metrics: non_additive_by, using_relationships, window, visibility, tags validation
- Tables: CONSTRAINT DISTINCT RANGE column validation + tags
- Tags: unqualified name warning

**Data Loading (data_loader.py):**
- Window/NAB/using_relationships added to JSON serialization list
- WINDOW column added to SM_METRICS schema

## Testing

- [x] Unit tests pass (`pytest tests/unit/`)
- [x] All existing tests pass
- [x] New tests added for new functionality
- [ ] Tested locally with Python 3.9-3.11
- [x] Manual testing completed (if applicable)
- [ ] Test coverage maintained or improved (target: >90%)

### Test Results

```
============ 1298 passed, 4 deselected, 25 subtests passed in 2.04s ============
```

**E2E (sst-jaffle-shop, complete-project branch):**
- sst extract: 91 metrics, 9 VQRs, 7 relationships, 5 filters
- sst generate --all: PASS=3 WARN=0 ERROR=0 SKIP=0 TOTAL=3

**E2E (analytics-dbt, 1372 models):**
- sst extract: 25,306 rows from 1372 models (858 metrics, 106 relationships)
- sst generate --all: PASS=69 WARN=0 ERROR=1 SKIP=0 TOTAL=70
- The 1 error is a naming collision (TABLE named ORDERS conflicts with semantic view named ORDERS), not a code bug

## Checklist

### Code Quality
- [x] Code follows the project's style guidelines (Black, line length 120)
- [x] Imports sorted with isort (black profile)
- [ ] Type hints added for new code (`mypy snowflake_semantic_tools/` passes)
- [ ] Docstrings added for public functions/classes
- [x] No linting errors
- [ ] Pre-commit hooks pass (if using pre-commit)

### Testing & Validation
- [x] All tests pass (`pytest tests/unit/`)
- [x] New functionality has test coverage
- [x] Test results included above

### Documentation & Compatibility
- [ ] Documentation updated (if needed)
- [x] Backward compatibility maintained (if applicable)
- [ ] Breaking changes discussed with maintainer first (see CONTRIBUTING.md)

### Performance
- [x] Performance impact considered
- [x] No significant performance regressions

## Additional Notes

**Known limitations (filed as separate bugs):**
- #158: Cross-table metrics with USING — needs derived metric prefix logic (deferred)
- #159: WITH TAG requires fully-qualified tag names (warns during validate)
- #160: Multiple relationships between same pair — Snowflake supports it but builder may have edge cases

**Validated against Snowflake features:**
- PRIVATE, NON ADDITIVE BY, USING, OVER (PARTITION BY / EXCLUDING), AI_VERIFIED_QUERIES, VERIFIED_AT, VERIFIED_BY, CONSTRAINT DISTINCT RANGE, BETWEEN...EXCLUSIVE, ASOF, UNIQUE, WITH SYNONYMS, COMMENT, PRIMARY KEY

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)
