### PR TITLE
[SST-135] Fix block scalar blank line preservation in sst format

### DIFF
--- a/snowflake_semantic_tools/services/format_yaml.py
+++ b/snowflake_semantic_tools/services/format_yaml.py
@@ -323,6 +323,27 @@ class YAMLFormattingService:
         for key in new_order:
             d[key] = d.pop(key)
 
+    def _is_after_block_scalar(self, lines: List[str]) -> bool:
+        """Check if the current position follows a YAML block scalar (| or |-).
+
+        Walks backward through lines to find the nearest `description:` at the
+        same or higher indent level. Returns True if that description uses a
+        block scalar style (|, |-, |+, with optional indent indicator).
+        """
+        import re
+
+        block_scalar_pattern = re.compile(r"^\s*description:\s+\|[+\-]?\d*\s*$")
+
+        for i in range(len(lines) - 1, -1, -1):
+            line = lines[i]
+            if line.strip() == "":
+                continue
+            if block_scalar_pattern.match(line):
+                return True
+            if re.match(r"^\s*(- name:|name:|columns:|models:)", line):
+                return False
+        return False
+
     def _adjust_blank_lines(self, content: str) -> str:
         """
         Adjust blank lines for readability.
@@ -332,6 +353,7 @@ class YAMLFormattingService:
         - Add blank line AFTER each column definition (before next - name:)
         - Remove blank lines between meta/config, columns:/first column
         - Remove excessive consecutive blank lines (max 1)
+        - PRESERVE blank lines that terminate block scalars (|- or |)
         """
         lines = content.split("\n")
         formatted_lines = []
@@ -339,59 +361,39 @@ class YAMLFormattingService:
         for i, line in enumerate(lines):
             stripped = line.strip()
 
-            # Skip blank lines in specific locations
             if stripped == "":
                 if formatted_lines and i + 1 < len(lines):
                     prev_line = formatted_lines[-1].strip()
                     next_line = lines[i + 1].strip()
 
-                    # Remove blank line between 'models:' and first '- name:'
                     if prev_line == "models:" and next_line.startswith("- name:"):
-                        continue  # Skip this blank line
-
-                    # Also remove if we're right after models: (ruamel adds this)
-                    if prev_line == "models:":
-                        continue  # Skip this blank line
-
-                    # Remove blank line between meta block and config
-                    # Check if we're after an SST metadata block and before config
-                    if next_line.startswith("config:"):
-                        # Skip this blank line (no blank line between meta and config)
                         continue
 
-                    # Remove blank line between columns: and first - name:
-                    if prev_line == "columns:" and next_line.startswith("- name:"):
-                        continue  # Skip this blank line
+                    if prev_line == "models:":
+                        continue
 
-                # Skip excessive blank lines (more than 1 consecutive)
+                    if next_line.startswith("config:"):
+                        if not self._is_after_block_scalar(formatted_lines):
+                            continue
+
+                    if prev_line == "columns:" and next_line.startswith("- name:"):
+                        continue
+
                 if formatted_lines and formatted_lines[-1].strip() == "":
-                    continue  # Skip this blank line
+                    continue
 
             formatted_lines.append(line)
 
-            # Add blank line AFTER each column definition ends (before next - name:)
-            # Only add if current line is not blank, not 'columns:', and next line is a new column
             if i + 1 < len(lines) and stripped != "" and stripped != "columns:":
                 next_line = lines[i + 1].strip()
-                # If next line is a new column, add blank line after current line
                 if next_line.startswith("- name:"):
                     formatted_lines.append("")
 
-        # Ensure file ends with single newline
         while formatted_lines and formatted_lines[-1].strip() == "":
             formatted_lines.pop()
 
         result = "\n".join(formatted_lines) + "\n"
 
-        # Final pass: remove unwanted blank lines that ruamel.yaml adds
         result = result.replace("models:\n\n  - name:", "models:\n  - name:")
-        # Remove blank line between description and meta
-        result = result.replace("description: |-\n          ", "description: |-\n          ").replace(
-            "\n\n        meta:", "\n        meta:"
-        )
-        # Also handle single-line descriptions
-        import re
-
-        result = re.sub(r"(description: .+)\n\n(        meta:)", r"\1\n\2", result)
 
         return result

--- a/snowflake_semantic_tools/services/format_yaml.py
+++ b/snowflake_semantic_tools/services/format_yaml.py
@@ -340,7 +340,7 @@ class YAMLFormattingService:
                 continue
             if block_scalar_pattern.match(line):
                 return True
-            if re.match(r"^\s*(- name:|name:|columns:|models:)", line):
+            if re.match(r"^\s*(- name:|name:|columns:|models:|data_tests:|tests:|config:|meta:)", line):
                 return False
         return False
 

--- a/tests/unit/services/test_format_yaml.py
+++ b/tests/unit/services/test_format_yaml.py
@@ -351,6 +351,7 @@ models:
         formatter.format_path(test_file)
 
         result = test_file.read_text()
+        assert "description: A simple one-line description\n        config:" in result
         yaml = YAML()
         parsed = yaml.load(result)
         col = parsed["models"][0]["columns"][0]

--- a/tests/unit/services/test_format_yaml.py
+++ b/tests/unit/services/test_format_yaml.py
@@ -263,3 +263,95 @@ class TestFormatPath:
 
         assert stats["files_processed"] == 3
         assert stats["errors"] == 0
+
+
+class TestBlockScalarPreservation:
+    """Test that sst format preserves blank lines after block scalar descriptions (issue #135)."""
+
+    def test_multiline_description_preserves_blank_line_before_config(self, formatter, tmp_path):
+        """Block scalar description must keep blank line before config: to avoid corruption."""
+        input_yaml = """version: 2
+models:
+  - name: test_model
+    columns:
+      - name: behavior_tracker_id
+        description: |-
+          Foreign key to behavior_trackers.id. ON DELETE CASCADE — if the tracker is
+          removed, its choices are also deleted.
+
+        config:
+          meta:
+            sst:
+              column_type: fact
+              data_type: NUMBER
+"""
+        test_file = tmp_path / "test.yml"
+        test_file.write_text(input_yaml)
+
+        formatter.format_path(test_file)
+
+        result = test_file.read_text()
+        yaml = YAML()
+        parsed = yaml.load(result)
+        col = parsed["models"][0]["columns"][0]
+        desc = str(col["description"])
+        assert "config" not in desc, f"config leaked into description: {desc}"
+        assert col["config"]["meta"]["sst"]["column_type"] == "fact"
+        assert col["config"]["meta"]["sst"]["data_type"] == "NUMBER"
+
+    def test_config_not_absorbed_into_description(self, formatter, tmp_path):
+        """Config block must not become part of the description text."""
+        input_yaml = """version: 2
+models:
+  - name: test_model
+    columns:
+      - name: my_column
+        description: |-
+          This is a multiline description that spans
+          multiple lines for clarity.
+
+        config:
+          meta:
+            sst:
+              column_type: dimension
+              data_type: TEXT
+              synonyms:
+                - my col
+"""
+        test_file = tmp_path / "test.yml"
+        test_file.write_text(input_yaml)
+
+        formatter.format_path(test_file)
+
+        result = test_file.read_text()
+        yaml = YAML()
+        parsed = yaml.load(result)
+        col = parsed["models"][0]["columns"][0]
+        desc = str(col["description"])
+        assert "column_type" not in desc, f"config content leaked into description: {desc}"
+        assert "synonyms" not in desc, f"config content leaked into description: {desc}"
+        assert col["config"]["meta"]["sst"]["column_type"] == "dimension"
+
+    def test_single_line_description_before_config_still_compact(self, formatter, tmp_path):
+        """Single-line descriptions should NOT have a blank line before config."""
+        input_yaml = """version: 2
+models:
+  - name: test_model
+    columns:
+      - name: simple_col
+        description: A simple one-line description
+        config:
+          meta:
+            sst:
+              column_type: fact
+"""
+        test_file = tmp_path / "test.yml"
+        test_file.write_text(input_yaml)
+
+        formatter.format_path(test_file)
+
+        result = test_file.read_text()
+        yaml = YAML()
+        parsed = yaml.load(result)
+        col = parsed["models"][0]["columns"][0]
+        assert col["config"]["meta"]["sst"]["column_type"] == "fact"


### PR DESCRIPTION
## PR Chain
**Position**: 2nd in chain
1. PR #167 — feature/diagnostics-overhaul (base: main) — IN REVIEW
2. **This PR** — fix/135-format-multiline (base: feature/diagnostics-overhaul)

Merge order: #167 first, then retarget this to main.

---

## Summary
- Fix `sst format` corrupting YAML files with multiline (`|-`) descriptions
- The formatter was removing blank lines before `config:` that YAML block scalars require as terminators
- Config blocks were being absorbed into description text, producing invalid/duplicate YAML

## Test plan
- [x] 3 new unit tests in `TestBlockScalarPreservation`
- [x] E2E: added multiline description to sst-jaffle-shop, ran `sst format --force`, verified no corruption
- [x] Full pipeline: validate → extract → generate → deploy (all pass)
- [x] 1470 total tests pass

## Root cause
`_adjust_blank_lines()` had an unconditional `continue` when the next line was `config:` — it always removed the preceding blank line. For block scalars, that blank line is syntactically required.

Closes #135

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)
