### PR TITLE
[SST-125] Column-level exclusion with config.meta.sst.exclude

### DIFF
--- a/docs/concepts/semantic-models.md
+++ b/docs/concepts/semantic-models.md
@@ -159,7 +159,40 @@ models:
                 - "ORD-001"
                 - "ORD-002"
               is_enum: false            # Optional: true if sample_values is exhaustive
+              exclude: false           # Optional: true to hide column from semantic view
 ```
+
+### Column Exclusion
+
+Add `exclude: true` to any column's `config.meta.sst` to hide it from the semantic view entirely:
+
+```yaml
+columns:
+  - name: email_address
+    description: Customer email (PII)
+    config:
+      meta:
+        sst:
+          exclude: true   # Column will not appear in the semantic view
+
+  - name: customer_id
+    config:
+      meta:
+        sst:
+          column_type: dimension
+          data_type: TEXT
+```
+
+Excluded columns are:
+- **Skipped during enrichment** — no sample values, synonyms, or type detection
+- **Omitted from extraction** — not written to SM_DIMENSIONS/SM_FACTS/SM_TIME_DIMENSIONS
+- **Absent from generated DDL** — do not appear in DIMENSIONS or FACTS clauses
+- **Skipped in validation** — no `column_type` requirement
+
+Use cases:
+- PII columns on joined tables that shouldn't be queryable via Cortex Agents
+- Internal/technical columns (ETL timestamps, hash keys, debug flags)
+- Columns that exist in the warehouse but aren't relevant to the semantic layer
 
 ### UNIQUE Keys for ASOF Relationships
 

--- a/snowflake_semantic_tools/core/diagnostics/error_codes.py
+++ b/snowflake_semantic_tools/core/diagnostics/error_codes.py
@@ -213,8 +213,12 @@ _register(
     ErrorCategory.VALIDATION,
     "Remove the invalid fields — derived metrics are view-scoped",
 )
-
-# --- Relationship validation ---
+_register(
+    "SST-V047",
+    "Excluded column referenced in expression",
+    ErrorCategory.VALIDATION,
+    "Remove the reference or un-exclude the column (config.meta.sst.exclude: false)",
+)
 _register(
     "SST-V040",
     "Missing relationship field",

--- a/snowflake_semantic_tools/core/enrichment/metadata_enricher.py
+++ b/snowflake_semantic_tools/core/enrichment/metadata_enricher.py
@@ -512,7 +512,7 @@ class MetadataEnricher:
         # Process each column
         updated_columns = []
         for idx, table_col in enumerate(table_columns, 1):
-            col_name_upper = table_col["column_name"].upper() if "column_name" in table_col else ""
+            col_name_upper = (table_col.get("name") or table_col.get("column_name") or "").upper()
             existing_col = existing_lookup.get(col_name_upper, {})
             sst_meta = existing_col.get("config", {}).get("meta", {}).get("sst", {}) or existing_col.get(
                 "meta", {}

--- a/snowflake_semantic_tools/core/enrichment/metadata_enricher.py
+++ b/snowflake_semantic_tools/core/enrichment/metadata_enricher.py
@@ -512,6 +512,15 @@ class MetadataEnricher:
         # Process each column
         updated_columns = []
         for idx, table_col in enumerate(table_columns, 1):
+            col_name_upper = table_col["column_name"].upper() if "column_name" in table_col else ""
+            existing_col = existing_lookup.get(col_name_upper, {})
+            sst_meta = existing_col.get("config", {}).get("meta", {}).get("sst", {}) or existing_col.get(
+                "meta", {}
+            ).get("sst", {})
+            if sst_meta.get("exclude"):
+                updated_columns.append(existing_col)
+                continue
+
             column = self._process_single_column(
                 table_col,
                 existing_lookup,

--- a/snowflake_semantic_tools/core/parsing/parsers/data_extractors.py
+++ b/snowflake_semantic_tools/core/parsing/parsers/data_extractors.py
@@ -303,18 +303,19 @@ def extract_column_info(column: Dict[str, Any], table_name: str, file_path: Path
         column_record = {
             "table_name": table_name,
             "name": name.upper() if name else name,
-            "expr": name.upper() if name else name,  # expr is just the column name
-            "column_type": sst_meta.get("column_type"),  # Extract column_type from meta.sst
+            "expr": name.upper() if name else name,
+            "column_type": sst_meta.get("column_type"),
             "data_type": data_type,
-            "_native_data_type": native_data_type,  # Preserve original for validation
-            "_sst_data_type": sst_data_type,  # Preserve original for validation
+            "_native_data_type": native_data_type,
+            "_sst_data_type": sst_data_type,
             "description": description,
             "synonyms": sst_meta.get("synonyms", []),
             "sample_values": sst_meta.get("sample_values", []),
             "is_enum": sst_meta.get("is_enum", False),
             "visibility": sst_meta.get("visibility"),
             "tags": sst_meta.get("tags"),
-            "source_file": str(file_path),  # Store the file path for validation errors
+            "exclude": sst_meta.get("exclude", False),
+            "source_file": str(file_path),
         }
 
         return column_record

--- a/snowflake_semantic_tools/core/parsing/parsers/dbt_parser.py
+++ b/snowflake_semantic_tools/core/parsing/parsers/dbt_parser.py
@@ -155,6 +155,11 @@ def parse_single_model(
     table_name = model.get("name", "unknown")
 
     for column in columns:
+        col_sst_meta = get_sst_meta(column, node_type="column", node_name=column.get("name", ""), emit_warning=False)
+        if col_sst_meta.get("exclude"):
+            logger.debug(f"Skipping excluded column '{column.get('name', '')}' in table '{table_name}'")
+            continue
+
         column_data = extract_column_info(column, table_name, file_path)
 
         # Get column_type for classification (preserve original in column_data for validation)

--- a/snowflake_semantic_tools/core/validation/rules/dbt_models.py
+++ b/snowflake_semantic_tools/core/validation/rules/dbt_models.py
@@ -526,6 +526,20 @@ class DbtModelValidator:
         column_name = column.get("name", "unknown")
         source_file = column.get("source_file")
 
+        if column.get("exclude"):
+            if column.get("column_type"):
+                result.add_warning(
+                    f"Column '{column_name}' in table '{table_name}' has both 'exclude: true' and "
+                    f"'column_type: {column.get('column_type')}'. The column will be excluded from "
+                    f"the semantic view — column_type is ignored.",
+                    file_path=source_file,
+                    rule_id="SST-V047",
+                    suggestion="Remove column_type or remove exclude: true",
+                    entity_name=column_name,
+                    context={"table": table_name, "column": column_name},
+                )
+            return
+
         # Check required column fields
         self._check_required_column_fields(column, table_name, column_name, source_file, result)
 

--- a/snowflake_semantic_tools/core/validation/rules/dbt_models.py
+++ b/snowflake_semantic_tools/core/validation/rules/dbt_models.py
@@ -529,6 +529,20 @@ class DbtModelValidator:
         column_name = column.get("name", "unknown")
         source_file = column.get("source_file")
 
+        if column.get("exclude"):
+            if column.get("column_type"):
+                result.add_warning(
+                    f"Column '{column_name}' in table '{table_name}' has both 'exclude: true' and "
+                    f"'column_type: {column.get('column_type')}'. The column will be excluded from "
+                    f"the semantic view — column_type is ignored.",
+                    file_path=source_file,
+                    rule_id="SST-V047",
+                    suggestion="Remove column_type or remove exclude: true",
+                    entity_name=column_name,
+                    context={"table": table_name, "column": column_name},
+                )
+            return
+
         # Check required column fields
         self._check_required_column_fields(column, table_name, column_name, source_file, result)
 

--- a/snowflake_semantic_tools/core/validation/rules/dbt_models.py
+++ b/snowflake_semantic_tools/core/validation/rules/dbt_models.py
@@ -149,6 +149,9 @@ class DbtModelValidator:
         # Check for models that should be included but aren't
         self._check_missing_models(models, tables, result)
 
+        # Check for excluded columns with conflicting column_type (V047)
+        self._check_excluded_column_conflicts(models, result)
+
         # Report each skipped table as an individual warning
         if skipped_tables:
             for table_name, missing_fields, source_file in sorted(skipped_tables):
@@ -525,20 +528,6 @@ class DbtModelValidator:
         """Validate a single column."""
         column_name = column.get("name", "unknown")
         source_file = column.get("source_file")
-
-        if column.get("exclude"):
-            if column.get("column_type"):
-                result.add_warning(
-                    f"Column '{column_name}' in table '{table_name}' has both 'exclude: true' and "
-                    f"'column_type: {column.get('column_type')}'. The column will be excluded from "
-                    f"the semantic view — column_type is ignored.",
-                    file_path=source_file,
-                    rule_id="SST-V047",
-                    suggestion="Remove column_type or remove exclude: true",
-                    entity_name=column_name,
-                    context={"table": table_name, "column": column_name},
-                )
-            return
 
         # Check required column fields
         self._check_required_column_fields(column, table_name, column_name, source_file, result)
@@ -969,6 +958,29 @@ class DbtModelValidator:
                         "level": "column",
                     },
                 )
+
+    def _check_excluded_column_conflicts(self, models: List[Dict[str, Any]], result: ValidationResult):
+        """Check for columns with both exclude: true and column_type set (V047)."""
+        for model in models:
+            model_name = model.get("name", "unknown")
+            source_file = model.get("source_file") or model.get("path")
+            sst_meta = get_sst_meta(model, node_type="model", node_name=model_name, emit_warning=False)
+            if not sst_meta:
+                continue
+            for column in model.get("columns", []):
+                col_name = column.get("name", "unknown")
+                col_sst = get_sst_meta(column, node_type="column", node_name=col_name, emit_warning=False)
+                if col_sst.get("exclude") and col_sst.get("column_type"):
+                    result.add_warning(
+                        f"Column '{col_name}' in table '{model_name}' has both 'exclude: true' and "
+                        f"'column_type: {col_sst.get('column_type')}'. The column will be excluded from "
+                        f"the semantic view — column_type is ignored.",
+                        file_path=source_file,
+                        rule_id="SST-V047",
+                        suggestion="Remove column_type or remove exclude: true",
+                        entity_name=col_name,
+                        context={"table": model_name, "column": col_name},
+                    )
 
     def _check_missing_models(
         self, all_models: List[Dict[str, Any]], included_tables: List[Dict[str, Any]], result: ValidationResult

--- a/tests/unit/core/test_column_exclusion.py
+++ b/tests/unit/core/test_column_exclusion.py
@@ -1,0 +1,149 @@
+"""
+Unit tests for column-level exclusion (meta.sst.exclude: true).
+Issue #125: Hide columns from semantic view generation.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from snowflake_semantic_tools.core.models import ValidationResult
+from snowflake_semantic_tools.core.parsing.parsers.data_extractors import extract_column_info
+from snowflake_semantic_tools.core.parsing.parsers.dbt_parser import parse_single_model
+from snowflake_semantic_tools.core.validation.rules.dbt_models import DbtModelValidator
+
+
+class TestExtractionFiltersExcludedColumns:
+    """Excluded columns should not appear in SM_DIMENSIONS/SM_FACTS/SM_TIME_DIMENSIONS."""
+
+    def test_excluded_dimension_not_extracted(self):
+        model = {
+            "name": "orders",
+            "config": {"meta": {"sst": {"database": "DB", "schema": "SCH", "primary_key": "order_id"}}},
+            "columns": [
+                {
+                    "name": "order_id",
+                    "config": {"meta": {"sst": {"column_type": "dimension", "data_type": "TEXT"}}},
+                },
+                {
+                    "name": "internal_hash",
+                    "config": {"meta": {"sst": {"column_type": "dimension", "data_type": "TEXT", "exclude": True}}},
+                },
+            ],
+        }
+        from snowflake_semantic_tools.core.parsing.parsers.error_handler import ErrorTracker
+
+        result = parse_single_model(model, Path("/tmp/test.yml"), ErrorTracker())
+        dim_names = [d["name"] for d in result["sm_dimensions"]]
+        assert "ORDER_ID" in dim_names
+        assert "INTERNAL_HASH" not in dim_names
+
+    def test_excluded_fact_not_extracted(self):
+        model = {
+            "name": "orders",
+            "config": {"meta": {"sst": {"database": "DB", "schema": "SCH", "primary_key": "order_id"}}},
+            "columns": [
+                {
+                    "name": "order_total",
+                    "config": {"meta": {"sst": {"column_type": "fact", "data_type": "NUMBER"}}},
+                },
+                {
+                    "name": "debug_score",
+                    "config": {"meta": {"sst": {"column_type": "fact", "data_type": "NUMBER", "exclude": True}}},
+                },
+            ],
+        }
+        from snowflake_semantic_tools.core.parsing.parsers.error_handler import ErrorTracker
+
+        result = parse_single_model(model, Path("/tmp/test.yml"), ErrorTracker())
+        fact_names = [f["name"] for f in result["sm_facts"]]
+        assert "ORDER_TOTAL" in fact_names
+        assert "DEBUG_SCORE" not in fact_names
+
+    def test_non_excluded_column_still_extracted(self):
+        model = {
+            "name": "orders",
+            "config": {"meta": {"sst": {"database": "DB", "schema": "SCH", "primary_key": "order_id"}}},
+            "columns": [
+                {
+                    "name": "col_a",
+                    "config": {"meta": {"sst": {"column_type": "dimension", "data_type": "TEXT", "exclude": False}}},
+                },
+            ],
+        }
+        from snowflake_semantic_tools.core.parsing.parsers.error_handler import ErrorTracker
+
+        result = parse_single_model(model, Path("/tmp/test.yml"), ErrorTracker())
+        dim_names = [d["name"] for d in result["sm_dimensions"]]
+        assert "COL_A" in dim_names
+
+
+class TestValidationSkipsExcludedColumns:
+    """Excluded columns should not trigger missing column_type errors."""
+
+    @pytest.fixture
+    def validator(self):
+        return DbtModelValidator()
+
+    def test_excluded_column_without_column_type_no_error(self, validator):
+        columns = [
+            {
+                "name": "email",
+                "exclude": True,
+                "source_file": "/tmp/test.yml",
+            }
+        ]
+        result = ValidationResult()
+        for col in columns:
+            validator._validate_column(col, "users", result)
+        errors = result.get_errors()
+        assert len(errors) == 0
+
+    def test_excluded_column_with_column_type_warns(self, validator):
+        columns = [
+            {
+                "name": "email",
+                "exclude": True,
+                "column_type": "dimension",
+                "source_file": "/tmp/test.yml",
+            }
+        ]
+        result = ValidationResult()
+        for col in columns:
+            validator._validate_column(col, "users", result)
+        warnings = [i for i in result.issues if i.severity.name == "WARNING"]
+        assert len(warnings) == 1
+        assert "V047" in warnings[0].rule_id
+
+    def test_non_excluded_column_still_validated(self, validator):
+        columns = [
+            {
+                "name": "bad_col",
+                "source_file": "/tmp/test.yml",
+            }
+        ]
+        result = ValidationResult()
+        for col in columns:
+            validator._validate_column(col, "users", result)
+        errors = result.get_errors()
+        assert any("column_type" in str(e.message) for e in errors)
+
+
+class TestExtractColumnInfoIncludesExcludeField:
+    """extract_column_info should pass through the exclude flag."""
+
+    def test_exclude_true_in_record(self):
+        column = {
+            "name": "secret_col",
+            "config": {"meta": {"sst": {"column_type": "dimension", "data_type": "TEXT", "exclude": True}}},
+        }
+        record = extract_column_info(column, "my_table", Path("/tmp/test.yml"))
+        assert record["exclude"] is True
+
+    def test_exclude_false_by_default(self):
+        column = {
+            "name": "normal_col",
+            "config": {"meta": {"sst": {"column_type": "dimension", "data_type": "TEXT"}}},
+        }
+        record = extract_column_info(column, "my_table", Path("/tmp/test.yml"))
+        assert record["exclude"] is False


### PR DESCRIPTION
## PR Chain
**Position**: 5th in chain
1. PR #167 — feature/diagnostics-overhaul (base: main) — IN REVIEW
2. PR #169 — fix/135-format-multiline
3. PR #170 — chore/130-remove-cursor
4. PR #171 — fix/159-tag-validation
5. **This PR** — feat/125-column-exclusion (base: fix/159-tag-validation)

Merge order: #167 → #169 → #170 → #171 → this.

---

## Summary
Add `config.meta.sst.exclude: true` to hide columns from semantic view generation.

- **Extraction**: excluded columns skipped — not written to SM_DIMENSIONS/SM_FACTS
- **Enrichment**: excluded columns preserved as-is, no sample values/synonyms fetched
- **Validation**: skip column_type requirement; V047 warns on contradictory config
- **Generation**: excluded columns absent from DDL

## Test plan
- [x] 8 new unit tests in `tests/unit/core/test_column_exclusion.py`
- [x] E2E: excluded `order_total_cents` from sst-jaffle-shop, verified absent from deployed view
- [x] Confirmed non-excluded columns still work (`ORDER_TOTAL` returns data)
- [x] 1478 total tests pass

## Use cases
- PII columns on joined tables (email, phone) hidden from Cortex Agents
- Internal/technical columns (ETL timestamps, hash keys)
- Columns that exist in warehouse but shouldn't be in semantic layer

Closes #125

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)
