### PR TITLE
[SST-172] Validate unique_keys does not overlap primary_key

### DIFF
--- a/snowflake_semantic_tools/core/diagnostics/error_codes.py
+++ b/snowflake_semantic_tools/core/diagnostics/error_codes.py
@@ -220,6 +220,12 @@ _register(
     "Remove the reference or un-exclude the column (config.meta.sst.exclude: false)",
 )
 _register(
+    "SST-V048",
+    "Primary key and unique keys overlap",
+    ErrorCategory.VALIDATION,
+    "Remove overlapping columns from unique_keys — primary_key is already unique",
+)
+_register(
     "SST-V040",
     "Missing relationship field",
     ErrorCategory.VALIDATION,

--- a/snowflake_semantic_tools/core/validation/rules/dbt_models.py
+++ b/snowflake_semantic_tools/core/validation/rules/dbt_models.py
@@ -378,6 +378,22 @@ class DbtModelValidator:
                     context={"table": table_name, "primary_key": pk, "level": "table"},
                 )
 
+        unique_keys = table.get("unique_keys", [])
+        if unique_keys and isinstance(unique_keys, list):
+            pk_set = {p.upper().strip() for p in primary_keys}
+            uk_set = {u.upper().strip() for u in unique_keys if isinstance(u, str)}
+            overlap = pk_set & uk_set
+            if overlap:
+                result.add_error(
+                    f"Table '{table_name}' has columns in both primary_key and unique_keys: "
+                    f"{sorted(overlap)}. Snowflake rejects duplicate primary/unique key declarations.",
+                    file_path=source_file,
+                    rule_id="SST-V048",
+                    suggestion="Remove overlapping columns from unique_keys — primary_key is already unique",
+                    entity_name=table_name,
+                    context={"table": table_name, "overlap": sorted(overlap)},
+                )
+
     def _check_table_synonym_content(self, table: Dict[str, Any], table_name: str, result: ValidationResult):
         """Check that table synonyms don't contain characters that break SQL generation."""
         source_file = table.get("source_file")

--- a/snowflake_semantic_tools/core/validation/rules/dbt_models.py
+++ b/snowflake_semantic_tools/core/validation/rules/dbt_models.py
@@ -380,18 +380,19 @@ class DbtModelValidator:
 
         unique_keys = table.get("unique_keys", [])
         if unique_keys and isinstance(unique_keys, list):
-            pk_set = {p.upper().strip() for p in primary_keys}
-            uk_set = {u.upper().strip() for u in unique_keys if isinstance(u, str)}
-            overlap = pk_set & uk_set
-            if overlap:
+            pk_normalized = {p.upper().strip(): p for p in primary_keys}
+            uk_normalized = {u.upper().strip(): u for u in unique_keys if isinstance(u, str)}
+            overlap_keys = set(pk_normalized.keys()) & set(uk_normalized.keys())
+            if overlap_keys:
+                overlap_original = sorted(uk_normalized[k] for k in overlap_keys)
                 result.add_error(
                     f"Table '{table_name}' has columns in both primary_key and unique_keys: "
-                    f"{sorted(overlap)}. Snowflake rejects duplicate primary/unique key declarations.",
+                    f"{overlap_original}. Snowflake rejects duplicate primary/unique key declarations.",
                     file_path=source_file,
                     rule_id="SST-V048",
                     suggestion="Remove overlapping columns from unique_keys — primary_key is already unique",
                     entity_name=table_name,
-                    context={"table": table_name, "overlap": sorted(overlap)},
+                    context={"table": table_name, "overlap": overlap_original},
                 )
 
     def _check_table_synonym_content(self, table: Dict[str, Any], table_name: str, result: ValidationResult):

--- a/tests/unit/core/test_column_exclusion.py
+++ b/tests/unit/core/test_column_exclusion.py
@@ -191,3 +191,16 @@ class TestV048PrimaryKeyUniqueKeysOverlap:
         validator._check_primary_key(table, "ORDERS", [], [], [], result)
         errors = [e for e in result.get_errors() if e.rule_id == "SST-V048"]
         assert len(errors) == 0
+
+    def test_case_insensitive_overlap(self, validator):
+        table = {
+            "table_name": "ORDERS",
+            "primary_key": ["Order_ID"],
+            "unique_keys": ["order_id"],
+            "source_file": "/tmp/test.yml",
+        }
+        result = ValidationResult()
+        validator._check_primary_key(table, "ORDERS", [], [], [], result)
+        errors = [e for e in result.get_errors() if e.rule_id == "SST-V048"]
+        assert len(errors) == 1
+        assert "order_id" in str(errors[0].message)

--- a/tests/unit/core/test_column_exclusion.py
+++ b/tests/unit/core/test_column_exclusion.py
@@ -147,3 +147,47 @@ class TestExtractColumnInfoIncludesExcludeField:
         }
         record = extract_column_info(column, "my_table", Path("/tmp/test.yml"))
         assert record["exclude"] is False
+
+
+class TestV048PrimaryKeyUniqueKeysOverlap:
+    """V048: unique_keys must not overlap with primary_key."""
+
+    @pytest.fixture
+    def validator(self):
+        return DbtModelValidator()
+
+    def test_overlap_produces_error(self, validator):
+        table = {
+            "table_name": "ORDERS",
+            "primary_key": ["order_id"],
+            "unique_keys": ["order_id"],
+            "source_file": "/tmp/test.yml",
+        }
+        result = ValidationResult()
+        validator._check_primary_key(table, "ORDERS", [], [], [], result)
+        errors = [e for e in result.get_errors() if e.rule_id == "SST-V048"]
+        assert len(errors) == 1
+        assert "primary_key" in str(errors[0].message) or "unique_keys" in str(errors[0].message)
+
+    def test_no_overlap_no_error(self, validator):
+        table = {
+            "table_name": "ORDERS",
+            "primary_key": ["order_id"],
+            "unique_keys": ["customer_id", "ordered_at"],
+            "source_file": "/tmp/test.yml",
+        }
+        result = ValidationResult()
+        validator._check_primary_key(table, "ORDERS", [], [], [], result)
+        errors = [e for e in result.get_errors() if e.rule_id == "SST-V048"]
+        assert len(errors) == 0
+
+    def test_no_unique_keys_no_error(self, validator):
+        table = {
+            "table_name": "ORDERS",
+            "primary_key": ["order_id"],
+            "source_file": "/tmp/test.yml",
+        }
+        result = ValidationResult()
+        validator._check_primary_key(table, "ORDERS", [], [], [], result)
+        errors = [e for e in result.get_errors() if e.rule_id == "SST-V048"]
+        assert len(errors) == 0


### PR DESCRIPTION
## PR Chain
**Position**: 6th in chain
1. PR #167 — feature/diagnostics-overhaul (base: main) — IN REVIEW
2. PR #169 — fix/135-format-multiline
3. PR #170 — chore/130-remove-cursor
4. PR #171 — fix/159-tag-validation
5. PR #173 — feat/125-column-exclusion
6. **This PR** — fix/172-unique-key-overlap (base: feat/125-column-exclusion)

Merge order: #167 → #169 → #170 → #171 → #173 → this.

---

## Summary
Add SST-V048 validation rule: detect when `unique_keys` overlaps with `primary_key`.

Snowflake rejects DDL with "duplicate primary or unique keys" error. This was previously only caught at generation time with a cryptic Snowflake error. Now caught at `sst validate` with a clear message.

## Test plan
- [x] 3 new unit tests for V048 (overlap, no-overlap, no-unique-keys)
- [x] 1481 total tests pass

Closes #172

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)
