### PR TITLE
[SST-124] Add sst drop command for removing semantic views

### DIFF
--- a/snowflake_semantic_tools/interfaces/cli/commands/drop.py
+++ b/snowflake_semantic_tools/interfaces/cli/commands/drop.py
@@ -5,6 +5,8 @@ CLI command for removing semantic views from Snowflake.
 Supports dropping specific views or pruning orphaned views.
 """
 
+import re
+
 import click
 
 from snowflake_semantic_tools._version import __version__
@@ -60,6 +62,9 @@ def drop(ctx, dbt_target, db, schema, view_name, prune, dry_run, yes, verbose):
     if not view_name and not prune:
         raise click.UsageError("Specify a VIEW_NAME to drop, or use --prune to remove orphaned views.")
 
+    if view_name and prune:
+        raise click.UsageError("Cannot use both VIEW_NAME and --prune. Choose one mode.")
+
     config = build_snowflake_config(dbt_target)
     database, schema_name = get_target_database_schema(dbt_target, db, schema)
 
@@ -68,34 +73,48 @@ def drop(ctx, dbt_target, db, schema, view_name, prune, dry_run, yes, verbose):
     try:
         with snowflake_session(config=config) as client:
             if view_name:
-                _drop_specific_view(client, database, schema_name, view_name, dry_run, output)
+                success = _drop_specific_view(client, database, schema_name, view_name, dry_run, output)
             elif prune:
-                _prune_orphaned_views(client, database, schema_name, dry_run, yes, verbose, output)
+                success = _prune_orphaned_views(client, database, schema_name, dry_run, yes, verbose, output)
+            else:
+                success = True
     except Exception as e:
         output.error(str(e))
         raise click.Abort()
 
+    if not success:
+        raise SystemExit(1)
 
-def _drop_specific_view(client, database: str, schema: str, view_name: str, dry_run: bool, output: CLIOutput):
+
+_VALID_IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _drop_specific_view(client, database: str, schema: str, view_name: str, dry_run: bool, output: CLIOutput) -> bool:
     """Drop a single named semantic view."""
+    if not _VALID_IDENTIFIER.match(view_name):
+        output.error(f"Invalid view name: '{view_name}'. Must be a valid SQL identifier.")
+        return False
+
     fqn = f"{database}.{schema}.{view_name.upper()}"
 
     if dry_run:
         output.info(f"Would drop: {fqn}")
         output.info("DRY RUN — no views were dropped.")
-        return
+        return True
 
     sql = f"DROP SEMANTIC VIEW IF EXISTS {fqn}"
     try:
         client.execute_query(sql)
         output.success(f"Dropped: {fqn}")
+        return True
     except Exception as e:
         output.error(f"Failed to drop {fqn}: {e}")
+        return False
 
 
 def _prune_orphaned_views(
     client, database: str, schema: str, dry_run: bool, yes: bool, verbose: bool, output: CLIOutput
-):
+) -> bool:
     """Find and drop orphaned semantic views (not tracked in SM_SEMANTIC_VIEWS)."""
     output.info(f"Scanning semantic views in: {database}.{schema}")
 
@@ -117,7 +136,7 @@ def _prune_orphaned_views(
 
     if not orphaned:
         output.success("No orphaned semantic views found. Schema is clean.")
-        return
+        return True
 
     output.info(f"\n{len(orphaned)} orphaned semantic view(s) detected:")
     for name in orphaned:
@@ -125,7 +144,7 @@ def _prune_orphaned_views(
 
     if dry_run:
         output.info("\nDRY RUN — no views were dropped. Re-run without --dry-run to drop.")
-        return
+        return True
 
     if not yes:
         click.confirm(f"\nDrop {len(orphaned)} orphaned view(s)?", abort=True)
@@ -141,3 +160,4 @@ def _prune_orphaned_views(
             output.error(f"Failed to drop {fqn}: {e}")
 
     output.success(f"\nDropped {dropped}/{len(orphaned)} orphaned view(s).")
+    return dropped == len(orphaned)

--- a/snowflake_semantic_tools/interfaces/cli/commands/drop.py
+++ b/snowflake_semantic_tools/interfaces/cli/commands/drop.py
@@ -1,0 +1,143 @@
+"""
+Drop Command
+
+CLI command for removing semantic views from Snowflake.
+Supports dropping specific views or pruning orphaned views.
+"""
+
+import click
+
+from snowflake_semantic_tools._version import __version__
+from snowflake_semantic_tools.interfaces.cli.options import database_schema_options, target_option
+from snowflake_semantic_tools.interfaces.cli.output import CLIOutput
+from snowflake_semantic_tools.interfaces.cli.utils import (
+    build_snowflake_config,
+    get_target_database_schema,
+    setup_command,
+)
+from snowflake_semantic_tools.shared.utils import get_logger
+
+logger = get_logger("cli.drop")
+
+
+@click.command(
+    short_help="Remove semantic views from Snowflake",
+)
+@target_option
+@database_schema_options
+@click.argument("view_name", required=False)
+@click.option("--prune", is_flag=True, help="Drop all orphaned views not tracked in SM_SEMANTIC_VIEWS")
+@click.option("--dry-run", is_flag=True, help="Show what would be dropped without executing")
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt (for CI)")
+@click.option("--verbose", "-V", is_flag=True, help="Show detailed output")
+@click.pass_context
+def drop(ctx, dbt_target, db, schema, view_name, prune, dry_run, yes, verbose):
+    """Remove semantic views from Snowflake.
+
+    \b
+    Two modes:
+      sst drop VIEW_NAME          Drop a specific semantic view
+      sst drop --prune            Find and drop orphaned views
+
+    \b
+    Examples:
+      sst drop OLD_VIEW_NAME --target prod
+      sst drop --prune --dry-run --target prod
+      sst drop --prune --yes --target prod       (CI mode, no prompt)
+
+    \b
+    Safety:
+      --prune without --yes shows a confirmation prompt before dropping.
+      --dry-run shows what would be dropped without executing.
+
+    \b
+    Next step: sst generate --all (to recreate views if needed)
+    """
+    setup_command(ctx)
+    output = CLIOutput(verbose=verbose)
+    output.header(f"sst drop (v{__version__})")
+
+    if not view_name and not prune:
+        raise click.UsageError("Specify a VIEW_NAME to drop, or use --prune to remove orphaned views.")
+
+    config = build_snowflake_config(dbt_target)
+    database, schema_name = get_target_database_schema(dbt_target, db, schema)
+
+    from snowflake_semantic_tools.interfaces.cli.utils import snowflake_session
+
+    try:
+        with snowflake_session(config=config) as client:
+            if view_name:
+                _drop_specific_view(client, database, schema_name, view_name, dry_run, output)
+            elif prune:
+                _prune_orphaned_views(client, database, schema_name, dry_run, yes, verbose, output)
+    except Exception as e:
+        output.error(str(e))
+        raise click.Abort()
+
+
+def _drop_specific_view(client, database: str, schema: str, view_name: str, dry_run: bool, output: CLIOutput):
+    """Drop a single named semantic view."""
+    fqn = f"{database}.{schema}.{view_name.upper()}"
+
+    if dry_run:
+        output.info(f"Would drop: {fqn}")
+        output.info("DRY RUN — no views were dropped.")
+        return
+
+    sql = f"DROP SEMANTIC VIEW IF EXISTS {fqn}"
+    try:
+        client.execute_query(sql)
+        output.success(f"Dropped: {fqn}")
+    except Exception as e:
+        output.error(f"Failed to drop {fqn}: {e}")
+
+
+def _prune_orphaned_views(
+    client, database: str, schema: str, dry_run: bool, yes: bool, verbose: bool, output: CLIOutput
+):
+    """Find and drop orphaned semantic views (not tracked in SM_SEMANTIC_VIEWS)."""
+    output.info(f"Scanning semantic views in: {database}.{schema}")
+
+    df = client.execute_query(f"SHOW SEMANTIC VIEWS IN {database}.{schema}")
+    actual_views = set(df["name"].str.upper().tolist()) if not df.empty else set()
+
+    sm_table = f"{database}.{schema}.SM_SEMANTIC_VIEWS"
+    try:
+        tracked_df = client.execute_query(f"SELECT UPPER(NAME) AS NAME FROM {sm_table}")
+        tracked_views = set(tracked_df["NAME"].tolist()) if not tracked_df.empty else set()
+    except Exception:
+        output.warning(f"Could not read {sm_table} — assuming no tracked views")
+        tracked_views = set()
+
+    orphaned = sorted(actual_views - tracked_views)
+
+    output.info(f"Found {len(actual_views)} semantic views in schema")
+    output.info(f"Found {len(tracked_views)} views in SM_SEMANTIC_VIEWS tracking table")
+
+    if not orphaned:
+        output.success("No orphaned semantic views found. Schema is clean.")
+        return
+
+    output.info(f"\n{len(orphaned)} orphaned semantic view(s) detected:")
+    for name in orphaned:
+        output.info(f"  • {name}")
+
+    if dry_run:
+        output.info("\nDRY RUN — no views were dropped. Re-run without --dry-run to drop.")
+        return
+
+    if not yes:
+        click.confirm(f"\nDrop {len(orphaned)} orphaned view(s)?", abort=True)
+
+    dropped = 0
+    for name in orphaned:
+        fqn = f"{database}.{schema}.{name}"
+        try:
+            client.execute_query(f"DROP SEMANTIC VIEW IF EXISTS {fqn}")
+            output.success(f"Dropped: {fqn}")
+            dropped += 1
+        except Exception as e:
+            output.error(f"Failed to drop {fqn}: {e}")
+
+    output.success(f"\nDropped {dropped}/{len(orphaned)} orphaned view(s).")

--- a/snowflake_semantic_tools/interfaces/cli/main.py
+++ b/snowflake_semantic_tools/interfaces/cli/main.py
@@ -115,6 +115,7 @@ LAZY_COMMANDS = {
     "validate": ("snowflake_semantic_tools.interfaces.cli.commands.validate", "validate"),
     "generate": ("snowflake_semantic_tools.interfaces.cli.commands.generate", "generate"),
     "deploy": ("snowflake_semantic_tools.interfaces.cli.commands.deploy", "deploy"),
+    "drop": ("snowflake_semantic_tools.interfaces.cli.commands.drop", "drop"),
     "list": ("snowflake_semantic_tools.interfaces.cli.commands.list", "list_cmd"),
     "migrate-meta": ("snowflake_semantic_tools.interfaces.cli.commands.migrate_meta", "migrate_meta"),
 }

--- a/tests/unit/interfaces/cli/test_drop.py
+++ b/tests/unit/interfaces/cli/test_drop.py
@@ -1,0 +1,102 @@
+"""
+Unit tests for sst drop command.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from snowflake_semantic_tools.interfaces.cli.commands.drop import (
+    _drop_specific_view,
+    _prune_orphaned_views,
+)
+from snowflake_semantic_tools.interfaces.cli.output import CLIOutput
+
+
+class TestDropSpecificView:
+    """Test dropping a single named view."""
+
+    def test_dry_run_does_not_execute(self):
+        client = MagicMock()
+        output = CLIOutput(verbose=False)
+        _drop_specific_view(client, "DB", "SCHEMA", "MY_VIEW", dry_run=True, output=output)
+        client.execute_query.assert_not_called()
+
+    def test_executes_drop_statement(self):
+        client = MagicMock()
+        output = CLIOutput(verbose=False)
+
+        _drop_specific_view(client, "DB", "SCHEMA", "old_view", dry_run=False, output=output)
+
+        client.execute_query.assert_called_once_with("DROP SEMANTIC VIEW IF EXISTS DB.SCHEMA.OLD_VIEW")
+
+    def test_view_name_uppercased(self):
+        client = MagicMock()
+        output = CLIOutput(verbose=False)
+
+        _drop_specific_view(client, "MY_DB", "MY_SCHEMA", "lowercase_view", dry_run=False, output=output)
+
+        client.execute_query.assert_called_once_with("DROP SEMANTIC VIEW IF EXISTS MY_DB.MY_SCHEMA.LOWERCASE_VIEW")
+
+
+class TestPruneOrphanedViews:
+    """Test the prune logic."""
+
+    def _mock_client(self, actual_views, tracked_views):
+        client = MagicMock()
+
+        def side_effect(sql):
+            if "SHOW SEMANTIC VIEWS" in sql:
+                return pd.DataFrame({"name": actual_views}) if actual_views else pd.DataFrame()
+            elif "SM_SEMANTIC_VIEWS" in sql:
+                return pd.DataFrame({"NAME": [v.upper() for v in tracked_views]}) if tracked_views else pd.DataFrame()
+            return pd.DataFrame()
+
+        client.execute_query.side_effect = side_effect
+        return client
+
+    def test_no_orphans_reports_clean(self):
+        client = self._mock_client(
+            actual_views=["VIEW_A", "VIEW_B"],
+            tracked_views=["VIEW_A", "VIEW_B"],
+        )
+        output = CLIOutput(verbose=False)
+
+        _prune_orphaned_views(client, "DB", "SCH", dry_run=False, yes=True, verbose=False, output=output)
+
+        all_calls = [str(c) for c in client.execute_query.call_args_list]
+        drop_calls = [c for c in all_calls if "DROP" in c]
+        assert len(drop_calls) == 0
+
+    def test_orphans_detected_in_dry_run(self):
+        client = self._mock_client(
+            actual_views=["VIEW_A", "VIEW_B", "ORPHAN_1"],
+            tracked_views=["VIEW_A", "VIEW_B"],
+        )
+        output = CLIOutput(verbose=False)
+
+        _prune_orphaned_views(client, "DB", "SCH", dry_run=True, yes=False, verbose=False, output=output)
+
+        all_calls = [str(c) for c in client.execute_query.call_args_list]
+        drop_calls = [c for c in all_calls if "DROP" in c]
+        assert len(drop_calls) == 0
+
+    def test_orphans_dropped_with_yes(self):
+        client = MagicMock()
+
+        def side_effect(sql):
+            if "SHOW SEMANTIC VIEWS" in sql:
+                return pd.DataFrame({"name": ["VIEW_A", "ORPHAN_1", "ORPHAN_2"]})
+            elif "SM_SEMANTIC_VIEWS" in sql:
+                return pd.DataFrame({"NAME": ["VIEW_A"]})
+            return pd.DataFrame()
+
+        client.execute_query.side_effect = side_effect
+        output = CLIOutput(verbose=False)
+
+        _prune_orphaned_views(client, "DB", "SCH", dry_run=False, yes=True, verbose=False, output=output)
+
+        all_calls = [str(c) for c in client.execute_query.call_args_list]
+        drop_calls = [c for c in all_calls if "DROP SEMANTIC VIEW" in c]
+        assert len(drop_calls) == 2


### PR DESCRIPTION
## PR Chain
**Position**: 7th in chain
1. PR #167 — feature/diagnostics-overhaul (base: main) — IN REVIEW
2. PR #169 — fix/135-format-multiline
3. PR #170 — chore/130-remove-cursor
4. PR #171 — fix/159-tag-validation
5. PR #173 — feat/125-column-exclusion
6. PR #174 — fix/172-unique-key-overlap
7. **This PR** — feat/124-sst-drop (base: fix/172-unique-key-overlap)

Merge order: #167 → #169 → #170 → #171 → #173 → #174 → this.

---

## Summary
New `sst drop` CLI command for removing semantic views from Snowflake.

Two modes:
- `sst drop VIEW_NAME` — drop a specific semantic view
- `sst drop --prune` — find orphaned views (exist in Snowflake but not in SM_SEMANTIC_VIEWS) and drop them

Safety:
- `--dry-run` shows what would be dropped
- Interactive confirmation prompt (skip with `--yes` for CI)
- Uses `DROP SEMANTIC VIEW IF EXISTS` for idempotency

## Test plan
- [x] 6 unit tests (dry-run, execute, prune clean, prune dry-run, prune with orphans)
- [x] E2E: `sst drop --prune --dry-run --target e2e` reports 0 orphans on clean schema
- [x] 1487 total tests pass

## Usage
```bash
sst drop OLD_VIEW --target prod
sst drop --prune --dry-run --target prod
sst drop --prune --yes --target prod   # CI mode
```

Closes #124

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)
