### PR TITLE
[SST-132] Add pre-commit hooks for black, isort, and common checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.10.0
+    hooks:
+      - id: black
+        args: [--line-length=120]
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        args: [--profile=black, --line-length=120]
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+        args: [--allow-multiple-documents]
+      - id: check-added-large-files

--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ cd snowflake-semantic-tools
 # Install with Poetry (includes dev dependencies)
 poetry install --with dev
 
+# Set up pre-commit hooks (catches formatting before CI)
+pre-commit install
+
 # Verify installation
 sst --version
 

--- a/snowflake_semantic_tools/interfaces/cli/commands/validate.py
+++ b/snowflake_semantic_tools/interfaces/cli/commands/validate.py
@@ -241,7 +241,6 @@ def validate(ctx, dbt, semantic, strict, verbose, exclude, dbt_compile, verify_s
 
         if output_format == "json":
             import json as json_mod
-            import os
 
             from snowflake_semantic_tools._version import __version__ as sst_version
 


### PR DESCRIPTION
## Description

Add `.pre-commit-config.yaml` with hooks for black, isort, trailing whitespace, end-of-file fixer, YAML validation, and large file checks. This catches formatting issues locally before they reach CI.

## Related Issue

Closes #132

## Type of Change

- [x] Other (please describe): Developer tooling / quality of life improvement

## Changes Made

- Created `.pre-commit-config.yaml` with:
  - `black` (v24.10.0, line-length=120) — matches CI exactly
  - `isort` (v5.13.2, profile=black, line-length=120) — matches CI exactly
  - `trailing-whitespace` and `end-of-file-fixer`
  - `check-yaml` (with --allow-multiple-documents)
  - `check-added-large-files`
- Updated README Development Setup to include `pre-commit install` step

## Testing

- All 1494 unit tests pass
- `pre-commit` already in dev dependencies (pyproject.toml)
- Hook versions pinned to match CI (black 24.10.0, isort 5.13.2)

## Setup

After pulling this branch:
```bash
poetry install --with dev
pre-commit install
```

## PR Chain Position

PR #10 in chain. Merge order:
1. #167 → 2. #169 → 3. #170 → 4. #171 → 5. #173 → 6. #174 → 7. #175 → 8. #176 → 9. #181 → 10. **This PR**

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)
