### PR TITLE
[SST-183] Fix V091 false positives in duplicate metric detection

### DIFF
--- a/snowflake_semantic_tools/core/validation/rules/duplicates.py
+++ b/snowflake_semantic_tools/core/validation/rules/duplicates.py
@@ -11,6 +11,7 @@ Also validates that table-level synonyms are unique within each semantic view,
 as Snowflake requires unique synonyms for semantic view generation.
 """
 
+import json
 from collections import defaultdict
 from typing import Any, Dict, List, Optional
 
@@ -113,12 +114,12 @@ class DuplicateValidator:
                     if metric.get("using_relationships"):
                         sig_parts.append(f"using:{sorted(metric['using_relationships'])}")
                     if metric.get("window"):
-                        sig_parts.append(f"window:{metric['window']}")
+                        sig_parts.append(f"window:{json.dumps(metric['window'], sort_keys=True)}")
                     if metric.get("non_additive_by"):
-                        sig_parts.append(f"nab:{metric['non_additive_by']}")
+                        sig_parts.append(f"nab:{json.dumps(metric['non_additive_by'], sort_keys=True)}")
                     if metric.get("derived"):
                         sig_parts.append("derived")
-                    signature = "|".join(sig_parts)
+                    signature = "\x00".join(sig_parts)
                     expressions_seen[signature].append((i, name))
 
         # Report duplicate names

--- a/snowflake_semantic_tools/core/validation/rules/duplicates.py
+++ b/snowflake_semantic_tools/core/validation/rules/duplicates.py
@@ -104,14 +104,22 @@ class DuplicateValidator:
                 name = metric.get("name", "")
                 expr = metric.get("expr", "")
 
-                # Check duplicate names
                 if name:
                     names_seen[name.lower()].append(i)
 
-                # Check duplicate expressions (normalized)
                 if expr:
                     normalized_expr = self._normalize_expression(expr)
-                    expressions_seen[normalized_expr].append((i, name))
+                    sig_parts = [normalized_expr]
+                    if metric.get("using_relationships"):
+                        sig_parts.append(f"using:{sorted(metric['using_relationships'])}")
+                    if metric.get("window"):
+                        sig_parts.append(f"window:{metric['window']}")
+                    if metric.get("non_additive_by"):
+                        sig_parts.append(f"nab:{metric['non_additive_by']}")
+                    if metric.get("derived"):
+                        sig_parts.append("derived")
+                    signature = "|".join(sig_parts)
+                    expressions_seen[signature].append((i, name))
 
         # Report duplicate names
         for name, indices in names_seen.items():

--- a/tests/unit/core/validation/test_duplicate_detection.py
+++ b/tests/unit/core/validation/test_duplicate_detection.py
@@ -470,6 +470,16 @@ class TestV091MetricDuplicateDetection:
         warnings = [w for w in result.get_warnings() if w.rule_id == "SST-V091"]
         assert len(warnings) == 0
 
+    def test_same_expr_same_window_is_duplicate(self, validator):
+        window_config = {"partition_by": ["customer_id"], "order_by": [{"column": "ordered_at"}]}
+        data = self._make_metrics_data([
+            {"name": "metric_a", "expr": "SUM(ORDERS.TOTAL)", "window": window_config},
+            {"name": "metric_b", "expr": "SUM(ORDERS.TOTAL)", "window": window_config},
+        ])
+        result = validator.validate(data)
+        warnings = [w for w in result.get_warnings() if w.rule_id == "SST-V091"]
+        assert len(warnings) == 1
+
     def test_same_expr_different_using_relationships_not_duplicate(self, validator):
         data = self._make_metrics_data([
             {"name": "revenue", "expr": "SUM(orders.total)"},

--- a/tests/unit/core/validation/test_duplicate_detection.py
+++ b/tests/unit/core/validation/test_duplicate_detection.py
@@ -440,3 +440,59 @@ class TestTableSynonymDuplicateDetection:
 
         # Should have 2 errors: one for "dup1" and one for "dup2"
         assert len(duplicate_errors) == 2
+
+
+class TestV091MetricDuplicateDetection:
+    """V091: metrics with same expr but different modifiers are NOT duplicates."""
+
+    @pytest.fixture
+    def validator(self):
+        return DuplicateValidator()
+
+    def _make_metrics_data(self, metrics):
+        return {"metrics": {"items": metrics}}
+
+    def test_truly_duplicate_metrics_flagged(self, validator):
+        data = self._make_metrics_data([
+            {"name": "metric_a", "expr": "SUM(orders.total)"},
+            {"name": "metric_b", "expr": "SUM(orders.total)"},
+        ])
+        result = validator.validate(data)
+        warnings = [w for w in result.get_warnings() if w.rule_id == "SST-V091"]
+        assert len(warnings) == 1
+
+    def test_same_expr_different_window_not_duplicate(self, validator):
+        data = self._make_metrics_data([
+            {"name": "cumulative", "expr": "SUM(ORDERS.TOTAL_REVENUE)", "window": {"partition_by_excluding": ["ordered_at"]}},
+            {"name": "ranked", "expr": "SUM(ORDERS.TOTAL_REVENUE)", "window": {"partition_by": ["customer_id"]}},
+        ])
+        result = validator.validate(data)
+        warnings = [w for w in result.get_warnings() if w.rule_id == "SST-V091"]
+        assert len(warnings) == 0
+
+    def test_same_expr_different_using_relationships_not_duplicate(self, validator):
+        data = self._make_metrics_data([
+            {"name": "revenue", "expr": "SUM(orders.total)"},
+            {"name": "revenue_by_loc", "expr": "SUM(orders.total)", "using_relationships": ["orders_to_locations"]},
+        ])
+        result = validator.validate(data)
+        warnings = [w for w in result.get_warnings() if w.rule_id == "SST-V091"]
+        assert len(warnings) == 0
+
+    def test_same_expr_different_non_additive_by_not_duplicate(self, validator):
+        data = self._make_metrics_data([
+            {"name": "max_total", "expr": "MAX(orders.total)"},
+            {"name": "latest_total", "expr": "MAX(orders.total)", "non_additive_by": [{"dimension": "ordered_at"}]},
+        ])
+        result = validator.validate(data)
+        warnings = [w for w in result.get_warnings() if w.rule_id == "SST-V091"]
+        assert len(warnings) == 0
+
+    def test_same_expr_one_derived_not_duplicate(self, validator):
+        data = self._make_metrics_data([
+            {"name": "total", "expr": "SUM(orders.total)"},
+            {"name": "total_derived", "expr": "SUM(orders.total)", "derived": True},
+        ])
+        result = validator.validate(data)
+        warnings = [w for w in result.get_warnings() if w.rule_id == "SST-V091"]
+        assert len(warnings) == 0


### PR DESCRIPTION
## Description

Fix V091 (duplicate metric detection) false positives. The validator now includes `using_relationships`, `window`, `non_additive_by`, and `derived` in the metric signature when comparing expressions. Metrics that share a base expression but differ in any of these modifiers are no longer flagged as duplicates.

## Related Issue

Closes #183

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `duplicates.py`: Build a composite signature from `expr + using_relationships + window + non_additive_by + derived` instead of just `expr`
- Added 5 unit tests covering each modifier dimension

## Testing

- 1499 unit tests pass
- Verified against sst-jaffle-shop: false positives for `cumulative_revenue`/`customer_revenue_rank`, `revenue_by_location`/`total_revenue`, `latest_order_total`/`max_order_value` are eliminated

## PR Chain Position

PR #11 in chain. Merge order:
1. #167 → 2. #169 → 3. #170 → 4. #171 → 5. #173 → 6. #174 → 7. #175 → 8. #176 → 9. #181 → 10. #182 → 11. **This PR**

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)
