### PR TITLE
[SST-185] Align custom instruction keys with Snowflake DDL naming

### DIFF
--- a/docs/concepts/semantic-models.md
+++ b/docs/concepts/semantic-models.md
@@ -584,15 +584,15 @@ snowflake_filters:
 
 Guide Cortex Analyst's behavior with business-specific rules. Custom instructions are automatically included in the generated `CREATE SEMANTIC VIEW` DDL as `AI_SQL_GENERATION` and `AI_QUESTION_CATEGORIZATION` clauses.
 
-When you reference custom instructions in a semantic view using `{{ custom_instructions('name') }}`, the instruction's `sql_generation` field is included in the `AI_SQL_GENERATION` clause and the `question_categorization` field is included in the `AI_QUESTION_CATEGORIZATION` clause.
+When you reference custom instructions in a semantic view using `{{ custom_instructions('name') }}`, the instruction's `ai_sql_generation` field is included in the `AI_SQL_GENERATION` clause and the `ai_question_categorization` field is included in the `AI_QUESTION_CATEGORIZATION` clause.
 
 ### Structure
 
 ```yaml
 snowflake_custom_instructions:
   - name: instruction_name
-    question_categorization: Instructions for categorizing questions
-    sql_generation: Instructions for generating SQL queries
+    ai_question_categorization: Instructions for categorizing questions
+    ai_sql_generation: Instructions for generating SQL queries
 ```
 
 ### Real Example
@@ -600,9 +600,9 @@ snowflake_custom_instructions:
 ```yaml
 snowflake_custom_instructions: 
   - name: customer_privacy_rules
-    question_categorization: >
+    ai_question_categorization: >
       Reject all questions asking about individual customer details. Ask users to contact their admin.
-    sql_generation: >
+    ai_sql_generation: >
       When querying customer data, always apply the active_customers_only filter.
       Always round currency metrics to 2 decimal places.
 ```

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -46,8 +46,9 @@ Stable error codes for SST diagnostics. Each code is a permanent identifier that
 | `SST-V046` | Invalid field on derived metric | Derived metrics cannot use using_relationships, non_additive_by, or window |
 | `SST-V047` | Excluded column conflict | Column has both exclude: true and column_type set. Excluded columns are omitted from semantic views |
 | `SST-V048` | Primary key and unique keys overlap | Columns in both primary_key and unique_keys. Remove duplicates from unique_keys |
-| `SST-V050` | Deprecated filters syntax | Migrate to snowflake_custom_instructions with sql_generation text |
+| `SST-V050` | Deprecated filters syntax | Migrate to snowflake_custom_instructions with ai_sql_generation text |
 | `SST-V051` | Invalid filter expression | Filter expression must be a non-empty SQL string |
+| `SST-V052` | Deprecated custom instruction key names | Use 'ai_sql_generation' and 'ai_question_categorization' to align with Snowflake DDL |
 | `SST-V060` | Missing verified query field | Verified query '{name}' is missing required field: {field} |
 | `SST-V061` | VQR sql_file not found | File '{path}' does not exist. Check the path relative to the YAML file |
 | `SST-V062` | VQR mutual exclusivity violation | Specify either 'sql' or 'sql_file', not both |

--- a/snowflake_semantic_tools/core/diagnostics/error_codes.py
+++ b/snowflake_semantic_tools/core/diagnostics/error_codes.py
@@ -261,13 +261,19 @@ _register(
     "SST-V050",
     "Deprecated filters syntax",
     ErrorCategory.VALIDATION,
-    "Migrate to snowflake_custom_instructions with sql_generation text",
+    "Migrate to snowflake_custom_instructions with ai_sql_generation text",
 )
 _register(
     "SST-V051",
     "Invalid filter expression",
     ErrorCategory.VALIDATION,
     "Filter expression must be a non-empty SQL string",
+)
+_register(
+    "SST-V052",
+    "Deprecated custom instruction key names",
+    ErrorCategory.VALIDATION,
+    "Use 'ai_sql_generation' and 'ai_question_categorization' to align with Snowflake DDL",
 )
 
 # --- Verified query validation ---

--- a/snowflake_semantic_tools/core/parsing/parsers/semantic_parser.py
+++ b/snowflake_semantic_tools/core/parsing/parsers/semantic_parser.py
@@ -345,15 +345,23 @@ def parse_snowflake_custom_instructions(instructions: List[Dict[str, Any]], file
 
     for instruction in instructions:
         try:
-            # Keep question_categorization and sql_generation separate for GUIDANCE clause
-            question_cat = instruction.get("question_categorization", "").strip()
-            sql_gen = instruction.get("sql_generation", "").strip()
+            question_cat = (
+                instruction.get("ai_question_categorization") or instruction.get("question_categorization", "")
+            ).strip()
+            sql_gen = (
+                instruction.get("ai_sql_generation") or instruction.get("sql_generation", "")
+            ).strip()
 
             instruction_record = {
                 "name": instruction.get("name", "").upper(),
                 "question_categorization": question_cat if question_cat else None,
                 "sql_generation": sql_gen if sql_gen else None,
-                "source_file": str(file_path),  # Store the file path for validation errors
+                "source_file": str(file_path),
+                "_used_legacy_keys": bool(
+                    instruction.get("question_categorization") or instruction.get("sql_generation")
+                ) and not (
+                    instruction.get("ai_question_categorization") or instruction.get("ai_sql_generation")
+                ),
             }
             instruction_records.append(instruction_record)
 

--- a/snowflake_semantic_tools/core/parsing/parsers/semantic_parser.py
+++ b/snowflake_semantic_tools/core/parsing/parsers/semantic_parser.py
@@ -348,9 +348,7 @@ def parse_snowflake_custom_instructions(instructions: List[Dict[str, Any]], file
             question_cat = (
                 instruction.get("ai_question_categorization") or instruction.get("question_categorization", "")
             ).strip()
-            sql_gen = (
-                instruction.get("ai_sql_generation") or instruction.get("sql_generation", "")
-            ).strip()
+            sql_gen = (instruction.get("ai_sql_generation") or instruction.get("sql_generation", "")).strip()
 
             instruction_record = {
                 "name": instruction.get("name", "").upper(),
@@ -359,9 +357,8 @@ def parse_snowflake_custom_instructions(instructions: List[Dict[str, Any]], file
                 "source_file": str(file_path),
                 "_used_legacy_keys": bool(
                     instruction.get("question_categorization") or instruction.get("sql_generation")
-                ) and not (
-                    instruction.get("ai_question_categorization") or instruction.get("ai_sql_generation")
-                ),
+                )
+                and not (instruction.get("ai_question_categorization") or instruction.get("ai_sql_generation")),
             }
             instruction_records.append(instruction_record)
 

--- a/snowflake_semantic_tools/core/validation/rules/semantic_models.py
+++ b/snowflake_semantic_tools/core/validation/rules/semantic_models.py
@@ -76,9 +76,9 @@ class SemanticModelValidator:
                     "snowflake_filters is deprecated and will be removed in a future major version. "
                     "Filters are auto-converted to AI_SQL_GENERATION instructions at generation time, "
                     "but for full control over instruction wording, migrate to snowflake_custom_instructions "
-                    "with sql_generation text.",
+                    "with ai_sql_generation text.",
                     rule_id="SST-V050",
-                    suggestion="Migrate to snowflake_custom_instructions with sql_generation",
+                    suggestion="Migrate to snowflake_custom_instructions with ai_sql_generation",
                     entity_name="snowflake_filters",
                     context={"type": "DEPRECATION"},
                 )
@@ -562,20 +562,31 @@ class SemanticModelValidator:
             # Required fields
             self._check_required_field(instruction, "name", instruction_name, "custom_instruction", source_file, result)
 
-            # At least one of question_categorization or sql_generation must be present
+            if instruction.get("_used_legacy_keys"):
+                result.add_warning(
+                    f"Custom instruction '{instruction_name}' uses deprecated key names. "
+                    f"Rename 'sql_generation' to 'ai_sql_generation' and "
+                    f"'question_categorization' to 'ai_question_categorization' to align with Snowflake DDL.",
+                    file_path=source_file,
+                    rule_id="SST-V052",
+                    suggestion="Use 'ai_sql_generation' and 'ai_question_categorization' (matches Snowflake DDL)",
+                    entity_name=instruction_name,
+                    context={"custom_instruction": instruction_name},
+                )
+
             has_question_cat = "question_categorization" in instruction and instruction.get("question_categorization")
             has_sql_gen = "sql_generation" in instruction and instruction.get("sql_generation")
 
             if not has_question_cat and not has_sql_gen:
                 result.add_error(
-                    f"Custom instruction '{instruction_name}' is missing required field: must have at least one of 'question_categorization' or 'sql_generation'",
+                    f"Custom instruction '{instruction_name}' is missing required field: must have at least one of 'ai_sql_generation' or 'ai_question_categorization'",
                     file_path=source_file,
                     rule_id="SST-V001",
-                    suggestion="Must have at least question_categorization or sql_generation",
+                    suggestion="Must have at least ai_sql_generation or ai_question_categorization",
                     entity_name=instruction_name,
                     context={
                         "custom_instruction": instruction_name,
-                        "field": "question_categorization or sql_generation",
+                        "field": "ai_sql_generation or ai_question_categorization",
                         "type": "custom_instruction",
                     },
                 )

--- a/tests/unit/core/validation/test_semantic_models.py
+++ b/tests/unit/core/validation/test_semantic_models.py
@@ -455,7 +455,7 @@ class TestCustomInstructionValidation:
         assert result.error_count > 0
         errors = [i.message for i in result.issues if i.severity.name == "ERROR"]
         assert any(
-            "missing required field: must have at least one of 'question_categorization' or 'sql_generation'" in e
+            "missing required field: must have at least one of 'ai_sql_generation' or 'ai_question_categorization'" in e
             for e in errors
         )
 


### PR DESCRIPTION
## Description

Align custom instruction YAML keys with Snowflake's DDL naming convention. The new primary keys `ai_sql_generation` and `ai_question_categorization` match the Snowflake `AI_SQL_GENERATION` and `AI_QUESTION_CATEGORIZATION` clauses directly.

Old keys (`sql_generation`, `question_categorization`) still work but emit a V052 deprecation warning.

## Related Issue

Closes #185

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- **Parser** (`semantic_parser.py`): Accept new keys first, fall back to old keys. Tags records with `_used_legacy_keys` flag.
- **Validator** (`semantic_models.py`): Emit V052 warning when legacy keys are used. Updated V050 message and V001 error text.
- **Error codes** (`error_codes.py`): Added SST-V052. Updated V050 help text.
- **Docs** (`semantic-models.md`, `error-codes.md`): Updated examples and reference.
- **Test**: Updated assertion for new error message text.

## Testing

- 1500 unit tests pass
- sst-jaffle-shop migrated to new keys (separate commit)
- No breaking change: old keys continue to work

## PR Chain Position

PR #12 in chain. Merge order:
1. #167 -> 2. #169 -> 3. #170 -> 4. #171 -> 5. #173 -> 6. #174 -> 7. #175 -> 8. #176 -> 9. #181 -> 10. #182 -> 11. #184 -> 12. **This PR**

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)
