### PR TITLE
[SST-187] Fix generate output alignment on CREATED lines

### DIFF
--- a/snowflake_semantic_tools/core/parsing/parsers/semantic_parser.py
+++ b/snowflake_semantic_tools/core/parsing/parsers/semantic_parser.py
@@ -348,9 +348,7 @@ def parse_snowflake_custom_instructions(instructions: List[Dict[str, Any]], file
             question_cat = (
                 instruction.get("ai_question_categorization") or instruction.get("question_categorization", "")
             ).strip()
-            sql_gen = (
-                instruction.get("ai_sql_generation") or instruction.get("sql_generation", "")
-            ).strip()
+            sql_gen = (instruction.get("ai_sql_generation") or instruction.get("sql_generation", "")).strip()
 
             instruction_record = {
                 "name": instruction.get("name", "").upper(),
@@ -359,9 +357,8 @@ def parse_snowflake_custom_instructions(instructions: List[Dict[str, Any]], file
                 "source_file": str(file_path),
                 "_used_legacy_keys": bool(
                     instruction.get("question_categorization") or instruction.get("sql_generation")
-                ) and not (
-                    instruction.get("ai_question_categorization") or instruction.get("ai_sql_generation")
-                ),
+                )
+                and not (instruction.get("ai_question_categorization") or instruction.get("ai_sql_generation")),
             }
             instruction_records.append(instruction_record)
 

--- a/snowflake_semantic_tools/shared/events/types.py
+++ b/snowflake_semantic_tools/shared/events/types.py
@@ -40,8 +40,9 @@ def format_duration(seconds: float) -> str:
 
 
 def format_progress(current: int, total: int) -> str:
-    """Format progress indicator (e.g., " 1 of  5")."""
-    return f"{current:2d} of {total:2d}"
+    """Format progress indicator (e.g., "1 of 3")."""
+    width = len(str(total))
+    return f"{str(current).rjust(width)} of {total}"
 
 
 # ============================================================================


### PR DESCRIPTION
## Description

Fix misaligned indentation in `sst generate` output. The CREATED lines used fixed `:2d` formatting which added extra spaces for small counts (` 1 of  3`). Now uses dynamic width matching the RUN line format (`1 of 3`).

## Related Issue

Closes #187

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `shared/events/types.py`: Changed `format_progress()` from `f"{current:2d} of {total:2d}"` to dynamic `str(current).rjust(len(str(total)))` — matches `output.progress()` alignment logic.

## Testing

- 1500 unit tests pass

## PR Chain Position

PR #13 in chain.

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)