### PR TITLE
[SST-196] Fix validation message wording and terminology

### DIFF
--- a/snowflake_semantic_tools/core/validation/rules/dbt_models.py
+++ b/snowflake_semantic_tools/core/validation/rules/dbt_models.py
@@ -154,7 +154,7 @@ class DbtModelValidator:
             for table_name, missing_fields, source_file in sorted(skipped_tables):
                 missing_fields_str = ", ".join(missing_fields)
                 result.add_warning(
-                    f"Table '{table_name}' skipped due to missing critical metadata ({missing_fields_str})",
+                    f"Model '{table_name}' will be excluded from extraction due to missing metadata ({missing_fields_str})",
                     file_path=source_file,
                     context={"table": table_name, "reason": "missing_metadata", "missing_fields": missing_fields},
                 )
@@ -276,7 +276,7 @@ class DbtModelValidator:
         description = table.get("description")
         if not description or (isinstance(description, str) and not description.strip()):
             result.add_error(
-                f"Table '{table_name}' is missing required field: description at the table-level",
+                f"Model '{table_name}' is missing required field: description",
                 file_path=source_file,
                 context={"table": table_name, "field": "description", "level": "table"},
             )
@@ -285,13 +285,13 @@ class DbtModelValidator:
         primary_key = table.get("primary_key")
         if not primary_key:
             result.add_error(
-                f"Table '{table_name}' is missing required field: meta.sst.primary_key at the table-level",
+                f"Model '{table_name}' is missing required field: meta.sst.primary_key",
                 file_path=source_file,
                 context={"table": table_name, "field": "meta.sst.primary_key", "level": "table"},
             )
         elif primary_key == []:
             result.add_error(
-                f"Table '{table_name}' has empty primary key list at the table-level",
+                f"Model '{table_name}' has empty primary key list",
                 file_path=source_file,
                 context={"table": table_name, "field": "meta.sst.primary_key", "level": "table"},
             )
@@ -319,13 +319,13 @@ class DbtModelValidator:
                 else:
                     primary_keys = [primary_keys]
                 result.add_warning(
-                    f"Table '{table_name}' has primary_key as string instead of list at the table-level",
+                    f"Model '{table_name}' has primary_key as string instead of list",
                     file_path=source_file,
                     context={"table": table_name, "field": "primary_key", "level": "table"},
                 )
             else:
                 result.add_error(
-                    f"Table '{table_name}' has primary_key as {type(primary_keys).__name__} instead of list at the table-level",
+                    f"Model '{table_name}' has primary_key as {type(primary_keys).__name__} instead of list",
                     file_path=source_file,
                     context={
                         "table": table_name,
@@ -352,7 +352,7 @@ class DbtModelValidator:
 
             if pk_normalized not in table_columns:
                 result.add_error(
-                    f"Table '{table_name}' has primary key '{pk}' that doesn't exist as a column at the table-level",
+                    f"Model '{table_name}' has primary key '{pk}' that doesn't exist as a column",
                     file_path=source_file,
                     context={"table": table_name, "primary_key": pk, "level": "table"},
                 )
@@ -391,7 +391,7 @@ class DbtModelValidator:
         synonyms = table.get("synonyms")
         if synonyms is not None and not isinstance(synonyms, list):
             result.add_error(
-                f"Table '{table_name}' has synonyms as {type(synonyms).__name__} instead of list at the table-level",
+                f"Model '{table_name}' has synonyms as {type(synonyms).__name__} instead of list",
                 file_path=source_file,
                 context={"table": table_name, "field": "synonyms", "type": type(synonyms).__name__, "level": "table"},
             )
@@ -399,7 +399,7 @@ class DbtModelValidator:
         # Check for synonyms
         if not synonyms:
             result.add_warning(
-                f"Table '{table_name}' has no synonyms defined at the table-level (helpful for natural language queries)",
+                f"Model '{table_name}' has no synonyms defined (helpful for natural language queries)",
                 file_path=source_file,
                 context={"table": table_name, "best_practice": "synonyms", "level": "table"},
             )
@@ -511,7 +511,7 @@ class DbtModelValidator:
         column_type = column.get("column_type")
         if not column_type:
             result.add_error(
-                f"Column '{column_name}' in table '{table_name}' is missing required field: meta.sst.column_type at the column-level",
+                f"Column '{column_name}' in table '{table_name}' is missing required field: meta.sst.column_type",
                 file_path=source_file,
                 context={"table": table_name, "column": column_name, "field": "column_type", "level": "column"},
             )
@@ -533,7 +533,7 @@ class DbtModelValidator:
         # Can be specified in native dbt contracts (column.data_type) or SST metadata (config.meta.sst.data_type)
         if not column.get("data_type"):
             result.add_error(
-                f"Column '{column_name}' in table '{table_name}' is missing required field: data_type at the column-level. "
+                f"Column '{column_name}' in table '{table_name}' is missing required field: data_type. "
                 f"Specify either as native dbt contract (column.data_type) or SST metadata (config.meta.sst.data_type)",
                 file_path=source_file,
                 context={"table": table_name, "column": column_name, "field": "data_type", "level": "column"},
@@ -542,7 +542,7 @@ class DbtModelValidator:
         # Description is REQUIRED (not just technically)
         if not column.get("description"):
             result.add_error(
-                f"Column '{column_name}' in table '{table_name}' is missing required field: description at the column-level",
+                f"Column '{column_name}' in table '{table_name}' is missing required field: description",
                 file_path=source_file,
                 context={"table": table_name, "column": column_name, "field": "description", "level": "column"},
             )
@@ -584,7 +584,7 @@ class DbtModelValidator:
         base_data_type = data_type.split("(")[0] if "(" in data_type else data_type
         if base_data_type and base_data_type not in self.VALID_DATA_TYPES:
             result.add_error(
-                f"Column '{column_name}' in table '{table_name}' has unrecognized data_type: '{data_type}' at the column-level. "
+                f"Column '{column_name}' in table '{table_name}' has unrecognized data_type: '{data_type}'. "
                 f"Must be a valid Snowflake data type.",
                 file_path=source_file,
                 context={"table": table_name, "column": column_name, "data_type": data_type, "level": "column"},
@@ -622,7 +622,7 @@ class DbtModelValidator:
             }
             if base_data_type and base_data_type not in numeric_types:
                 result.add_error(
-                    f"Fact column '{column_name}' in table '{table_name}' has non-numeric data_type: '{data_type}' at the column-level",
+                    f"Fact column '{column_name}' in table '{table_name}' has non-numeric data_type: '{data_type}'",
                     file_path=source_file,
                     context={
                         "table": table_name,
@@ -638,7 +638,7 @@ class DbtModelValidator:
             time_types = {"date", "datetime", "time", "timestamp", "timestamp_ltz", "timestamp_ntz", "timestamp_tz"}
             if base_data_type and base_data_type not in time_types:
                 result.add_error(
-                    f"Time dimension '{column_name}' in table '{table_name}' has non-temporal data_type: '{data_type}' at the column-level",
+                    f"Time dimension '{column_name}' in table '{table_name}' has non-temporal data_type: '{data_type}'",
                     file_path=source_file,
                     context={
                         "table": table_name,
@@ -653,7 +653,7 @@ class DbtModelValidator:
         synonyms = column.get("synonyms")
         if synonyms is not None and not isinstance(synonyms, list):
             result.add_error(
-                f"Column '{column_name}' in table '{table_name}' has synonyms as {type(synonyms).__name__} instead of list at the column-level",
+                f"Column '{column_name}' in table '{table_name}' has synonyms as {type(synonyms).__name__} instead of list",
                 file_path=source_file,
                 context={
                     "table": table_name,
@@ -667,7 +667,7 @@ class DbtModelValidator:
         sample_values = column.get("sample_values")
         if sample_values is not None and not isinstance(sample_values, list):
             result.add_error(
-                f"Column '{column_name}' in table '{table_name}' has sample_values as {type(sample_values).__name__} instead of list at the column-level",
+                f"Column '{column_name}' in table '{table_name}' has sample_values as {type(sample_values).__name__} instead of list",
                 file_path=source_file,
                 context={
                     "table": table_name,
@@ -686,7 +686,7 @@ class DbtModelValidator:
         if privacy_category == "direct_identifier" and sample_values_list:
             result.add_error(
                 f"Column '{column_name}' in table '{table_name}' has privacy_category='direct_identifier' "
-                f"but contains sample_values. PII columns must not expose sample data at the column-level",
+                f"but contains sample_values. PII columns must not expose sample data",
                 file_path=source_file,
                 context={
                     "table": table_name,
@@ -710,7 +710,7 @@ class DbtModelValidator:
             if problematic_values:
                 result.add_error(
                     f"Column '{column_name}' in table '{table_name}' contains sample_values with Jinja template "
-                    f"characters that will break dbt compilation. Run 'sst enrich' to sanitize these values at the column-level",
+                    f"characters that will break dbt compilation. Run 'sst enrich' to sanitize these values",
                     file_path=source_file,
                     context={
                         "table": table_name,
@@ -731,7 +731,7 @@ class DbtModelValidator:
         if is_enum and column_type in ["fact", "time_dimension"]:
             result.add_error(
                 f"Column '{column_name}' in table '{table_name}' has is_enum=true but column_type='{column_type}'. "
-                f"Fact and time_dimension columns should never be enums at the column-level",
+                f"Fact and time_dimension columns should never be enums",
                 file_path=source_file,
                 context={
                     "table": table_name,
@@ -744,7 +744,7 @@ class DbtModelValidator:
 
         if is_enum and not sample_values:
             result.add_warning(
-                f"Column '{column_name}' in table '{table_name}' has is_enum=true but no sample_values at the column-level",
+                f"Column '{column_name}' in table '{table_name}' has is_enum=true but no sample_values",
                 file_path=source_file,
                 context={"table": table_name, "column": column_name, "level": "column"},
             )
@@ -827,7 +827,7 @@ class DbtModelValidator:
             column_type = self._determine_column_type(column)
             if column_type == "dimension":
                 result.add_info(
-                    f"Consider adding sample_values for dimension '{column_name}' in table '{table_name}' at the column-level",
+                    f"Consider adding sample_values for dimension '{column_name}' in table '{table_name}'",
                     file_path=source_file,
                     context={
                         "table": table_name,
@@ -843,7 +843,7 @@ class DbtModelValidator:
             common_columns = {"id", "created_at", "updated_at", "deleted_at"}
             if column_name.lower() not in common_columns:
                 result.add_info(
-                    f"Consider adding synonyms for column '{column_name}' in table '{table_name}' at the column-level",
+                    f"Consider adding synonyms for column '{column_name}' in table '{table_name}'",
                     file_path=source_file,
                     context={
                         "table": table_name,

--- a/snowflake_semantic_tools/core/validation/rules/references.py
+++ b/snowflake_semantic_tools/core/validation/rules/references.py
@@ -445,8 +445,7 @@ class ReferenceValidator:
                         result.add_error(
                             f"Relationship '{name}' references table '{right_table}' which has no primary key metadata.\n\n"
                             f"The RIGHT (referenced) table must declare meta.sst.primary_key or meta.sst.unique_keys for the join columns.\n\n"
-                            f"This usually means the table was not properly extracted or enriched. Run 'sst enrich' on the table's "
-                            f"YAML file, or check meta.sst configuration."
+                            f"Add primary_key to the model's config.meta.sst block in your dbt YAML file."
                             f"{_RELATIONSHIP_DIRECTION_HINT}",
                             file_path=source_file,
                             context={
@@ -460,7 +459,7 @@ class ReferenceValidator:
                     result.add_error(
                         f"Relationship '{name}' references table '{right_table}' that was not extracted. "
                         f"This usually means the table's metadata is missing or incomplete. "
-                        f"Check that the table has proper meta.sst configuration or run 'sst enrich' to populate metadata.",
+                        f"Check that the table has proper meta.sst configuration in its dbt YAML file.",
                         file_path=source_file,
                         context={"relationship": name, "right_table": right_table, "issue": "missing_table_dependency"},
                     )


### PR DESCRIPTION
## Summary
- Replace "Table" with "Model" in validation messages pointing to dbt YAML files
- Remove redundant "at the table-level" / "at the column-level" suffixes from all messages
- Fix V010 misleading "skipped" wording → "will be excluded from extraction"
- Fix V042 misleading "Run sst enrich" suggestion (enrich doesn't generate primary keys)

Closes #196
Closes #194
Closes #189
Also addresses #201 context (the "<=256" help text is in compiled diagnostics module; the error body itself correctly references the constant)

## Test plan
- [ ] Run `sst validate --verbose` on jaffle-shop and verify messages say "Model" not "Table"
- [ ] Remove primary_key from a model → verify V010 says "excluded from extraction" not "skipped"
- [ ] Trigger V042 → verify no "sst enrich" reference in message

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)

