### PR TITLE
[SST-199] Add missing required field validations

### DIFF
--- a/snowflake_semantic_tools/core/parsing/parsers/dbt_parser.py
+++ b/snowflake_semantic_tools/core/parsing/parsers/dbt_parser.py
@@ -183,9 +183,10 @@ def parse_single_model(
             result["sm_facts"].append(fact_data)
 
         else:
-            # Skip columns with missing or invalid column_type - validation will catch this
+            unclassified_data = apply_uppercase_formatting(column_data, ["table_name", "name", "expr", "data_type"])
+            result["sm_dimensions"].append(unclassified_data)
             logger.debug(
-                f"Skipping column '{column.get('name', 'unknown')}' with missing/invalid column_type during extraction"
+                f"Column '{column.get('name', 'unknown')}' with missing/invalid column_type added for validation"
             )
 
     return result

--- a/snowflake_semantic_tools/core/parsing/parsers/semantic_parser.py
+++ b/snowflake_semantic_tools/core/parsing/parsers/semantic_parser.py
@@ -167,7 +167,8 @@ def parse_snowflake_relationships(
                 "relationship_name": relationship.get("name", "").upper(),
                 "left_table_name": relationship.get("left_table", "").upper(),
                 "right_table_name": relationship.get("right_table", "").upper(),
-                "source_file": str(file_path),  # Store the file path for validation errors
+                "source_file": str(file_path),
+                "_has_conditions": bool(relationship.get("relationship_conditions")),
             }
             relationship_records.append(rel_record)
 
@@ -385,25 +386,25 @@ def parse_semantic_views(
     for view_def in semantic_views:
         try:
             if not isinstance(view_def, dict):
-                logger.error(f"Semantic view definition must be a dictionary, got {type(view_def)} in {file_path}")
+                logger.warning(f"Semantic view definition must be a dictionary, got {type(view_def)} in {file_path}")
+                view_records.append(
+                    {
+                        "name": "",
+                        "description": "",
+                        "tables": "[]",
+                        "custom_instructions": "[]",
+                        "source_file": str(file_path),
+                    }
+                )
                 continue
 
-            # Extract required fields
-            name = view_def.get("name")
-            if not name:
-                logger.error(f"Semantic view definition missing required 'name' field in {file_path}")
-                continue
-
+            name = view_def.get("name", "")
             description = view_def.get("description", "")
 
             tables = view_def.get("tables", [])
             if not isinstance(tables, list):
-                logger.error(f"'tables' must be a list for view '{name}' in {file_path}, got {type(tables)}")
-                continue
-
-            if not tables:
-                logger.error(f"Semantic view '{name}' must have at least one table in {file_path}")
-                continue
+                logger.warning(f"'tables' must be a list for view '{name}' in {file_path}, got {type(tables)}")
+                tables = []
 
             # Convert tables list to JSON string for storage
             tables_json = json.dumps(tables)

--- a/snowflake_semantic_tools/core/validation/rules/semantic_models.py
+++ b/snowflake_semantic_tools/core/validation/rules/semantic_models.py
@@ -278,6 +278,13 @@ class SemanticModelValidator:
                             file_path=source_file,
                             context={"relationship": rel_name, "field": display_field, "type": "relationship"},
                         )
+
+                if not relationship.get("_has_conditions", True):
+                    result.add_error(
+                        f"Relationship '{rel_name}' is missing required field: relationship_conditions",
+                        file_path=source_file,
+                        context={"relationship": rel_name, "field": "relationship_conditions", "type": "relationship"},
+                    )
             else:
                 # Raw YAML format
                 required_fields = ["name", "left_table", "right_table", "relationship_conditions"]


### PR DESCRIPTION
## Summary
- Fix `relationship_conditions` not validated when missing (silently passes) (#199)
- Fix semantic views with missing `name`/`tables` silently dropped by parser (#200)
- Fix columns with invalid/missing `column_type` never reaching the validator (#197, #193)

Key insight: The parser was dropping invalid entries before they could reach validation, causing silent failures. Now invalid entries pass through to the validator which emits proper structured diagnostics.

Closes #199
Closes #200
Closes #197
Closes #193

## Test plan
- [ ] Comment out `relationship_conditions:` → verify V040 error fires
- [ ] Comment out SV `- name:` → verify V006 or V070 error fires
- [ ] Remove SV `tables:` → verify V070 error fires
- [ ] Set `column_type: banana` → verify invalid column_type error fires
- [ ] Comment out `column_type:` → verify missing column_type error fires
- [ ] Run clean `sst validate` on jaffle-shop → 0 errors, 0 warnings

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)

