### PR TITLE
[SST-191] Warn on unrecognized sst meta keys and dedup V042 hint

### DIFF
--- a/snowflake_semantic_tools/core/parsing/parsers/data_extractors.py
+++ b/snowflake_semantic_tools/core/parsing/parsers/data_extractors.py
@@ -179,10 +179,10 @@ def extract_table_info(
             "unique_keys": unique_keys_upper,
             "constraints": sst_meta.get("constraints", []),
             "synonyms": sst_meta.get("synonyms", []),
-            "model_name": name,  # Store the original model name
-            "source_file": str(file_path),  # Store the file path for validation errors
-            "cortex_searchable": sst_meta.get("cortex_searchable", False),
+            "model_name": name,
+            "source_file": str(file_path),
             "tags": sst_meta.get("tags"),
+            "_raw_sst_keys": list(sst_meta.keys()),
         }
 
         return table_record

--- a/snowflake_semantic_tools/core/validation/rules/dbt_models.py
+++ b/snowflake_semantic_tools/core/validation/rules/dbt_models.py
@@ -50,13 +50,26 @@ class DbtModelValidator:
     VALID_COLUMN_TYPES = {"dimension", "time_dimension", "fact"}
 
     KNOWN_TABLE_SST_KEYS = {
-        "primary_key", "unique_keys", "synonyms", "constraints", "tags",
-        "table", "database", "schema", "exclude",
+        "primary_key",
+        "unique_keys",
+        "synonyms",
+        "constraints",
+        "tags",
+        "table",
+        "database",
+        "schema",
+        "exclude",
     }
 
     KNOWN_COLUMN_SST_KEYS = {
-        "column_type", "data_type", "synonyms", "sample_values", "is_enum",
-        "visibility", "tags", "exclude",
+        "column_type",
+        "data_type",
+        "synonyms",
+        "sample_values",
+        "is_enum",
+        "visibility",
+        "tags",
+        "exclude",
     }
 
     REMOVED_SST_KEYS = {

--- a/snowflake_semantic_tools/core/validation/rules/dbt_models.py
+++ b/snowflake_semantic_tools/core/validation/rules/dbt_models.py
@@ -49,6 +49,20 @@ class DbtModelValidator:
     # Valid values for column_type
     VALID_COLUMN_TYPES = {"dimension", "time_dimension", "fact"}
 
+    KNOWN_TABLE_SST_KEYS = {
+        "primary_key", "unique_keys", "synonyms", "constraints", "tags",
+        "table", "database", "schema", "exclude",
+    }
+
+    KNOWN_COLUMN_SST_KEYS = {
+        "column_type", "data_type", "synonyms", "sample_values", "is_enum",
+        "visibility", "tags", "exclude",
+    }
+
+    REMOVED_SST_KEYS = {
+        "cortex_searchable": "Cortex Search Service support was removed in v0.3.0",
+    }
+
     # Valid Snowflake data types (common ones)
     VALID_DATA_TYPES = {
         # Numeric types
@@ -228,6 +242,8 @@ class DbtModelValidator:
         # Check required table-level fields
         self._check_required_table_fields(table, table_name, result)
 
+        self._check_unrecognized_sst_keys(table, table_name, result)
+
         # Check naming conventions
         self._check_naming_conventions(table, table_name, result)
 
@@ -295,6 +311,26 @@ class DbtModelValidator:
                 file_path=source_file,
                 context={"table": table_name, "field": "meta.sst.primary_key", "level": "table"},
             )
+
+    def _check_unrecognized_sst_keys(self, table: Dict[str, Any], table_name: str, result: ValidationResult):
+        """Warn about unrecognized keys in the sst meta block."""
+        raw_keys = table.get("_raw_sst_keys", [])
+        source_file = table.get("source_file")
+        for key in raw_keys:
+            if key in self.REMOVED_SST_KEYS:
+                result.add_warning(
+                    f"Model '{table_name}' uses removed key '{key}' in config.meta.sst. "
+                    f"{self.REMOVED_SST_KEYS[key]}. This key is ignored.",
+                    file_path=source_file,
+                    context={"table": table_name, "key": key, "level": "table"},
+                )
+            elif key not in self.KNOWN_TABLE_SST_KEYS:
+                result.add_warning(
+                    f"Model '{table_name}' has unrecognized key '{key}' in config.meta.sst. "
+                    f"This key will be ignored. Known keys: {', '.join(sorted(self.KNOWN_TABLE_SST_KEYS))}",
+                    file_path=source_file,
+                    context={"table": table_name, "key": key, "level": "table"},
+                )
 
     def _check_primary_key(
         self,

--- a/snowflake_semantic_tools/core/validation/rules/references.py
+++ b/snowflake_semantic_tools/core/validation/rules/references.py
@@ -23,6 +23,21 @@ _RELATIONSHIP_DIRECTION_HINT = (
     "  If the uniquely keyed table is on the left, swap left_table and right_table."
 )
 
+_relationship_hint_shown = False
+
+
+def _get_relationship_hint():
+    global _relationship_hint_shown
+    if not _relationship_hint_shown:
+        _relationship_hint_shown = True
+        return _RELATIONSHIP_DIRECTION_HINT
+    return ""
+
+
+def _reset_relationship_hint():
+    global _relationship_hint_shown
+    _relationship_hint_shown = False
+
 
 class ReferenceValidator:
     """
@@ -58,6 +73,7 @@ class ReferenceValidator:
         """
         result = ValidationResult()
         self._semantic_data = semantic_data
+        _reset_relationship_hint()
 
         # Validate metrics
         metrics_data = semantic_data.get("metrics", {})
@@ -406,7 +422,7 @@ class ReferenceValidator:
                                         f"  (1) Add the missing columns to complete the primary key reference, or\n"
                                         f"  (2) Add meta.sst.unique_keys for [{', '.join(right_columns_used)}] on '{right_table}' if that set is unique on that table, or\n"
                                         f"  (3) Swap left/right so the keyed table is on the right."
-                                        f"{_RELATIONSHIP_DIRECTION_HINT}",
+                                        f"{_get_relationship_hint()}",
                                         file_path=source_file,
                                         context={
                                             "relationship": name,
@@ -427,7 +443,7 @@ class ReferenceValidator:
                                     f"To fix:\n"
                                     f"  - Swap left/right so the keyed table is on the right, or\n"
                                     f"  - Add meta.sst.unique_keys if that column or column set is unique on '{right_table}'.\n"
-                                    f"{_RELATIONSHIP_DIRECTION_HINT}",
+                                    f"{_get_relationship_hint()}",
                                     file_path=source_file,
                                     context={
                                         "relationship": name,
@@ -447,7 +463,7 @@ class ReferenceValidator:
                             f"The RIGHT (referenced) table must declare meta.sst.primary_key or meta.sst.unique_keys for the join columns.\n\n"
                             f"This usually means the table was not properly extracted or enriched. Run 'sst enrich' on the table's "
                             f"YAML file, or check meta.sst configuration."
-                            f"{_RELATIONSHIP_DIRECTION_HINT}",
+                            f"{_get_relationship_hint()}",
                             file_path=source_file,
                             context={
                                 "relationship": name,


### PR DESCRIPTION
## Summary
- Add known-key allowlist for `config.meta.sst` block (table and column level)
- Warn on unrecognized keys (catches typos and stale config)
- `cortex_searchable` now triggers a specific removal warning instead of being silently ignored
- V042 relationship direction hint only prints once per validation run (dedup)

Closes #191
Closes #195

## Test plan
- [ ] Add `cortex_searchable: true` to a model → verify warning about removal
- [ ] Add `bogus_key: value` to a model's sst meta → verify unrecognized key warning
- [ ] Trigger 2+ V042 errors → verify direction hint only prints once
- [ ] Clean validate on jaffle-shop → 0 errors (may have 1 warning for cortex_searchable in customers.yml)

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)

