### PR TITLE
[SST-198] Fix structured error handling for parsing failures

### DIFF
--- a/snowflake_semantic_tools/core/parsing/parsers/dbt_parser.py
+++ b/snowflake_semantic_tools/core/parsing/parsers/dbt_parser.py
@@ -87,6 +87,12 @@ def parse_dbt_yaml_file(
         result = get_empty_result()
 
         for model in models:
+            if not isinstance(model, dict):
+                error_tracker.add_error(
+                    f"Invalid model structure in {file_path}: expected a mapping with 'name' key, "
+                    f"got {type(model).__name__}. Ensure each model starts with '- name: <model_name>'"
+                )
+                continue
             model_data = parse_single_model(model, file_path, target_database, manifest_parser)
 
             # Merge results

--- a/snowflake_semantic_tools/core/parsing/parsers/semantic_parser.py
+++ b/snowflake_semantic_tools/core/parsing/parsers/semantic_parser.py
@@ -359,6 +359,7 @@ def parse_snowflake_verified_queries(queries: List[Dict[str, Any]], file_path: P
                 "verified_at": query.get("verified_at", ""),
                 "verified_by": query.get("verified_by", ""),
                 "sql": sql,
+                "sql_file": sql_file if sql_file else "",
                 "source_file": str(file_path),
             }
             if "use_as_onboarding_question" in query:

--- a/snowflake_semantic_tools/core/validation/rules/semantic_models.py
+++ b/snowflake_semantic_tools/core/validation/rules/semantic_models.py
@@ -1348,7 +1348,7 @@ class SemanticModelValidator:
         """
         seen = {}
         for item in items:
-            name = item.get("name", "")
+            name = item.get("name") or item.get("relationship_name", "")
             if not name:
                 continue
 


### PR DESCRIPTION
## Summary
- Add `isinstance(model, dict)` guard in dbt parser — malformed YAML now emits a structured error instead of crashing (#190)
- Preserve `sql_file` field in parsed VQ records so validator correctly identifies file-not-found vs missing-field (#202)
- Fix duplicate relationship name detection for parsed format (`relationship_name` key) (#203)
- #198 (template resolution → structured errors) is partially addressed — the remaining unstructured template errors need deeper refactoring of the template resolution system

Closes #190
Closes #202
Closes #203

## Test plan
- [ ] Comment out `- name: customers` in model YAML → verify structured error (not crash)
- [ ] Set `sql_file: sql/nonexistent.sql` in VQ → verify "file not found" error (not "missing field")
- [ ] Duplicate relationship name → verify V004-style duplicate name error
- [ ] Clean validate on jaffle-shop → 0 errors

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)

