### PR TITLE
[SST-204] Fix generate exit code and add extract validation hint

### DIFF
--- a/snowflake_semantic_tools/interfaces/cli/commands/extract.py
+++ b/snowflake_semantic_tools/interfaces/cli/commands/extract.py
@@ -59,6 +59,7 @@ def extract(dbt_target, db, schema, dbt, semantic, verbose):
     # IMMEDIATE OUTPUT
     output = CLIOutput(verbose=verbose, quiet=False)
     output.info(f"Running with sst={__version__}")
+    output.debug("Tip: Run 'sst validate' before extract to catch issues early")
 
     # Common CLI setup
     output.debug("Setting up...")

--- a/snowflake_semantic_tools/services/generate_semantic_views.py
+++ b/snowflake_semantic_tools/services/generate_semantic_views.py
@@ -658,10 +658,10 @@ class SemanticViewGenerationService:
                 found_views = {v["name"] for v in view_configs}
                 missing_views = requested_views - found_views
                 if missing_views:
-                    result.add_warning(f"Requested views not found: {', '.join(missing_views)}")
+                    result.add_error(f"Requested views not found: {', '.join(sorted(missing_views))}")
 
             if not view_configs:
-                result.add_warning("No views found to generate")
+                result.add_error("No views found to generate")
                 return result
 
             # Convert to low-level config and execute


### PR DESCRIPTION
## Summary
- `sst generate --views nonexistent_view` now returns exit code 1 (was 0) (#204)
- "Requested views not found" changed from warning → error, which marks result as FAILED
- Added verbose-level hint in `sst extract` suggesting to run validate first (#205)

Closes #204
Closes #205

## Test plan
- [ ] Run `sst generate --views nonexistent_view` → verify exit code 1 and "FAILED" status
- [ ] Run `sst generate --all` on clean data → verify still passes normally
- [ ] Run `sst extract --verbose` → verify "Tip: Run validate" message in debug output

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)

