### PR TITLE
[SST-215] Parallel semantic view generation (--threads)

### DIFF
--- a/snowflake_semantic_tools/interfaces/cli/commands/generate.py
+++ b/snowflake_semantic_tools/interfaces/cli/commands/generate.py
@@ -23,6 +23,7 @@ from snowflake_semantic_tools.services.generate_semantic_views import (
     SemanticViewGenerationService,
     UnifiedGenerationConfig,
 )
+from snowflake_semantic_tools.shared.config import get_config
 from snowflake_semantic_tools.shared.progress import CLIProgressCallback
 
 
@@ -35,6 +36,7 @@ from snowflake_semantic_tools.shared.progress import CLIProgressCallback
 @click.option("--views", "-v", multiple=True, help="Specific views to generate (can repeat)")
 @click.option("--all", "-a", is_flag=True, help="Generate all available views")
 @click.option("--dry-run", is_flag=True, help="Show what would be generated without executing")
+@click.option("--threads", type=int, default=None, help="Concurrent views (default: from sst_config.yml or 1)")
 @click.option("--verbose", is_flag=True, help="Verbose output")
 @click.pass_context
 def generate(
@@ -49,6 +51,7 @@ def generate(
     views,
     all,
     dry_run,
+    threads,
     verbose,
 ):
     """Create Snowflake SEMANTIC VIEW objects from extracted metadata.
@@ -91,6 +94,17 @@ def generate(
     # Common CLI setup
     output.debug("Setting up...")
     setup_command(verbose=verbose, quiet=quiet_mode, validate_config=True)
+
+    # Resolve threads from CLI > config > default(1)
+    config = get_config()
+    effective_threads = threads if threads is not None else config.get("generation.threads", 1)
+    if effective_threads < 1:
+        output.error("--threads must be at least 1")
+        raise click.Abort()
+    if effective_threads > 16:
+        output.error("--threads cannot exceed 16")
+        raise click.Abort()
+    view_timeout = config.get("generation.view_timeout", 300)
 
     # Validate options
     if not views and not all:
@@ -157,7 +171,7 @@ def generate(
             defer_manifest = None
 
     # Create configuration
-    config = UnifiedGenerationConfig(
+    gen_config = UnifiedGenerationConfig(
         metadata_database=target_db,
         metadata_schema=target_schema,
         target_database=target_db,
@@ -165,6 +179,8 @@ def generate(
         views_to_generate=list(views) if views else None,
         dry_run=dry_run,
         defer_manifest=defer_manifest,
+        threads=effective_threads,
+        view_timeout=view_timeout,
     )
 
     # Create and execute service
@@ -181,6 +197,10 @@ def generate(
                 config_items.append(("Defer target", defer_config.target))
             if defer_config.manifest_path:
                 config_items.append(("Defer manifest", str(defer_config.manifest_path)))
+        if effective_threads > 1:
+            config_items.append(("Threads", str(effective_threads)))
+        else:
+            config_items.append(("Threads", "1 (sequential)"))
         output.config_table(config_items)
 
         # Display defer warning if applicable
@@ -206,14 +226,14 @@ def generate(
                         if len(filtered_views) == 0:
                             output.success("All views are up to date - nothing to regenerate")
                             return
-                        config.views_to_generate = filtered_views
+                        gen_config.views_to_generate = filtered_views
                         output.info(f"Filtering to {len(filtered_views)} view(s): {', '.join(filtered_views)}")
 
             # Create progress callback from CLIOutput
             progress_callback = CLIProgressCallback(output)
 
             gen_start = time.time()
-            result = service.generate(config, progress_callback=progress_callback)
+            result = service.generate(gen_config, progress_callback=progress_callback)
             gen_duration = time.time() - gen_start
 
             # Display results with improved formatting
@@ -279,8 +299,11 @@ def generate(
             if not result.success:
                 raise click.ClickException("Generation failed - see errors above")
 
+    except KeyboardInterrupt:
+        output.blank_line()
+        output.warning("Generation interrupted by user (Ctrl+C)")
+        raise SystemExit(130)
     except click.ClickException:
-        # Re-raise ClickException without traceback (expected user-facing errors)
         raise
     except Exception as e:
         output.blank_line()

--- a/snowflake_semantic_tools/services/connection_pool.py
+++ b/snowflake_semantic_tools/services/connection_pool.py
@@ -1,0 +1,121 @@
+"""
+Thread-safe Connection Pool for Parallel Generation.
+
+Manages a pool of Snowflake ConnectionManager instances for concurrent
+semantic view generation. Supports warmup (fail-fast auth validation),
+checkout/checkin semantics, and guaranteed cleanup.
+"""
+
+import queue
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import List
+
+from snowflake_semantic_tools.infrastructure.snowflake.config import SnowflakeConfig
+from snowflake_semantic_tools.infrastructure.snowflake.connection_manager import ConnectionManager
+from snowflake_semantic_tools.shared.utils import get_logger
+
+logger = get_logger("connection_pool")
+
+
+class ConnectionPool:
+    """
+    Thread-safe pool of Snowflake ConnectionManagers.
+
+    Each ConnectionManager maintains one persistent connection.
+    Workers checkout a manager, use it for one or more views,
+    then return it for reuse by another worker.
+    """
+
+    def __init__(self, config: SnowflakeConfig, size: int):
+        self._config = config
+        self._size = size
+        self._pool: queue.Queue[ConnectionManager] = queue.Queue(maxsize=size)
+        self._all_managers: List[ConnectionManager] = []
+        self._closed = False
+
+    @property
+    def size(self) -> int:
+        return self._size
+
+    def warmup(self) -> None:
+        """
+        Open all connections in parallel and validate with SELECT 1.
+
+        Raises:
+            RuntimeError: If any connection fails to authenticate.
+        """
+        logger.info(f"Warming up {self._size} connection(s)...")
+        managers: List[ConnectionManager] = []
+        errors: List[str] = []
+
+        def _open_one(idx: int) -> ConnectionManager:
+            cm = ConnectionManager(config=self._config)
+            with cm.get_connection() as conn:
+                cursor = conn.cursor()
+                cursor.execute("SELECT 1")
+                cursor.fetchone()
+                cursor.close()
+            return cm
+
+        with ThreadPoolExecutor(max_workers=self._size) as executor:
+            futures = {executor.submit(_open_one, i): i for i in range(self._size)}
+            for future in as_completed(futures):
+                idx = futures[future]
+                try:
+                    cm = future.result(timeout=30)
+                    managers.append(cm)
+                except Exception as e:
+                    errors.append(f"Connection {idx + 1}: {e}")
+
+        if errors:
+            for cm in managers:
+                try:
+                    cm.close()
+                except Exception:
+                    pass
+            raise RuntimeError(
+                f"Failed to establish {len(errors)} of {self._size} connection(s):\n"
+                + "\n".join(f"  {err}" for err in errors)
+            )
+
+        self._all_managers = managers
+        for cm in managers:
+            self._pool.put(cm)
+        logger.info(f"Connection pool ready ({self._size} connection(s))")
+
+    def checkout(self, timeout: float = 60.0) -> ConnectionManager:
+        """
+        Get a ConnectionManager from the pool (blocking).
+
+        Args:
+            timeout: Max seconds to wait for an available connection.
+
+        Returns:
+            A ConnectionManager ready for use.
+
+        Raises:
+            queue.Empty: If no connection available within timeout.
+        """
+        return self._pool.get(timeout=timeout)
+
+    def checkin(self, cm: ConnectionManager) -> None:
+        """Return a ConnectionManager to the pool."""
+        if not self._closed:
+            self._pool.put(cm)
+
+    def close_all(self) -> None:
+        """Close all connections and drain the pool."""
+        self._closed = True
+        for cm in self._all_managers:
+            try:
+                cm.close()
+            except Exception:
+                pass
+        self._all_managers.clear()
+        while not self._pool.empty():
+            try:
+                self._pool.get_nowait()
+            except queue.Empty:
+                break
+        logger.debug("Connection pool closed")

--- a/snowflake_semantic_tools/services/generate_semantic_views.py
+++ b/snowflake_semantic_tools/services/generate_semantic_views.py
@@ -8,13 +8,16 @@ interfaces for flexibility.
 """
 
 import json
+import threading
 import time
-from dataclasses import dataclass
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from snowflake_semantic_tools.core.generation import SemanticViewBuilder
 from snowflake_semantic_tools.infrastructure.snowflake import SnowflakeClient, SnowflakeConfig
 from snowflake_semantic_tools.infrastructure.snowflake.connection_manager import ConnectionManager
+from snowflake_semantic_tools.services.connection_pool import ConnectionPool
 from snowflake_semantic_tools.shared.events import (
     GenerationCompleted,
     GenerationStarted,
@@ -158,6 +161,10 @@ class GenerateConfig:
     # Execution mode
     execute: bool = True  # If True, executes SQL in Snowflake. If False, returns SQL only.
 
+    # Parallelism
+    threads: int = 1  # Number of concurrent view generations
+    view_timeout: int = 300  # Per-view timeout in seconds
+
 
 @dataclass
 class GenerateResult:
@@ -195,6 +202,9 @@ class UnifiedGenerationConfig:
     defer_database: Optional[str] = None
     # Defer manifest for looking up actual table locations (database + schema per table)
     defer_manifest: Optional["ManifestParser"] = None
+    # Parallelism
+    threads: int = 1
+    view_timeout: int = 300
 
 
 class UnifiedGenerationResult:
@@ -340,7 +350,11 @@ class SemanticViewGenerationService:
             # Fire event: Generation started
             fire_event(GenerationStarted(view_count=len(views_to_generate)))
 
-            # Generate each view
+            # Dispatch: parallel or sequential
+            if generate_config.threads > 1:
+                return self._execute_parallel(views_to_generate, generate_config, progress, start_time)
+
+            # Generate each view (sequential)
             for idx, view_config in enumerate(views_to_generate, 1):
                 view_name = view_config.get("name")
                 table_names = view_config.get("tables", [])
@@ -458,6 +472,251 @@ class SemanticViewGenerationService:
             return GenerateResult(
                 success=False, views_generated=views_generated, views_failed=views_failed, errors=errors
             )
+
+    # Transient Snowflake error codes that merit a retry
+    _TRANSIENT_ERRORS = {"250001", "250003"}
+
+    def _is_transient_error(self, error: Exception) -> bool:
+        """Check if a Snowflake error is transient and retryable."""
+        msg = str(error)
+        for code in self._TRANSIENT_ERRORS:
+            if code in msg:
+                return True
+        if "503" in msg or "Service Unavailable" in msg:
+            return True
+        return False
+
+    def _execute_parallel(
+        self,
+        views_to_generate: List[Dict[str, Any]],
+        generate_config: GenerateConfig,
+        progress: "ProgressCallback",
+        start_time: float,
+    ) -> GenerateResult:
+        """
+        Execute view generation in parallel using a thread pool.
+
+        Each thread gets its own ConnectionManager from a pool,
+        builds a SemanticViewBuilder, and generates one view at a time.
+        """
+        threads = min(generate_config.threads, len(views_to_generate))
+        view_timeout = generate_config.view_timeout
+        total = len(views_to_generate)
+
+        views_generated = []
+        views_failed = []
+        errors = []
+        sql_statements = {}
+        output_lock = threading.Lock()
+        cancelled = threading.Event()
+
+        logger.info(f"Parallel generation: {threads} threads, {total} views, timeout={view_timeout}s")
+
+        pool = ConnectionPool(config=self.config, size=threads)
+        try:
+            pool.warmup()
+        except RuntimeError as e:
+            logger.error(f"Connection pool warmup failed: {e}")
+            fire_event(
+                GenerationCompleted(
+                    total_views=total, successful=0, failed=total, duration_seconds=time.time() - start_time
+                )
+            )
+            return GenerateResult(success=False, views_generated=[], views_failed=[], errors=[str(e)])
+
+        def _generate_one(view_config: Dict[str, Any], idx: int) -> Dict[str, Any]:
+            """Worker: generate a single semantic view."""
+            view_name = view_config.get("name")
+            table_names = view_config.get("tables", [])
+            description = view_config.get("description", "")
+            custom_instruction_names = view_config.get("custom_instructions", [])
+
+            if cancelled.is_set():
+                return {"view_name": view_name, "success": False, "error": "Cancelled", "duration": 0}
+
+            if not table_names:
+                with output_lock:
+                    progress.item_progress(idx, total, view_name, "ERROR")
+                    fire_event(
+                        ViewGenerationFailed(
+                            view_name=view_name, error_message="No tables specified", current=idx, total=total
+                        )
+                    )
+                return {"view_name": view_name, "success": False, "error": "No tables specified", "duration": 0}
+
+            cm = pool.checkout()
+            try:
+                builder = SemanticViewBuilder(config=self.config, snowflake_loader=cm)
+                builder.target_database = generate_config.target_database
+                builder.target_schema = generate_config.target_schema
+                builder.metadata_database = generate_config.metadata_database
+                builder.metadata_schema = generate_config.metadata_schema
+
+                with output_lock:
+                    progress.item_progress(idx, total, view_name, "RUN")
+
+                view_start = time.time()
+                result = builder.build_semantic_view(
+                    table_names=table_names,
+                    view_name=view_name,
+                    description=description,
+                    execute=generate_config.execute,
+                    defer_database=generate_config.defer_database,
+                    defer_manifest=generate_config.defer_manifest,
+                    custom_instruction_names=custom_instruction_names,
+                )
+                view_duration = time.time() - view_start
+
+                if result["success"]:
+                    with output_lock:
+                        fire_event(
+                            ViewGenerated(
+                                view_name=view_name,
+                                table_count=len(table_names),
+                                duration_seconds=view_duration,
+                                current=idx,
+                                total=total,
+                                executed=generate_config.execute,
+                            )
+                        )
+                    return {
+                        "view_name": view_name,
+                        "success": True,
+                        "sql": result["sql_statement"],
+                        "duration": view_duration,
+                    }
+                else:
+                    with output_lock:
+                        fire_event(
+                            ViewGenerationFailed(
+                                view_name=view_name,
+                                error_message=result["message"][:200],
+                                current=idx,
+                                total=total,
+                            )
+                        )
+                    return {
+                        "view_name": view_name,
+                        "success": False,
+                        "error": result["message"],
+                        "duration": view_duration,
+                    }
+
+            except Exception as e:
+                # Retry once on transient errors
+                if self._is_transient_error(e):
+                    logger.debug(f"Transient error on '{view_name}', retrying in 2s...")
+                    time.sleep(2)
+                    try:
+                        view_start = time.time()
+                        result = builder.build_semantic_view(
+                            table_names=table_names,
+                            view_name=view_name,
+                            description=description,
+                            execute=generate_config.execute,
+                            defer_database=generate_config.defer_database,
+                            defer_manifest=generate_config.defer_manifest,
+                            custom_instruction_names=custom_instruction_names,
+                        )
+                        view_duration = time.time() - view_start
+                        if result["success"]:
+                            with output_lock:
+                                fire_event(
+                                    ViewGenerated(
+                                        view_name=view_name,
+                                        table_count=len(table_names),
+                                        duration_seconds=view_duration,
+                                        current=idx,
+                                        total=total,
+                                        executed=generate_config.execute,
+                                    )
+                                )
+                            return {
+                                "view_name": view_name,
+                                "success": True,
+                                "sql": result["sql_statement"],
+                                "duration": view_duration,
+                            }
+                    except Exception:
+                        pass  # Fall through to error handling
+
+                error_msg = _format_snowflake_error(view_name, e)
+                with output_lock:
+                    fire_event(
+                        ViewGenerationFailed(view_name=view_name, error_message=str(e)[:200], current=idx, total=total)
+                    )
+                return {"view_name": view_name, "success": False, "error": error_msg, "duration": 0}
+            finally:
+                pool.checkin(cm)
+
+        try:
+            with ThreadPoolExecutor(max_workers=threads) as executor:
+                futures = {
+                    executor.submit(_generate_one, view_config, idx): view_config
+                    for idx, view_config in enumerate(views_to_generate, 1)
+                }
+
+                for future in as_completed(futures):
+                    try:
+                        result = future.result(timeout=view_timeout)
+                    except TimeoutError:
+                        view_config = futures[future]
+                        view_name = view_config.get("name", "unknown")
+                        error_msg = f"View '{view_name}' timed out after {view_timeout}s"
+                        views_failed.append(view_name)
+                        errors.append(error_msg)
+                        with output_lock:
+                            fire_event(
+                                ViewGenerationFailed(
+                                    view_name=view_name, error_message=error_msg, current=0, total=total
+                                )
+                            )
+                        continue
+                    except Exception as e:
+                        view_config = futures[future]
+                        view_name = view_config.get("name", "unknown")
+                        error_msg = _format_snowflake_error(view_name, e)
+                        views_failed.append(view_name)
+                        errors.append(error_msg)
+                        continue
+
+                    if result["success"]:
+                        views_generated.append(result["view_name"])
+                        if result.get("sql"):
+                            sql_statements[result["view_name"]] = result["sql"]
+                    else:
+                        views_failed.append(result["view_name"])
+                        if result.get("error"):
+                            errors.append(result["error"])
+
+        except KeyboardInterrupt:
+            cancelled.set()
+            logger.warning("Ctrl+C received — shutting down...")
+            with output_lock:
+                progress.warning(
+                    f"Cancelled. {len(views_generated)} of {total} completed, "
+                    f"{total - len(views_generated) - len(views_failed)} aborted."
+                )
+        finally:
+            pool.close_all()
+
+        duration = time.time() - start_time
+        fire_event(
+            GenerationCompleted(
+                total_views=total,
+                successful=len(views_generated),
+                failed=len(views_failed),
+                duration_seconds=duration,
+            )
+        )
+
+        return GenerateResult(
+            success=len(views_failed) == 0 and not cancelled.is_set(),
+            views_generated=views_generated,
+            views_failed=views_failed,
+            errors=errors,
+            sql_statements=sql_statements if not generate_config.execute else None,
+        )
 
     def _query_available_views(self) -> List[Dict[str, Any]]:
         """
@@ -692,6 +951,8 @@ class SemanticViewGenerationService:
                 defer_database=config.defer_database,
                 defer_manifest=config.defer_manifest,
                 execute=not config.dry_run,
+                threads=config.threads,
+                view_timeout=config.view_timeout,
             )
 
             # Execute using low-level interface with progress callback

--- a/snowflake_semantic_tools/shared/config.py
+++ b/snowflake_semantic_tools/shared/config.py
@@ -78,6 +78,8 @@ class Config:
             },
             "generation": {
                 "filters_to_instructions": True,  # Convert filters to AI_SQL_GENERATION instructions
+                "threads": 1,  # Number of concurrent semantic view generations (1 = sequential)
+                "view_timeout": 300,  # Per-view timeout in seconds
             },
             "logging": {"level": "INFO", "format": "%(asctime)s - %(name)s - %(levelname)s - %(message)s"},
         }

--- a/snowflake_semantic_tools/templates/sst_config.yml.j2
+++ b/snowflake_semantic_tools/templates/sst_config.yml.j2
@@ -37,3 +37,10 @@ enrichment:
 #   state_path: null                                # Path to state artifacts (for dbt Cloud CLI users)
 #   auto_compile: false                             # For dbt Core: auto-compile manifest if not found
 
+# ============================================================================
+# GENERATION (Optional)
+# ============================================================================
+# generation:
+#   threads: 4                                      # Concurrent semantic view generations (default: 1)
+#   view_timeout: 300                               # Per-view timeout in seconds (default: 300)
+

--- a/tests/unit/services/test_parallel_generation.py
+++ b/tests/unit/services/test_parallel_generation.py
@@ -1,0 +1,296 @@
+"""
+Unit tests for parallel semantic view generation (--threads).
+
+Tests the ConnectionPool, parallel execution, error isolation,
+timeout handling, retry logic, and config resolution.
+"""
+
+import queue
+import threading
+import time
+from concurrent.futures import TimeoutError
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from snowflake_semantic_tools.services.connection_pool import ConnectionPool
+from snowflake_semantic_tools.services.generate_semantic_views import (
+    GenerateConfig,
+    SemanticViewGenerationService,
+    UnifiedGenerationConfig,
+)
+
+
+class TestConnectionPool:
+    """Tests for ConnectionPool lifecycle."""
+
+    def test_pool_size(self):
+        config = MagicMock()
+        pool = ConnectionPool(config=config, size=4)
+        assert pool.size == 4
+
+    @patch("snowflake_semantic_tools.services.connection_pool.ConnectionManager")
+    def test_warmup_success(self, MockCM):
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+
+        mock_cm_instance = MagicMock()
+        mock_cm_instance.get_connection.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_cm_instance.get_connection.return_value.__exit__ = MagicMock(return_value=False)
+        MockCM.return_value = mock_cm_instance
+
+        config = MagicMock()
+        pool = ConnectionPool(config=config, size=2)
+        pool.warmup()
+        assert pool._pool.qsize() == 2
+
+    @patch("snowflake_semantic_tools.services.connection_pool.ConnectionManager")
+    def test_warmup_failure_raises(self, MockCM):
+        mock_cm_instance = MagicMock()
+        mock_cm_instance.get_connection.return_value.__enter__ = MagicMock(side_effect=Exception("Auth failed"))
+        mock_cm_instance.get_connection.return_value.__exit__ = MagicMock(return_value=False)
+        MockCM.return_value = mock_cm_instance
+
+        config = MagicMock()
+        pool = ConnectionPool(config=config, size=2)
+        with pytest.raises(RuntimeError, match="Failed to establish"):
+            pool.warmup()
+
+    def test_checkout_checkin(self):
+        config = MagicMock()
+        pool = ConnectionPool(config=config, size=2)
+        cm1 = MagicMock()
+        cm2 = MagicMock()
+        pool._pool.put(cm1)
+        pool._pool.put(cm2)
+        pool._all_managers = [cm1, cm2]
+
+        checked_out = pool.checkout(timeout=1.0)
+        assert checked_out is cm1
+        pool.checkin(checked_out)
+        assert pool._pool.qsize() == 2
+
+    def test_close_all(self):
+        config = MagicMock()
+        pool = ConnectionPool(config=config, size=2)
+        cm1 = MagicMock()
+        cm2 = MagicMock()
+        pool._all_managers = [cm1, cm2]
+        pool._pool.put(cm1)
+        pool._pool.put(cm2)
+
+        pool.close_all()
+        cm1.close.assert_called_once()
+        cm2.close.assert_called_once()
+        assert pool._closed is True
+
+
+class TestParallelExecution:
+    """Tests for parallel generation in SemanticViewGenerationService."""
+
+    def _make_service(self):
+        """Create a service with mocked Snowflake config."""
+        config = MagicMock()
+        config.account = "test"
+        config.user = "test_user"
+        config.role = "test_role"
+        config.connection_params = {}
+        with patch(
+            "snowflake_semantic_tools.services.generate_semantic_views.ConnectionManager"
+        ) as MockCM:
+            mock_cm = MagicMock()
+            MockCM.return_value = mock_cm
+            service = SemanticViewGenerationService(config)
+        return service
+
+    def test_threads_1_uses_sequential_path(self):
+        """threads=1 should NOT call _execute_parallel."""
+        service = self._make_service()
+        service._execute_parallel = MagicMock()
+        service._query_available_views = MagicMock(return_value=[])
+
+        gen_config = GenerateConfig(
+            views_to_generate=[],
+            target_database="DB",
+            target_schema="SCH",
+            metadata_database="DB",
+            metadata_schema="SCH",
+            threads=1,
+        )
+        service.execute(gen_config)
+        service._execute_parallel.assert_not_called()
+
+    def test_threads_gt1_uses_parallel_path(self):
+        """threads>1 should call _execute_parallel."""
+        service = self._make_service()
+
+        views = [
+            {"name": "view_a", "tables": ["T1"], "description": "", "custom_instructions": []},
+            {"name": "view_b", "tables": ["T2"], "description": "", "custom_instructions": []},
+        ]
+        service._query_available_views = MagicMock(return_value=views)
+        service._execute_parallel = MagicMock(
+            return_value=MagicMock(success=True, views_generated=["view_a", "view_b"], views_failed=[], errors=[])
+        )
+
+        gen_config = GenerateConfig(
+            views_to_generate=views,
+            target_database="DB",
+            target_schema="SCH",
+            metadata_database="DB",
+            metadata_schema="SCH",
+            threads=4,
+        )
+        result = service.execute(gen_config)
+        service._execute_parallel.assert_called_once()
+
+    @patch("snowflake_semantic_tools.services.generate_semantic_views.ConnectionPool")
+    @patch("snowflake_semantic_tools.services.generate_semantic_views.SemanticViewBuilder")
+    def test_parallel_generates_all_views(self, MockBuilder, MockPool):
+        """Parallel execution should generate all views successfully."""
+        mock_pool = MagicMock()
+        mock_pool.warmup = MagicMock()
+        mock_cm = MagicMock()
+        mock_pool.checkout.return_value = mock_cm
+        MockPool.return_value = mock_pool
+
+        mock_builder = MagicMock()
+        mock_builder.build_semantic_view.return_value = {
+            "success": True,
+            "sql_statement": "CREATE SEMANTIC VIEW ...",
+            "message": "ok",
+        }
+        MockBuilder.return_value = mock_builder
+
+        service = self._make_service()
+
+        views = [
+            {"name": f"view_{i}", "tables": [f"T{i}"], "description": "", "custom_instructions": []}
+            for i in range(8)
+        ]
+
+        gen_config = GenerateConfig(
+            views_to_generate=views,
+            target_database="DB",
+            target_schema="SCH",
+            metadata_database="DB",
+            metadata_schema="SCH",
+            threads=4,
+            view_timeout=30,
+        )
+
+        from snowflake_semantic_tools.shared.progress import NoOpProgressCallback
+
+        result = service._execute_parallel(views, gen_config, NoOpProgressCallback(), time.time())
+        assert result.success
+        assert len(result.views_generated) == 8
+        assert len(result.views_failed) == 0
+
+    @patch("snowflake_semantic_tools.services.generate_semantic_views.ConnectionPool")
+    @patch("snowflake_semantic_tools.services.generate_semantic_views.SemanticViewBuilder")
+    def test_one_failure_doesnt_crash_others(self, MockBuilder, MockPool):
+        """A single view failure should not prevent other views from succeeding."""
+        mock_pool = MagicMock()
+        mock_pool.warmup = MagicMock()
+        mock_cm = MagicMock()
+        mock_pool.checkout.return_value = mock_cm
+        MockPool.return_value = mock_pool
+
+        call_count = {"n": 0}
+
+        def side_effect(**kwargs):
+            call_count["n"] += 1
+            if kwargs.get("view_name") == "view_bad":
+                return {"success": False, "sql_statement": "", "message": "Snowflake error"}
+            return {"success": True, "sql_statement": "CREATE ...", "message": "ok"}
+
+        mock_builder = MagicMock()
+        mock_builder.build_semantic_view.side_effect = side_effect
+        MockBuilder.return_value = mock_builder
+
+        service = self._make_service()
+
+        views = [
+            {"name": "view_good_1", "tables": ["T1"], "description": "", "custom_instructions": []},
+            {"name": "view_bad", "tables": ["T2"], "description": "", "custom_instructions": []},
+            {"name": "view_good_2", "tables": ["T3"], "description": "", "custom_instructions": []},
+        ]
+
+        gen_config = GenerateConfig(
+            views_to_generate=views,
+            target_database="DB",
+            target_schema="SCH",
+            metadata_database="DB",
+            metadata_schema="SCH",
+            threads=2,
+            view_timeout=30,
+        )
+
+        from snowflake_semantic_tools.shared.progress import NoOpProgressCallback
+
+        result = service._execute_parallel(views, gen_config, NoOpProgressCallback(), time.time())
+        assert not result.success
+        assert len(result.views_generated) == 2
+        assert "view_bad" in result.views_failed
+
+
+class TestIsTransientError:
+    """Tests for transient error detection."""
+
+    @pytest.fixture
+    def service(self):
+        config = MagicMock()
+        config.connection_params = {}
+        with patch("snowflake_semantic_tools.services.generate_semantic_views.ConnectionManager"):
+            return SemanticViewGenerationService(config)
+
+    def test_250001_is_transient(self, service):
+        assert service._is_transient_error(Exception("250001: connection reset"))
+
+    def test_503_is_transient(self, service):
+        assert service._is_transient_error(Exception("HTTP 503 Service Unavailable"))
+
+    def test_normal_error_is_not_transient(self, service):
+        assert not service._is_transient_error(Exception("Object does not exist"))
+
+
+class TestConfigResolution:
+    """Tests for threads config resolution."""
+
+    def test_unified_config_defaults(self):
+        config = UnifiedGenerationConfig(
+            metadata_database="DB",
+            metadata_schema="SCH",
+            target_database="DB",
+            target_schema="SCH",
+        )
+        assert config.threads == 1
+        assert config.view_timeout == 300
+
+    def test_unified_config_custom_threads(self):
+        config = UnifiedGenerationConfig(
+            metadata_database="DB",
+            metadata_schema="SCH",
+            target_database="DB",
+            target_schema="SCH",
+            threads=8,
+            view_timeout=60,
+        )
+        assert config.threads == 8
+        assert config.view_timeout == 60
+
+    def test_generate_config_defaults(self):
+        config = GenerateConfig()
+        assert config.threads == 1
+        assert config.view_timeout == 300
+
+    def test_config_file_threads_default(self):
+        from snowflake_semantic_tools.shared.config import Config
+
+        config = Config.__new__(Config)
+        config._config = config._get_defaults()
+        assert config.get("generation.threads") == 1
+        assert config.get("generation.view_timeout") == 300


### PR DESCRIPTION
## Summary

- Add `--threads` flag to `sst generate` for concurrent `CREATE SEMANTIC VIEW` execution
- Thread-safe `ConnectionPool` with warmup (fail-fast), checkout/checkin, and cleanup
- Per-view timeout, graceful Ctrl+C, and single retry on transient Snowflake errors
- Config: `generation.threads` (default 1) and `generation.view_timeout` (default 300s)
- 16 new unit tests covering pool lifecycle, parallelism, error isolation, and config resolution

## Performance (72 views, analytics-dbt)

| Threads | Time | Speedup |
|---------|------|---------|
| 1 (sequential) | 12m 29s | 1x |
| 4 | 3m 18s | 3.8x |
| 12 | 1m 32s | 8.1x |

## Test plan

- [x] All 1516 unit tests pass (16 new)
- [x] `sst generate --all --threads 1` — identical to current behavior
- [x] `sst generate --all --threads 4` — 72/72 created in 3m 18s
- [x] `sst generate --all --threads 12` — 72/72 created in 1m 32s
- [x] `s## Sumerate --all --dry-run --threads 4` — parallel SQL gen, no execution
- [x] black + isort clean

Closes #215

.... Generate- Thread-safe `ConnectionPool` with warmup (fail-fast), checkout/checkin, and cleanup
-EN- Per-view timeout, graceful Ctrl+C, and single retry on transient Snowflake errors
)"- Config: `generation.threads` (default 1) and `generation.view_timeoutgh pr create --title "[SST-215] Parallel semantic view generation (--threads)" --base fix/v030-release-bugs-combined --body-file /tmp/sst_pr_body.md
true
