### PR TITLE
[SST-106] Support SQL expressions in relationship join conditions

### DIFF
--- a/.cortex/skills/sst-e2e-test/references/expected-outputs.md
+++ b/.cortex/skills/sst-e2e-test/references/expected-outputs.md
@@ -17,7 +17,7 @@ Note: `sst validate` reports 16 models because it also counts the _error_example
 | Component            | Count | Notes |
 |----------------------|-------|-------|
 | Metrics              | 80+   | Across all 6 core tables + advanced (window, composition, non_additive, etc.) |
-| Relationships        | 8     | Standard (5) + ASOF (1) + Range/BETWEEN EXCLUSIVE (1) + Composite (1) |
+| Relationships        | 11    | Standard (5) + ASOF (2) + Range/BETWEEN EXCLUSIVE (1) + Composite (1) + Expression-based (2) |
 | Semantic Views       | 3     | Sales analytics, menu analytics, complete |
 | Custom Instructions  | 2     | business_rules, menu_analytics_guidance |
 | Filters              | 6     | Equality, date range, numeric, boolean, multi-table, legacy syntax |
@@ -29,7 +29,7 @@ Note: `sst validate` reports 16 models because it also counts the _error_example
 |------|----------------------|
 | `models/marts/_error_examples.yml` | V007, V008, V010, V011, V012, V013, V014, V015, V016, V020, V023, V024, V025 |
 | `snowflake_semantic_models/metrics/_error_examples.yml` | V002, V003, V004, V032, V033, V034, V035, V036, V037, V038, V044, V091 |
-| `snowflake_semantic_models/relationships/_error_examples.yml` | V040, V041, V043 |
+| `snowflake_semantic_models/relationships/_error_examples.yml` | V040, V041, V043, V049 |
 | `snowflake_semantic_models/filters/_error_examples.yml` | V051 |
 | `snowflake_semantic_models/verified_queries/_error_examples.yml` | V060, V061, V062 |
 | `snowflake_semantic_models/_error_semantic_views.yml` | V070, V071 |
@@ -47,9 +47,12 @@ These files are EXPECTED to produce validation errors. The test passes if:
 | order_items_to_orders      | order_items | orders          | Standard equality |
 | order_items_to_products    | order_items | products        | Standard equality |
 | supplies_to_products       | supplies    | products        | Standard equality |
+| orders_to_customers_asof   | orders      | customers       | ASOF (temporal)   |
 | orders_to_locations_asof   | orders      | locations       | ASOF (temporal)   |
 | orders_to_pricing_periods  | orders      | pricing_periods | Range/BETWEEN EXCLUSIVE |
 | order_items_composite_join | order_items | orders          | Composite (multi-column) |
+| orders_to_time_spine_daily | orders      | metricflow_time_spine | Expression: DATE(ordered_at) |
+| order_items_to_time_spine_daily | order_items | metricflow_time_spine | Expression: DATE_TRUNC('day', ordered_at) |
 
 ## Semantic Views
 
@@ -57,7 +60,7 @@ These files are EXPECTED to produce validation errors. The test passes if:
 |-------------------------------|--------|---------------------|
 | jaffle_shop_sales_analytics   | orders, customers, locations | jaffle_shop_business_rules |
 | jaffle_shop_menu_analytics    | order_items, products, supplies | menu_analytics_guidance |
-| jaffle_shop_complete          | orders, order_items, customers, products, locations, supplies, pricing_periods | jaffle_shop_business_rules, menu_analytics_guidance |
+| jaffle_shop_complete          | orders, order_items, customers, products, locations, supplies, pricing_periods, metricflow_time_spine | jaffle_shop_business_rules, menu_analytics_guidance |
 
 ## Validation (Expected)
 
@@ -72,7 +75,7 @@ These files are EXPECTED to produce validation errors. The test passes if:
 
 | Metric        | Expected |
 |---------------|----------|
-| Total tests   | ~1191    |
+| Total tests   | ~1568    |
 | Failures      | 0        |
 | Errors        | 0        |
 
@@ -111,7 +114,7 @@ These tables should be populated in the target schema after `sst extract`:
 | Column features | data_type, synonyms, sample_values, is_enum, visibility, tags |
 | VQR features | inline sql, sql_file, description, use_as_onboarding_question, verified_by, verified_at, multi-table |
 | Filter features | equality, date range, numeric, boolean, synonyms, legacy syntax |
-| Relationship features | standard equality, ASOF, range/BETWEEN EXCLUSIVE, composite/multi-column, description |
+| Relationship features | standard equality, ASOF, range/BETWEEN EXCLUSIVE, composite/multi-column, expression-based (DATE, DATE_TRUNC), description |
 
 ## Known Warnings (Expected, Non-Blocking)
 

--- a/docs/concepts/semantic-models.md
+++ b/docs/concepts/semantic-models.md
@@ -534,6 +534,62 @@ ORDERS (ORDERED_AT) REFERENCES EXCHANGE_RATES (BETWEEN EFFECTIVE_START AND EFFEC
 
 > **Prerequisite:** The right table must have a `CONSTRAINT DISTINCT RANGE` declared (see [Constraints](#constraints-distinct-range)) to guarantee non-overlapping ranges.
 
+### Expression-Based Joins (Auto-Generated Join Key Dimensions)
+
+When joining tables on transformed columns (e.g., a TIMESTAMP to a DATE), you can use SQL expressions directly in relationship conditions. SST auto-generates a synthetic "join key dimension" behind the scenes so the relationship works in Snowflake's semantic view.
+
+```yaml
+snowflake_relationships:
+  - name: orders_to_calendar
+    left_table: {{ ref('orders') }}
+    right_table: {{ ref('calendar') }}
+    relationship_conditions:
+      - "DATE({{ ref('orders', 'ordered_at') }}) = {{ ref('calendar', 'date_day') }}"
+```
+
+This generates a hidden dimension and references it in the relationship:
+```sql
+DIMENSIONS (
+    ...
+    ORDERS._JK_ORDERED_AT_032F AS DATE(ORDERED_AT)
+      COMMENT = 'Auto-generated join key: DATE(ORDERED_AT)'
+)
+RELATIONSHIPS (
+    ORDERS_TO_CALENDAR AS
+      ORDERS (_JK_ORDERED_AT_032F) REFERENCES CALENDAR (DATE_DAY)
+)
+```
+
+**Supported expression patterns:**
+
+Any valid Snowflake SQL expression that wraps a single column reference is supported. Common examples:
+
+| Pattern | Example |
+|---------|---------|
+| `DATE()` | `DATE({{ ref('orders', 'ordered_at') }})` |
+| `DATE_TRUNC()` | `DATE_TRUNC('month', {{ ref('orders', 'ordered_at') }})` |
+| `::` cast | `{{ ref('orders', 'ordered_at') }}::DATE` |
+| `CAST(... AS ...)` | `CAST({{ ref('orders', 'ordered_at') }} AS DATE)` |
+| `TO_DATE()` / `TO_TIMESTAMP()` | `TO_DATE({{ ref('orders', 'ordered_at') }})` |
+| `UPPER()` / `LOWER()` / `TRIM()` | `UPPER({{ ref('users', 'email') }})` |
+| Arithmetic | `{{ ref('orders', 'amount') }} + 1` |
+
+Expressions referencing multiple columns (e.g., `{{ ref('a', 'col1') }} + {{ ref('a', 'col2') }}`) are not supported — each expression must wrap exactly one column.
+
+The expression is passed through to Snowflake as-is in the generated dimension definition. Snowflake validates the SQL at semantic view creation time.
+
+**How it works:**
+1. SST detects the expression wrapping the column template during parsing
+2. The base column (e.g., `ordered_at`) is validated against the dbt catalog as usual
+3. At generation time, a synthetic dimension (prefixed `_JK_`) is created with the expression
+4. The RELATIONSHIPS clause references the dimension name instead of the raw column
+
+**Notes:**
+- The auto-generated dimension is publicly visible (Snowflake does not support private dimensions)
+- If the same expression is used in multiple relationships, the dimension is reused (deduplicated)
+- Expressions can appear on either side (or both sides) of a join condition
+- Nested expressions (e.g., `DATE_TRUNC('month', DATE(...))`) are not supported in this release
+
 ### Real Example
 
 ```yaml

--- a/docs/concepts/semantic-models.md
+++ b/docs/concepts/semantic-models.md
@@ -573,10 +573,11 @@ Any valid Snowflake SQL expression that wraps a single column reference is suppo
 | `TO_DATE()` / `TO_TIMESTAMP()` | `TO_DATE({{ ref('orders', 'ordered_at') }})` |
 | `UPPER()` / `LOWER()` / `TRIM()` | `UPPER({{ ref('users', 'email') }})` |
 | Arithmetic | `{{ ref('orders', 'amount') }} + 1` |
+| Nested | `DATE_TRUNC('month', DATE({{ ref('events', 'ts') }}))` |
 
-Expressions referencing multiple columns (e.g., `{{ ref('a', 'col1') }} + {{ ref('a', 'col2') }}`) are not supported — each expression must wrap exactly one column.
+This is not an exhaustive list — any expression wrapping a single column reference will work. Expressions referencing multiple columns (e.g., `{{ ref('a', 'col1') }} + {{ ref('a', 'col2') }}`) are not supported and will raise an SST-V049 error.
 
-The expression is passed through to Snowflake as-is in the generated dimension definition. Snowflake validates the SQL at semantic view creation time.
+The expression is passed through to Snowflake as-is in the generated dimension definition. Snowflake validates the SQL at semantic view creation time. To catch SQL typos before generation, use `sst validate --snowflake-syntax-check`.
 
 **How it works:**
 1. SST detects the expression wrapping the column template during parsing
@@ -588,7 +589,6 @@ The expression is passed through to Snowflake as-is in the generated dimension d
 - The auto-generated dimension is publicly visible (Snowflake does not support private dimensions)
 - If the same expression is used in multiple relationships, the dimension is reused (deduplicated)
 - Expressions can appear on either side (or both sides) of a join condition
-- Nested expressions (e.g., `DATE_TRUNC('month', DATE(...))`) are not supported in this release
 
 ### Real Example
 

--- a/docs/concepts/validation-rules.md
+++ b/docs/concepts/validation-rules.md
@@ -83,7 +83,7 @@ Complete list of all validation checks performed by `sst validate`.
 | **Relationship** | Right join columns exist in right table | ERROR|
 | **Relationship** | Right join columns reference primary key or unique columns | ERROR|
 | **Relationship** | Composite primary keys are fully referenced (not partial) | ERROR|
-| **Relationship** | No SQL transformations in column references (no `::`, `CAST`, functions) | ERROR|
+| **Relationship** | SQL expressions wrapping a single column reference are allowed and auto-generate [join key dimensions](semantic-models.md#expression-based-joins-auto-generated-join-key-dimensions). Multi-column expressions are not supported. | INFO|
 | **Relationship** | BETWEEN condition has valid left/right table and column references | ERROR|
 | **Relationship** | No duplicate relationship names (normalized¹) | ERROR|
 | **Relationship** | No circular dependencies in relationship chains | ERROR|

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -40,7 +40,7 @@ Stable error codes for SST diagnostics. Each code is a permanent identifier that
 | `SST-V040` | Missing relationship field | Relationship '{name}' is missing required field: {field} |
 | `SST-V041` | Relationship table not found | Table '{table}' in relationship '{name}' not found. Did you mean '{closest_match}'? |
 | `SST-V042` | Relationship missing primary key | Right table '{table}' needs a primary_key for join. Add primary_key to config.meta.sst |
-| `SST-V043` | Relationship column not found | Column '{column}' not found in table '{table}'. Note: [supported expression patterns](../concepts/semantic-models.md#expression-based-joins-auto-generated-join-key-dimensions) (DATE, DATE_TRUNC, etc.) are allowed and auto-generate join key dimensions |
+| `SST-V043` | Relationship column not found | Column '{column}' not found in table '{table}'. Note: single-column [expression-based joins](../concepts/semantic-models.md#expression-based-joins-auto-generated-join-key-dimensions) are supported and auto-generate join key dimensions |
 | `SST-V044` | Using relationship not found | Relationship '{name}' referenced in using_relationships not found. Available: {available} |
 | `SST-V045` | Derived metric must use metric references | Derived metrics must use {{ metric('name') }} syntax, not raw column expressions |
 | `SST-V046` | Invalid field on derived metric | Derived metrics cannot use using_relationships, non_additive_by, or window |

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -40,12 +40,13 @@ Stable error codes for SST diagnostics. Each code is a permanent identifier that
 | `SST-V040` | Missing relationship field | Relationship '{name}' is missing required field: {field} |
 | `SST-V041` | Relationship table not found | Table '{table}' in relationship '{name}' not found. Did you mean '{closest_match}'? |
 | `SST-V042` | Relationship missing primary key | Right table '{table}' needs a primary_key for join. Add primary_key to config.meta.sst |
-| `SST-V043` | Relationship column not found | Column '{column}' not found in table '{table}' |
+| `SST-V043` | Relationship column not found | Column '{column}' not found in table '{table}'. Note: [supported expression patterns](../concepts/semantic-models.md#expression-based-joins-auto-generated-join-key-dimensions) (DATE, DATE_TRUNC, etc.) are allowed and auto-generate join key dimensions |
 | `SST-V044` | Using relationship not found | Relationship '{name}' referenced in using_relationships not found. Available: {available} |
 | `SST-V045` | Derived metric must use metric references | Derived metrics must use {{ metric('name') }} syntax, not raw column expressions |
 | `SST-V046` | Invalid field on derived metric | Derived metrics cannot use using_relationships, non_additive_by, or window |
 | `SST-V047` | Excluded column conflict | Column has both exclude: true and column_type set. Excluded columns are omitted from semantic views |
 | `SST-V048` | Primary key and unique keys overlap | Columns in both primary_key and unique_keys. Remove duplicates from unique_keys |
+| `SST-V049` | Multi-column expression in relationship | Expressions in join conditions must reference exactly one column. Use a single-column expression, or add a computed column to the dbt model |
 | `SST-V050` | Deprecated filters syntax | Migrate to snowflake_custom_instructions with ai_sql_generation text |
 | `SST-V051` | Invalid filter expression | Filter expression must be a non-empty SQL string |
 | `SST-V052` | Deprecated custom instruction key names | Use 'ai_sql_generation' and 'ai_question_categorization' to align with Snowflake DDL |

--- a/snowflake_semantic_tools/core/diagnostics/error_codes.py
+++ b/snowflake_semantic_tools/core/diagnostics/error_codes.py
@@ -226,6 +226,13 @@ _register(
     "Remove overlapping columns from unique_keys — primary_key is already unique",
 )
 _register(
+    "SST-V049",
+    "Unsupported multi-column expression in relationship condition",
+    ErrorCategory.VALIDATION,
+    "Expressions in relationship conditions must reference exactly one column. "
+    "Multi-column expressions (e.g., COALESCE(col1, col2)) are not supported for join key generation.",
+)
+_register(
     "SST-V040",
     "Missing relationship field",
     ErrorCategory.VALIDATION,

--- a/snowflake_semantic_tools/core/generation/join_key_generator.py
+++ b/snowflake_semantic_tools/core/generation/join_key_generator.py
@@ -133,7 +133,7 @@ def _detect_resolved_expression(side_expr: str) -> Optional[Dict[str, str]]:
 
 
 def _normalize_sql_expression(sql_expr: str) -> str:
-    """Normalize a SQL expression: strip whitespace and uppercase function names."""
+    """Normalize a SQL expression: strip outer whitespace and collapse internal whitespace."""
     sql_expr = sql_expr.strip()
     sql_expr = re.sub(r"\s+", " ", sql_expr)
     return sql_expr

--- a/snowflake_semantic_tools/core/generation/join_key_generator.py
+++ b/snowflake_semantic_tools/core/generation/join_key_generator.py
@@ -1,0 +1,195 @@
+"""
+Join Key Dimension Generator
+
+Auto-generates synthetic dimension definitions for SQL expressions used in
+relationship join conditions. When a user writes an expression like
+DATE({{ column('events', 'event_timestamp') }}) in a relationship condition,
+this generator creates a corresponding dimension that can be referenced by the
+RELATIONSHIPS clause of a semantic view.
+
+The detection is GENERIC — any SQL expression wrapping a single column template
+is supported. SST does not whitelist specific functions; instead, it detects that
+the join condition side contains more than a bare column reference. Snowflake
+validates the SQL expression at semantic view creation time.
+
+See: https://github.com/WhoopInc/snowflake-semantic-tools/issues/106
+"""
+
+import hashlib
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+from snowflake_semantic_tools.shared import get_logger
+
+logger = get_logger("core.generation.join_key_generator")
+
+TEMPLATE_PATTERN = re.compile(r"{{\s*(?:column|ref)\s*\(\s*['\"]([^'\"]+)['\"]\s*,\s*['\"]([^'\"]+)['\"]\s*\)\s*}}")
+
+RESOLVED_COL_PATTERN = re.compile(r"([A-Z_][A-Z0-9_]*)\.([A-Z_][A-Z0-9_]*)", re.IGNORECASE)
+
+
+def has_wrapping_text(side_expr: str) -> bool:
+    """Check if a join condition side has text wrapping a column reference.
+
+    Returns True if the side contains a column template or TABLE.COL but also has
+    additional text around it (i.e., it's not just a bare column reference).
+    """
+    side_expr = side_expr.strip()
+    if not side_expr:
+        return False
+
+    tmpl_matches = list(TEMPLATE_PATTERN.finditer(side_expr))
+    if tmpl_matches:
+        if len(tmpl_matches) == 1 and side_expr == tmpl_matches[0].group(0).strip():
+            return False
+        return True
+
+    resolved_matches = list(RESOLVED_COL_PATTERN.finditer(side_expr))
+    if resolved_matches:
+        if len(resolved_matches) == 1 and side_expr == resolved_matches[0].group(0).strip():
+            return False
+        return True
+
+    return False
+
+
+def detect_expression(side_expr: str) -> Optional[Dict[str, str]]:
+    """Detect if a join condition side contains a SQL expression wrapping a column reference.
+
+    Uses a GENERIC approach: if the side string is anything other than a bare
+    column template (or bare TABLE.COL), it's treated as an expression. This
+    supports any valid Snowflake SQL expression (DATE, DATE_TRUNC, UPPER,
+    COALESCE, CAST, ::, arithmetic, etc.).
+
+    Supports both:
+    - Template format: DATE({{ column('events', 'ts') }})
+    - Resolved format: DATE(EVENTS.TS)
+
+    Args:
+        side_expr: One side of a join condition
+
+    Returns:
+        Dict with keys {table, column, sql_expression} if an expression is detected, else None.
+        sql_expression contains the SQL form with only the column name
+        (e.g., "DATE(EVENT_TIMESTAMP)").
+    """
+    side_expr = side_expr.strip()
+    if not side_expr:
+        return None
+
+    result = _detect_template_expression(side_expr)
+    if result:
+        return result
+
+    return _detect_resolved_expression(side_expr)
+
+
+def _detect_template_expression(side_expr: str) -> Optional[Dict[str, str]]:
+    """Detect expression in template format.
+
+    If the side contains exactly one {{ column/ref(...) }} template AND has
+    additional text around it, it's an expression. If the side IS just the
+    template with no surrounding text, it's a bare column reference (not an expression).
+    """
+    matches = list(TEMPLATE_PATTERN.finditer(side_expr))
+    if len(matches) != 1:
+        return None
+
+    m = matches[0]
+    table = m.group(1).upper()
+    column = m.group(2).upper()
+
+    bare_template = m.group(0).strip()
+    if side_expr.strip() == bare_template:
+        return None
+
+    sql_expr = side_expr.replace(m.group(0), column)
+    sql_expr = _normalize_sql_expression(sql_expr)
+
+    return {"table": table, "column": column, "sql_expression": sql_expr}
+
+
+def _detect_resolved_expression(side_expr: str) -> Optional[Dict[str, str]]:
+    """Detect expression in resolved format (post-template resolution).
+
+    If the side contains exactly one TABLE.COLUMN reference AND has additional
+    text around it, it's an expression. A bare TABLE.COLUMN is not an expression.
+    """
+    matches = list(RESOLVED_COL_PATTERN.finditer(side_expr))
+    if len(matches) != 1:
+        return None
+
+    m = matches[0]
+    table = m.group(1).upper()
+    column = m.group(2).upper()
+
+    if side_expr.strip() == m.group(0).strip():
+        return None
+
+    sql_expr = side_expr.replace(m.group(0), column)
+    sql_expr = _normalize_sql_expression(sql_expr)
+
+    return {"table": table, "column": column, "sql_expression": sql_expr}
+
+
+def _normalize_sql_expression(sql_expr: str) -> str:
+    """Normalize a SQL expression: strip whitespace and uppercase function names."""
+    sql_expr = sql_expr.strip()
+    sql_expr = re.sub(r"\s+", " ", sql_expr)
+    return sql_expr
+
+
+class JoinKeyDimensionGenerator:
+    """Generates synthetic dimensions for expression-based join keys."""
+
+    def __init__(self) -> None:
+        self._generated: Dict[Tuple[str, str], Dict[str, Any]] = {}
+
+    def register_join_key(self, table: str, column: str, sql_expression: str) -> str:
+        """Register a join key expression and return the generated dimension name.
+
+        Deduplicates: if the same (table, expression) pair is registered twice, the
+        same dimension name is returned.
+
+        Args:
+            table: Source table name (uppercased).
+            column: Base column name from the template (uppercased).
+            sql_expression: The SQL expression for the dimension (e.g., "DATE(EVENT_TIMESTAMP)").
+
+        Returns:
+            Generated dimension name (e.g., "_JK_EVENT_TIMESTAMP_A1B2").
+        """
+        key = (table.upper(), sql_expression.upper())
+        if key not in self._generated:
+            dim_name = self._generate_name(column, sql_expression)
+            self._generated[key] = {
+                "name": dim_name,
+                "table": table.upper(),
+                "expression": sql_expression,
+                "base_column": column.upper(),
+                "comment": f"Auto-generated join key: {sql_expression}",
+            }
+            logger.info(f"Registered join key dimension: {table.upper()}.{dim_name} AS {sql_expression}")
+        return self._generated[key]["name"]
+
+    def get_dimensions_for_table(self, table: str) -> List[Dict[str, Any]]:
+        """Return all generated dimensions for a specific table."""
+        return [d for d in self._generated.values() if d["table"] == table.upper()]
+
+    def get_all_dimensions(self) -> List[Dict[str, Any]]:
+        """Return all generated dimensions across all tables."""
+        return list(self._generated.values())
+
+    def has_dimensions(self) -> bool:
+        """Return True if any join key dimensions have been generated."""
+        return bool(self._generated)
+
+    def clear(self) -> None:
+        """Clear all generated dimensions (call between semantic views)."""
+        self._generated.clear()
+
+    @staticmethod
+    def _generate_name(column: str, sql_expression: str) -> str:
+        """Generate a deterministic, unique dimension name."""
+        hash_suffix = hashlib.md5(sql_expression.upper().encode()).hexdigest()[:4].upper()
+        return f"_JK_{column.upper()}_{hash_suffix}"

--- a/snowflake_semantic_tools/core/generation/semantic_view_builder.py
+++ b/snowflake_semantic_tools/core/generation/semantic_view_builder.py
@@ -1816,8 +1816,11 @@ class SemanticViewBuilder:
             sql_parts.append(f"  RELATIONSHIPS (\n{relationships_clause}\n  )")
 
         if join_key_generator.has_dimensions():
-            jk_count = len(join_key_generator.get_all_dimensions())
+            jk_dims = join_key_generator.get_all_dimensions()
+            jk_count = len(jk_dims)
             logger.info(f"Auto-generated {jk_count} join key dimension(s) for expression-based joins")
+            for jk in jk_dims:
+                logger.warning(f"  Join key dimension: {jk['table']}.{jk['name']} AS {jk['expression']}")
 
         # Build FACTS clause
         logger.info("Building FACTS clause...")

--- a/snowflake_semantic_tools/core/generation/semantic_view_builder.py
+++ b/snowflake_semantic_tools/core/generation/semantic_view_builder.py
@@ -20,6 +20,7 @@ import json
 import re
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+from snowflake_semantic_tools.core.generation.join_key_generator import JoinKeyDimensionGenerator
 from snowflake_semantic_tools.core.parsing.join_condition_parser import JoinConditionParser, JoinType
 from snowflake_semantic_tools.infrastructure.snowflake import SnowflakeClient
 from snowflake_semantic_tools.infrastructure.snowflake.config import SnowflakeConfig
@@ -949,8 +950,16 @@ class SemanticViewBuilder:
 
         return ",\n".join(table_definitions)
 
-    def _build_relationships_clause(self, conn, table_names: List[str]) -> str:
-        """Build the RELATIONSHIPS clause of the CREATE SEMANTIC VIEW statement ."""
+    def _build_relationships_clause(
+        self, conn, table_names: List[str], join_key_generator: Optional[JoinKeyDimensionGenerator] = None
+    ) -> str:
+        """Build the RELATIONSHIPS clause of the CREATE SEMANTIC VIEW statement.
+
+        When a join condition contains a SQL expression (e.g., DATE(timestamp_col)),
+        the expression is detected and a synthetic join key dimension is registered
+        in the generator. The generated dimension name is then used in the
+        REFERENCES clause instead of the raw column name.
+        """
         relationships = self._get_relationships(conn, table_names)
 
         if not relationships:
@@ -963,13 +972,11 @@ class SemanticViewBuilder:
             left_table = rel["LEFT_TABLE_NAME"].upper()
             right_table = rel["RIGHT_TABLE_NAME"].upper()
 
-            # Get relationship conditions (new format)
-            rel_conditions = rel.get("RELATIONSHIP_COLUMNS", [])  # Still called RELATIONSHIP_COLUMNS in the result
+            rel_conditions = rel.get("RELATIONSHIP_COLUMNS", [])
             if not rel_conditions:
                 logger.warning(f"No relationship conditions found for {rel_name}")
                 continue
 
-            # Parse join conditions
             parsed_conditions = []
             for condition_row in rel_conditions:
                 join_condition = condition_row.get("JOIN_CONDITION")
@@ -981,8 +988,23 @@ class SemanticViewBuilder:
                 logger.warning(f"Could not parse conditions for {rel_name}")
                 continue
 
-            # Generate SQL based on parsed conditions
-            sql_ref = JoinConditionParser.generate_sql_references(parsed_conditions, left_table, right_table)
+            join_key_overrides: Dict[str, str] = {}
+            if join_key_generator:
+                for pc in parsed_conditions:
+                    if pc.left_has_expression:
+                        dim_name = join_key_generator.register_join_key(
+                            pc.left_table, pc.left_column, pc.left_sql_expression
+                        )
+                        join_key_overrides[f"{pc.left_table.upper()}.{pc.left_column.upper()}"] = dim_name
+                    if pc.right_has_expression:
+                        dim_name = join_key_generator.register_join_key(
+                            pc.right_table, pc.right_column, pc.right_sql_expression
+                        )
+                        join_key_overrides[f"{pc.right_table.upper()}.{pc.right_column.upper()}"] = dim_name
+
+            sql_ref = JoinConditionParser.generate_sql_references(
+                parsed_conditions, left_table, right_table, join_key_overrides=join_key_overrides
+            )
 
             if sql_ref:
                 rel_def = f"    {rel_name.upper()} AS\n      {sql_ref}"
@@ -1041,25 +1063,29 @@ class SemanticViewBuilder:
 
         return ",\n".join(fact_definitions)
 
-    def _build_dimensions_clause(self, conn, table_names: List[str]) -> str:
-        """Build the DIMENSIONS clause of the CREATE SEMANTIC VIEW statement ."""
+    def _build_dimensions_clause(
+        self, conn, table_names: List[str], join_key_generator: Optional[JoinKeyDimensionGenerator] = None
+    ) -> str:
+        """Build the DIMENSIONS clause of the CREATE SEMANTIC VIEW statement.
+
+        If a join_key_generator is provided and contains generated dimensions,
+        they are appended after all regular and time dimensions.
+        """
         all_dimensions = []
 
         for table_name in table_names:
             dimensions = self._get_dimensions(conn, table_name)
             time_dimensions = self._get_time_dimensions(conn, table_name)
 
-            # Add regular dimensions
             for dim in dimensions:
                 dim["source_table"] = table_name
                 all_dimensions.append(dim)
 
-            # Add time dimensions
             for time_dim in time_dimensions:
                 time_dim["source_table"] = table_name
                 all_dimensions.append(time_dim)
 
-        if not all_dimensions:
+        if not all_dimensions and not (join_key_generator and join_key_generator.has_dimensions()):
             return ""
 
         dim_definitions = []
@@ -1071,7 +1097,6 @@ class SemanticViewBuilder:
 
             dim_def = f"    {table_name}.{dim_name} AS {expression}"
 
-            # Add synonyms if available
             if dim.get("SYNONYMS"):
                 synonyms = self._parse_json_field(dim["SYNONYMS"], "synonyms")
                 if synonyms and isinstance(synonyms, list):
@@ -1082,17 +1107,22 @@ class SemanticViewBuilder:
                             synonyms_str = ", ".join([f"'{syn}'" for syn in synonyms_cleaned])
                             dim_def += f"\n      WITH SYNONYMS = ({synonyms_str})"
 
-            # Add comment if available
             if dim.get("DESCRIPTION"):
                 description = self._sanitize_description(dim["DESCRIPTION"])
                 dim_def += f"\n      COMMENT = '{description}'"
 
-            # Add tags if available
             tag_clause = self._build_tag_clause(dim.get("TAGS"))
             if tag_clause:
                 dim_def += f"\n      {tag_clause}"
 
             dim_definitions.append(dim_def)
+
+        if join_key_generator and join_key_generator.has_dimensions():
+            for jk_dim in join_key_generator.get_all_dimensions():
+                comment = self._sanitize_description(jk_dim["comment"])
+                jk_def = f"    {jk_dim['table']}.{jk_dim['name']} AS {jk_dim['expression']}"
+                jk_def += f"\n      COMMENT = '{comment}'"
+                dim_definitions.append(jk_def)
 
         return ",\n".join(dim_definitions)
 
@@ -1776,11 +1806,18 @@ class SemanticViewBuilder:
         )
         sql_parts.append(f"  TABLES (\n{tables_clause}\n  )")
 
-        # Build RELATIONSHIPS clause
+        # Build RELATIONSHIPS clause (must run before DIMENSIONS so join key dims are registered)
         logger.info("Building RELATIONSHIPS clause...")
-        relationships_clause = self._build_relationships_clause(conn, table_names)
+        join_key_generator = JoinKeyDimensionGenerator()
+        relationships_clause = self._build_relationships_clause(
+            conn, table_names, join_key_generator=join_key_generator
+        )
         if relationships_clause:
             sql_parts.append(f"  RELATIONSHIPS (\n{relationships_clause}\n  )")
+
+        if join_key_generator.has_dimensions():
+            jk_count = len(join_key_generator.get_all_dimensions())
+            logger.info(f"Auto-generated {jk_count} join key dimension(s) for expression-based joins")
 
         # Build FACTS clause
         logger.info("Building FACTS clause...")
@@ -1788,9 +1825,9 @@ class SemanticViewBuilder:
         if facts_clause:
             sql_parts.append(f"  FACTS (\n{facts_clause}\n  )")
 
-        # Build DIMENSIONS clause
+        # Build DIMENSIONS clause (includes auto-generated join key dimensions from relationships)
         logger.info("Building DIMENSIONS clause...")
-        dimensions_clause = self._build_dimensions_clause(conn, table_names)
+        dimensions_clause = self._build_dimensions_clause(conn, table_names, join_key_generator=join_key_generator)
         if dimensions_clause:
             sql_parts.append(f"  DIMENSIONS (\n{dimensions_clause}\n  )")
 

--- a/snowflake_semantic_tools/core/parsing/join_condition_parser.py
+++ b/snowflake_semantic_tools/core/parsing/join_condition_parser.py
@@ -107,54 +107,33 @@ class JoinConditionParser:
         left_unresolved_expression = ""
         right_unresolved_expression = ""
 
-        if is_template_format:
-            from snowflake_semantic_tools.core.generation.join_key_generator import detect_expression, has_wrapping_text
+        from snowflake_semantic_tools.core.generation.join_key_generator import detect_expression, has_wrapping_text
 
-            left_expr_info = detect_expression(left_expr.strip())
-            if left_expr_info:
-                left_table = left_expr_info["table"]
-                left_column = left_expr_info["column"]
-                left_has_expression = True
-                left_sql_expression = left_expr_info["sql_expression"]
-            else:
-                left_table, left_column = cls._extract_table_column_from_template(left_expr)
-                if has_wrapping_text(left_expr.strip()):
-                    left_unresolved_expression = left_expr.strip()
+        fallback_extractor = (
+            cls._extract_table_column_from_template if is_template_format else cls._extract_table_column_from_resolved
+        )
 
-            right_expr_info = detect_expression(right_expr.strip())
-            if right_expr_info:
-                right_table = right_expr_info["table"]
-                right_column = right_expr_info["column"]
-                right_has_expression = True
-                right_sql_expression = right_expr_info["sql_expression"]
-            else:
-                right_table, right_column = cls._extract_table_column_from_template(right_expr)
-                if has_wrapping_text(right_expr.strip()):
-                    right_unresolved_expression = right_expr.strip()
+        left_expr_info = detect_expression(left_expr.strip())
+        if left_expr_info:
+            left_table = left_expr_info["table"]
+            left_column = left_expr_info["column"]
+            left_has_expression = True
+            left_sql_expression = left_expr_info["sql_expression"]
         else:
-            from snowflake_semantic_tools.core.generation.join_key_generator import detect_expression, has_wrapping_text
+            left_table, left_column = fallback_extractor(left_expr)
+            if has_wrapping_text(left_expr.strip()):
+                left_unresolved_expression = left_expr.strip()
 
-            left_expr_info = detect_expression(left_expr.strip())
-            if left_expr_info:
-                left_table = left_expr_info["table"]
-                left_column = left_expr_info["column"]
-                left_has_expression = True
-                left_sql_expression = left_expr_info["sql_expression"]
-            else:
-                left_table, left_column = cls._extract_table_column_from_resolved(left_expr)
-                if has_wrapping_text(left_expr.strip()):
-                    left_unresolved_expression = left_expr.strip()
-
-            right_expr_info = detect_expression(right_expr.strip())
-            if right_expr_info:
-                right_table = right_expr_info["table"]
-                right_column = right_expr_info["column"]
-                right_has_expression = True
-                right_sql_expression = right_expr_info["sql_expression"]
-            else:
-                right_table, right_column = cls._extract_table_column_from_resolved(right_expr)
-                if has_wrapping_text(right_expr.strip()):
-                    right_unresolved_expression = right_expr.strip()
+        right_expr_info = detect_expression(right_expr.strip())
+        if right_expr_info:
+            right_table = right_expr_info["table"]
+            right_column = right_expr_info["column"]
+            right_has_expression = True
+            right_sql_expression = right_expr_info["sql_expression"]
+        else:
+            right_table, right_column = fallback_extractor(right_expr)
+            if has_wrapping_text(right_expr.strip()):
+                right_unresolved_expression = right_expr.strip()
 
         # For BETWEEN range joins, extract the end column
         right_column_end = ""

--- a/snowflake_semantic_tools/core/parsing/join_condition_parser.py
+++ b/snowflake_semantic_tools/core/parsing/join_condition_parser.py
@@ -17,7 +17,7 @@ enabling it to work at any stage of the processing pipeline.
 import re
 from dataclasses import dataclass
 from enum import Enum
-from typing import List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 
 class JoinType(Enum):
@@ -43,6 +43,12 @@ class ParsedCondition:
     right_column: str  # Extracted column name from right
     operator: str  # = (equality), >= (ASOF), or BETWEEN (range)
     right_column_end: str = ""  # End column for BETWEEN...AND...EXCLUSIVE range joins
+    left_has_expression: bool = False
+    right_has_expression: bool = False
+    left_sql_expression: str = ""
+    right_sql_expression: str = ""
+    left_unresolved_expression: str = ""
+    right_unresolved_expression: str = ""
 
 
 class JoinConditionParser:
@@ -94,14 +100,61 @@ class JoinConditionParser:
         # Detect format and extract table/column accordingly
         is_template_format = "{{" in condition
 
+        left_has_expression = False
+        right_has_expression = False
+        left_sql_expression = ""
+        right_sql_expression = ""
+        left_unresolved_expression = ""
+        right_unresolved_expression = ""
+
         if is_template_format:
-            # Template format: {{ column('table', 'col') }}
-            left_table, left_column = cls._extract_table_column_from_template(left_expr)
-            right_table, right_column = cls._extract_table_column_from_template(right_expr)
+            from snowflake_semantic_tools.core.generation.join_key_generator import detect_expression, has_wrapping_text
+
+            left_expr_info = detect_expression(left_expr.strip())
+            if left_expr_info:
+                left_table = left_expr_info["table"]
+                left_column = left_expr_info["column"]
+                left_has_expression = True
+                left_sql_expression = left_expr_info["sql_expression"]
+            else:
+                left_table, left_column = cls._extract_table_column_from_template(left_expr)
+                if has_wrapping_text(left_expr.strip()):
+                    left_unresolved_expression = left_expr.strip()
+
+            right_expr_info = detect_expression(right_expr.strip())
+            if right_expr_info:
+                right_table = right_expr_info["table"]
+                right_column = right_expr_info["column"]
+                right_has_expression = True
+                right_sql_expression = right_expr_info["sql_expression"]
+            else:
+                right_table, right_column = cls._extract_table_column_from_template(right_expr)
+                if has_wrapping_text(right_expr.strip()):
+                    right_unresolved_expression = right_expr.strip()
         else:
-            # Resolved format: TABLE.COLUMN
-            left_table, left_column = cls._extract_table_column_from_resolved(left_expr)
-            right_table, right_column = cls._extract_table_column_from_resolved(right_expr)
+            from snowflake_semantic_tools.core.generation.join_key_generator import detect_expression, has_wrapping_text
+
+            left_expr_info = detect_expression(left_expr.strip())
+            if left_expr_info:
+                left_table = left_expr_info["table"]
+                left_column = left_expr_info["column"]
+                left_has_expression = True
+                left_sql_expression = left_expr_info["sql_expression"]
+            else:
+                left_table, left_column = cls._extract_table_column_from_resolved(left_expr)
+                if has_wrapping_text(left_expr.strip()):
+                    left_unresolved_expression = left_expr.strip()
+
+            right_expr_info = detect_expression(right_expr.strip())
+            if right_expr_info:
+                right_table = right_expr_info["table"]
+                right_column = right_expr_info["column"]
+                right_has_expression = True
+                right_sql_expression = right_expr_info["sql_expression"]
+            else:
+                right_table, right_column = cls._extract_table_column_from_resolved(right_expr)
+                if has_wrapping_text(right_expr.strip()):
+                    right_unresolved_expression = right_expr.strip()
 
         # For BETWEEN range joins, extract the end column
         right_column_end = ""
@@ -123,6 +176,12 @@ class JoinConditionParser:
             right_column=right_column,
             operator=operator,
             right_column_end=right_column_end,
+            left_has_expression=left_has_expression,
+            right_has_expression=right_has_expression,
+            left_sql_expression=left_sql_expression,
+            right_sql_expression=right_sql_expression,
+            left_unresolved_expression=left_unresolved_expression,
+            right_unresolved_expression=right_unresolved_expression,
         )
 
     @classmethod
@@ -283,7 +342,11 @@ class JoinConditionParser:
 
     @classmethod
     def generate_sql_references(
-        cls, parsed_conditions: List[ParsedCondition], left_table_alias: str, right_table_alias: str
+        cls,
+        parsed_conditions: List[ParsedCondition],
+        left_table_alias: str,
+        right_table_alias: str,
+        join_key_overrides: Optional[Dict[str, str]] = None,
     ) -> str:
         """
         Generate SQL REFERENCES clause from parsed conditions.
@@ -297,6 +360,9 @@ class JoinConditionParser:
             parsed_conditions: List of parsed conditions
             left_table_alias: Alias for left table
             right_table_alias: Alias for right table
+            join_key_overrides: Optional mapping of (TABLE.COLUMN) -> dimension name for
+                expression-based join keys. When a condition has an expression, the
+                generated dimension name is used instead of the raw column name.
 
         Returns:
             SQL REFERENCES clause with correct ASOF syntax
@@ -304,8 +370,14 @@ class JoinConditionParser:
         if not parsed_conditions:
             return ""
 
-        # Build left column list (all conditions in original order)
-        left_cols = [c.left_column for c in parsed_conditions]
+        overrides = join_key_overrides or {}
+
+        def _resolve_col(table: str, column: str, side: str, cond: ParsedCondition) -> str:
+            has_expr = cond.left_has_expression if side == "left" else cond.right_has_expression
+            if has_expr:
+                key = f"{table.upper()}.{column.upper()}"
+                return overrides.get(key, column)
+            return column
 
         # Check if any condition is a range join
         has_range = any(c.condition_type == JoinType.RANGE for c in parsed_conditions)
@@ -321,22 +393,23 @@ class JoinConditionParser:
                     f"Snowflake range joins only support a single BETWEEN condition per relationship."
                 )
             range_cond = next(c for c in parsed_conditions if c.condition_type == JoinType.RANGE)
+            left_col = _resolve_col(range_cond.left_table, range_cond.left_column, "left", range_cond)
             sql = (
-                f"{left_table_alias} ({range_cond.left_column}) REFERENCES "
+                f"{left_table_alias} ({left_col}) REFERENCES "
                 f"{right_table_alias} (BETWEEN {range_cond.right_column} AND {range_cond.right_column_end} EXCLUSIVE)"
             )
             return sql
 
-        # Build right column list maintaining same order as left
-        # ASOF columns get the ASOF prefix, equality columns are unchanged
+        left_cols = [_resolve_col(c.left_table, c.left_column, "left", c) for c in parsed_conditions]
+
         right_cols = []
         for c in parsed_conditions:
+            col = _resolve_col(c.right_table, c.right_column, "right", c)
             if c.condition_type == JoinType.ASOF:
-                right_cols.append(f"ASOF {c.right_column}")
+                right_cols.append(f"ASOF {col}")
             else:
-                right_cols.append(c.right_column)
+                right_cols.append(col)
 
-        # Generate SQL
         sql = f"{left_table_alias} ({', '.join(left_cols)}) REFERENCES {right_table_alias} ({', '.join(right_cols)})"
 
         return sql

--- a/snowflake_semantic_tools/core/parsing/parsers/semantic_parser.py
+++ b/snowflake_semantic_tools/core/parsing/parsers/semantic_parser.py
@@ -221,10 +221,14 @@ def parse_snowflake_relationships(
                     "condition_type": parsed.condition_type.value,
                     "left_expression": parsed.left_expression,
                     "right_expression": parsed.right_expression,
-                    "left_column": left_col_qualified,  # For backward compatibility with validation
-                    "right_column": right_col_qualified,  # For backward compatibility with validation
+                    "left_column": left_col_qualified,
+                    "right_column": right_col_qualified,
                     "operator": parsed.operator,
-                    "source_file": str(file_path),  # Store the file path for validation errors
+                    "source_file": str(file_path),
+                    "left_has_expression": parsed.left_has_expression,
+                    "right_has_expression": parsed.right_has_expression,
+                    "left_unresolved_expression": parsed.left_unresolved_expression,
+                    "right_unresolved_expression": parsed.right_unresolved_expression,
                 }
                 relationship_column_records.append(rel_col_record)
 

--- a/snowflake_semantic_tools/core/validation/rules/references.py
+++ b/snowflake_semantic_tools/core/validation/rules/references.py
@@ -689,6 +689,42 @@ class ReferenceValidator:
                             )
                             continue
 
+                        # Check for unresolved multi-column expressions
+                        left_unresolved = col_mapping.get("left_unresolved_expression", "")
+                        right_unresolved = col_mapping.get("right_unresolved_expression", "")
+                        if left_unresolved:
+                            result.add_error(
+                                f"Relationship '{name}' has a multi-column expression on the left side: '{left_unresolved}'. "
+                                f"Expression-based join conditions must reference exactly one column template. "
+                                f"Multi-column expressions (e.g., COALESCE of two columns) cannot be used as join keys.",
+                                file_path=source_file,
+                                rule_id="SST-V049",
+                                suggestion="Use a single-column expression, or add a computed column to the dbt model",
+                                entity_name=name,
+                                context={
+                                    "relationship": name,
+                                    "expression": left_unresolved,
+                                    "issue": "multi_column_expression",
+                                },
+                            )
+                            continue
+                        if right_unresolved:
+                            result.add_error(
+                                f"Relationship '{name}' has a multi-column expression on the right side: '{right_unresolved}'. "
+                                f"Expression-based join conditions must reference exactly one column template. "
+                                f"Multi-column expressions (e.g., COALESCE of two columns) cannot be used as join keys.",
+                                file_path=source_file,
+                                rule_id="SST-V049",
+                                suggestion="Use a single-column expression, or add a computed column to the dbt model",
+                                entity_name=name,
+                                context={
+                                    "relationship": name,
+                                    "expression": right_unresolved,
+                                    "issue": "multi_column_expression",
+                                },
+                            )
+                            continue
+
                         # Extract column names if in TABLE.COLUMN format
                         if "." in left_col:
                             _, left_col = left_col.rsplit(".", 1)

--- a/tests/unit/core/diagnostics/test_error_code_coverage.py
+++ b/tests/unit/core/diagnostics/test_error_code_coverage.py
@@ -14,7 +14,6 @@ import pytest
 
 from snowflake_semantic_tools.core.diagnostics import ERRORS
 
-
 RULES_DIR = Path(__file__).parents[4] / "snowflake_semantic_tools" / "core" / "validation" / "rules"
 SERVICES_DIR = Path(__file__).parents[4] / "snowflake_semantic_tools" / "services"
 

--- a/tests/unit/core/diagnostics/test_error_code_guard.py
+++ b/tests/unit/core/diagnostics/test_error_code_guard.py
@@ -10,7 +10,6 @@ from pathlib import Path
 
 import pytest
 
-
 RULES_DIR = Path(__file__).parents[4] / "snowflake_semantic_tools" / "core" / "validation" / "rules"
 
 

--- a/tests/unit/core/diagnostics/test_every_error_code.py
+++ b/tests/unit/core/diagnostics/test_every_error_code.py
@@ -609,7 +609,45 @@ class TestEveryErrorCode:
         result = validator.validate(semantic_data, dbt_catalog)
         _assert_fires(result, "SST-V043")
 
-    def test_SST_V044_using_relationship_not_found(self):
+    def test_SST_V049_multi_column_expression_in_relationship(self):
+        validator = ReferenceValidator()
+        semantic_data = {
+            "metrics": {"items": []},
+            "relationships": {
+                "items": [
+                    {
+                        "relationship_name": "order_customer",
+                        "left_table_name": "orders",
+                        "right_table_name": "customers",
+                    }
+                ],
+                "relationship_columns": [
+                    {
+                        "relationship_name": "order_customer",
+                        "left_column": "ORDERS.CUSTOMER_ID",
+                        "right_column": "CUSTOMERS.CUSTOMER_ID",
+                        "left_unresolved_expression": "COALESCE(ORDERS.CUSTOMER_ID, ORDERS.ORDER_ID)",
+                    },
+                ],
+            },
+        }
+        dbt_catalog = {
+            "orders": {
+                "columns": {"customer_id": {}, "order_id": {}},
+                "database": "DB",
+                "schema": "SCH",
+                "primary_key": "customer_id",
+            },
+            "customers": {
+                "columns": {"customer_id": {}},
+                "database": "DB",
+                "schema": "SCH",
+                "primary_key": "customer_id",
+            },
+        }
+        result = validator.validate(semantic_data, dbt_catalog)
+        _assert_fires(result, "SST-V049")
+
         validator = ReferenceValidator()
         semantic_data = {
             "metrics": {

--- a/tests/unit/core/generation/test_custom_instructions_integration.py
+++ b/tests/unit/core/generation/test_custom_instructions_integration.py
@@ -394,9 +394,9 @@ class TestCustomInstructionsInFullDDL:
         monkeypatch.setattr(builder, "_get_facts", lambda conn, name: [])
         monkeypatch.setattr(builder, "_build_metrics_clause", lambda conn, names: "")
         monkeypatch.setattr(builder, "_build_ca_extension", lambda conn, names: "")
-        monkeypatch.setattr(builder, "_build_relationships_clause", lambda conn, names: "")
+        monkeypatch.setattr(builder, "_build_relationships_clause", lambda conn, names, **kw: "")
         monkeypatch.setattr(builder, "_build_facts_clause", lambda conn, names: "")
-        monkeypatch.setattr(builder, "_build_dimensions_clause", lambda conn, names: "")
+        monkeypatch.setattr(builder, "_build_dimensions_clause", lambda conn, names, **kw: "")
 
         # Mock custom instructions retrieval
         mock_cursor.fetchall.return_value = [
@@ -457,9 +457,9 @@ class TestCustomInstructionsInFullDDL:
         monkeypatch.setattr(builder, "_get_facts", lambda conn, name: [])
         monkeypatch.setattr(builder, "_build_metrics_clause", lambda conn, names: "")
         monkeypatch.setattr(builder, "_build_ca_extension", lambda conn, names: "")
-        monkeypatch.setattr(builder, "_build_relationships_clause", lambda conn, names: "")
+        monkeypatch.setattr(builder, "_build_relationships_clause", lambda conn, names, **kw: "")
         monkeypatch.setattr(builder, "_build_facts_clause", lambda conn, name: "")
-        monkeypatch.setattr(builder, "_build_dimensions_clause", lambda conn, name: "")
+        monkeypatch.setattr(builder, "_build_dimensions_clause", lambda conn, name, **kw: "")
 
         sql = builder._generate_sql(
             conn=mock_conn,
@@ -495,9 +495,9 @@ class TestCustomInstructionsInFullDDL:
         monkeypatch.setattr(builder, "_get_facts", lambda conn, name: [])
         monkeypatch.setattr(builder, "_build_metrics_clause", lambda conn, names: "")
         monkeypatch.setattr(builder, "_build_ca_extension", lambda conn, names: "")
-        monkeypatch.setattr(builder, "_build_relationships_clause", lambda conn, names: "")
+        monkeypatch.setattr(builder, "_build_relationships_clause", lambda conn, names, **kw: "")
         monkeypatch.setattr(builder, "_build_facts_clause", lambda conn, name: "")
-        monkeypatch.setattr(builder, "_build_dimensions_clause", lambda conn, name: "")
+        monkeypatch.setattr(builder, "_build_dimensions_clause", lambda conn, name, **kw: "")
 
         # Multiple instructions
         mock_cursor.fetchall.return_value = [

--- a/tests/unit/core/generation/test_join_key_generator.py
+++ b/tests/unit/core/generation/test_join_key_generator.py
@@ -1,0 +1,358 @@
+"""
+Unit tests for JoinKeyDimensionGenerator.
+
+Tests cover:
+- Expression detection (DATE, DATE_TRUNC, ::DATE, CAST, TO_DATE, TO_TIMESTAMP)
+- Dimension name generation (deterministic, unique)
+- Deduplication (same expression reuses same dimension)
+- get_dimensions_for_table filtering
+"""
+
+import pytest
+
+from snowflake_semantic_tools.core.generation.join_key_generator import JoinKeyDimensionGenerator, detect_expression
+
+
+class TestDetectExpression:
+    """Test detect_expression() for various SQL transformation patterns."""
+
+    def test_date_function_with_column_template(self):
+        expr = "DATE({{ column('events', 'event_timestamp') }})"
+        result = detect_expression(expr)
+        assert result is not None
+        assert result["table"] == "EVENTS"
+        assert result["column"] == "EVENT_TIMESTAMP"
+        assert result["sql_expression"] == "DATE(EVENT_TIMESTAMP)"
+
+    def test_date_function_with_ref_template(self):
+        expr = "DATE({{ ref('events', 'event_timestamp') }})"
+        result = detect_expression(expr)
+        assert result is not None
+        assert result["table"] == "EVENTS"
+        assert result["column"] == "EVENT_TIMESTAMP"
+        assert result["sql_expression"] == "DATE(EVENT_TIMESTAMP)"
+
+    def test_date_trunc_month(self):
+        expr = "DATE_TRUNC('month', {{ column('events', 'event_timestamp') }})"
+        result = detect_expression(expr)
+        assert result is not None
+        assert result["table"] == "EVENTS"
+        assert result["column"] == "EVENT_TIMESTAMP"
+        assert result["sql_expression"] == "DATE_TRUNC('month', EVENT_TIMESTAMP)"
+
+    def test_date_trunc_quarter(self):
+        expr = "DATE_TRUNC('quarter', {{ ref('orders', 'order_date') }})"
+        result = detect_expression(expr)
+        assert result is not None
+        assert result["table"] == "ORDERS"
+        assert result["column"] == "ORDER_DATE"
+        assert result["sql_expression"] == "DATE_TRUNC('quarter', ORDER_DATE)"
+
+    def test_type_cast_double_colon(self):
+        expr = "{{ column('events', 'event_timestamp') }}::DATE"
+        result = detect_expression(expr)
+        assert result is not None
+        assert result["table"] == "EVENTS"
+        assert result["column"] == "EVENT_TIMESTAMP"
+        assert result["sql_expression"] == "EVENT_TIMESTAMP::DATE"
+
+    def test_cast_as_date(self):
+        expr = "CAST({{ column('events', 'event_timestamp') }} AS DATE)"
+        result = detect_expression(expr)
+        assert result is not None
+        assert result["table"] == "EVENTS"
+        assert result["column"] == "EVENT_TIMESTAMP"
+        assert result["sql_expression"] == "CAST(EVENT_TIMESTAMP AS DATE)"
+
+    def test_to_date_function(self):
+        expr = "TO_DATE({{ column('events', 'event_timestamp') }})"
+        result = detect_expression(expr)
+        assert result is not None
+        assert result["table"] == "EVENTS"
+        assert result["column"] == "EVENT_TIMESTAMP"
+        assert result["sql_expression"] == "TO_DATE(EVENT_TIMESTAMP)"
+
+    def test_to_timestamp_function(self):
+        expr = "TO_TIMESTAMP({{ ref('events', 'date_str') }})"
+        result = detect_expression(expr)
+        assert result is not None
+        assert result["table"] == "EVENTS"
+        assert result["column"] == "DATE_STR"
+        assert result["sql_expression"] == "TO_TIMESTAMP(DATE_STR)"
+
+    def test_plain_column_template_not_detected(self):
+        expr = "{{ column('events', 'user_id') }}"
+        result = detect_expression(expr)
+        assert result is None
+
+    def test_plain_ref_template_not_detected(self):
+        expr = "{{ ref('events', 'user_id') }}"
+        result = detect_expression(expr)
+        assert result is None
+
+    def test_empty_string_not_detected(self):
+        assert detect_expression("") is None
+
+    def test_arbitrary_text_not_detected(self):
+        assert detect_expression("some random text") is None
+
+    def test_case_insensitive_date(self):
+        expr = "date({{ column('events', 'ts') }})"
+        result = detect_expression(expr)
+        assert result is not None
+        assert result["sql_expression"] == "date(TS)"
+
+    def test_case_insensitive_date_trunc(self):
+        expr = "date_trunc('month', {{ column('events', 'ts') }})"
+        result = detect_expression(expr)
+        assert result is not None
+        assert "TS" in result["sql_expression"]
+
+    def test_whitespace_tolerance(self):
+        expr = "DATE(  {{ column('events', 'ts') }}  )"
+        result = detect_expression(expr)
+        assert result is not None
+        assert "TS" in result["sql_expression"]
+        assert result["column"] == "TS"
+
+
+class TestJoinKeyDimensionGenerator:
+    """Test JoinKeyDimensionGenerator class."""
+
+    def test_register_returns_dimension_name(self):
+        gen = JoinKeyDimensionGenerator()
+        name = gen.register_join_key("EVENTS", "EVENT_TIMESTAMP", "DATE(EVENT_TIMESTAMP)")
+        assert name.startswith("_JK_EVENT_TIMESTAMP_")
+        assert len(name) > len("_JK_EVENT_TIMESTAMP_")
+
+    def test_same_expression_deduplicated(self):
+        gen = JoinKeyDimensionGenerator()
+        name1 = gen.register_join_key("EVENTS", "EVENT_TIMESTAMP", "DATE(EVENT_TIMESTAMP)")
+        name2 = gen.register_join_key("EVENTS", "EVENT_TIMESTAMP", "DATE(EVENT_TIMESTAMP)")
+        assert name1 == name2
+        assert len(gen.get_all_dimensions()) == 1
+
+    def test_different_expressions_unique_names(self):
+        gen = JoinKeyDimensionGenerator()
+        name1 = gen.register_join_key("EVENTS", "EVENT_TIMESTAMP", "DATE(EVENT_TIMESTAMP)")
+        name2 = gen.register_join_key("EVENTS", "EVENT_TIMESTAMP", "DATE_TRUNC('month', EVENT_TIMESTAMP)")
+        assert name1 != name2
+        assert len(gen.get_all_dimensions()) == 2
+
+    def test_different_tables_same_expression(self):
+        gen = JoinKeyDimensionGenerator()
+        name1 = gen.register_join_key("EVENTS", "TS", "DATE(TS)")
+        name2 = gen.register_join_key("ORDERS", "TS", "DATE(TS)")
+        assert name1 == name2 or name1 != name2
+        assert len(gen.get_all_dimensions()) == 2
+
+    def test_get_dimensions_for_table(self):
+        gen = JoinKeyDimensionGenerator()
+        gen.register_join_key("EVENTS", "TS", "DATE(TS)")
+        gen.register_join_key("ORDERS", "ORDER_DATE", "DATE_TRUNC('month', ORDER_DATE)")
+        gen.register_join_key("EVENTS", "TS", "DATE_TRUNC('quarter', TS)")
+
+        events_dims = gen.get_dimensions_for_table("EVENTS")
+        assert len(events_dims) == 2
+        orders_dims = gen.get_dimensions_for_table("ORDERS")
+        assert len(orders_dims) == 1
+
+    def test_has_dimensions_empty(self):
+        gen = JoinKeyDimensionGenerator()
+        assert not gen.has_dimensions()
+
+    def test_has_dimensions_after_register(self):
+        gen = JoinKeyDimensionGenerator()
+        gen.register_join_key("EVENTS", "TS", "DATE(TS)")
+        assert gen.has_dimensions()
+
+    def test_clear(self):
+        gen = JoinKeyDimensionGenerator()
+        gen.register_join_key("EVENTS", "TS", "DATE(TS)")
+        assert gen.has_dimensions()
+        gen.clear()
+        assert not gen.has_dimensions()
+
+    def test_generated_dimension_metadata(self):
+        gen = JoinKeyDimensionGenerator()
+        gen.register_join_key("EVENTS", "EVENT_TIMESTAMP", "DATE(EVENT_TIMESTAMP)")
+        dims = gen.get_all_dimensions()
+        assert len(dims) == 1
+        dim = dims[0]
+        assert dim["table"] == "EVENTS"
+        assert dim["base_column"] == "EVENT_TIMESTAMP"
+        assert dim["expression"] == "DATE(EVENT_TIMESTAMP)"
+        assert "Auto-generated join key" in dim["comment"]
+        assert dim["name"].startswith("_JK_")
+
+    def test_deterministic_naming(self):
+        gen1 = JoinKeyDimensionGenerator()
+        gen2 = JoinKeyDimensionGenerator()
+        name1 = gen1.register_join_key("EVENTS", "TS", "DATE(TS)")
+        name2 = gen2.register_join_key("EVENTS", "TS", "DATE(TS)")
+        assert name1 == name2
+
+    def test_case_insensitive_dedup(self):
+        gen = JoinKeyDimensionGenerator()
+        name1 = gen.register_join_key("events", "ts", "DATE(TS)")
+        name2 = gen.register_join_key("EVENTS", "ts", "date(ts)")
+        assert name1 == name2
+        assert len(gen.get_all_dimensions()) == 1
+
+
+class TestDetectResolvedExpression:
+    """Test detect_expression() with resolved (post-template-resolution) format."""
+
+    def test_date_resolved(self):
+        result = detect_expression("DATE(ORDERS.ORDERED_AT)")
+        assert result is not None
+        assert result["table"] == "ORDERS"
+        assert result["column"] == "ORDERED_AT"
+        assert result["sql_expression"] == "DATE(ORDERED_AT)"
+
+    def test_date_trunc_resolved(self):
+        result = detect_expression("DATE_TRUNC('day', ORDER_ITEMS.ORDERED_AT)")
+        assert result is not None
+        assert result["table"] == "ORDER_ITEMS"
+        assert result["column"] == "ORDERED_AT"
+        assert result["sql_expression"] == "DATE_TRUNC('day', ORDERED_AT)"
+
+    def test_date_trunc_month_resolved(self):
+        result = detect_expression("DATE_TRUNC('month', EVENTS.EVENT_TIMESTAMP)")
+        assert result is not None
+        assert result["table"] == "EVENTS"
+        assert result["column"] == "EVENT_TIMESTAMP"
+        assert result["sql_expression"] == "DATE_TRUNC('month', EVENT_TIMESTAMP)"
+
+    def test_type_cast_resolved(self):
+        result = detect_expression("EVENTS.EVENT_TIMESTAMP::DATE")
+        assert result is not None
+        assert result["table"] == "EVENTS"
+        assert result["column"] == "EVENT_TIMESTAMP"
+        assert result["sql_expression"] == "EVENT_TIMESTAMP::DATE"
+
+    def test_cast_as_date_resolved(self):
+        result = detect_expression("CAST(EVENTS.EVENT_TIMESTAMP AS DATE)")
+        assert result is not None
+        assert result["table"] == "EVENTS"
+        assert result["column"] == "EVENT_TIMESTAMP"
+        assert result["sql_expression"] == "CAST(EVENT_TIMESTAMP AS DATE)"
+
+    def test_to_date_resolved(self):
+        result = detect_expression("TO_DATE(EVENTS.EVENT_TIMESTAMP)")
+        assert result is not None
+        assert result["sql_expression"] == "TO_DATE(EVENT_TIMESTAMP)"
+
+    def test_plain_resolved_column_not_detected(self):
+        result = detect_expression("ORDERS.CUSTOMER_ID")
+        assert result is None
+
+    def test_plain_column_name_not_detected(self):
+        result = detect_expression("CUSTOMER_ID")
+        assert result is None
+
+
+class TestGenericExpressionDetection:
+    """With the generic approach, ANY expression wrapping a column template is detected."""
+
+    def test_upper_detected(self):
+        result = detect_expression("UPPER({{ column('users', 'email') }})")
+        assert result is not None
+        assert result["table"] == "USERS"
+        assert result["column"] == "EMAIL"
+        assert result["sql_expression"] == "UPPER(EMAIL)"
+
+    def test_lower_detected(self):
+        result = detect_expression("LOWER({{ column('users', 'email') }})")
+        assert result is not None
+        assert result["sql_expression"] == "LOWER(EMAIL)"
+
+    def test_trim_detected(self):
+        result = detect_expression("TRIM({{ column('users', 'name') }})")
+        assert result is not None
+        assert result["sql_expression"] == "TRIM(NAME)"
+
+    def test_double_colon_timestamp_detected(self):
+        result = detect_expression("{{ column('events', 'ts') }}::TIMESTAMP")
+        assert result is not None
+        assert result["sql_expression"] == "TS::TIMESTAMP"
+
+    def test_double_colon_varchar_detected(self):
+        result = detect_expression("{{ column('events', 'id') }}::VARCHAR")
+        assert result is not None
+        assert result["sql_expression"] == "ID::VARCHAR"
+
+    def test_cast_as_timestamp_detected(self):
+        result = detect_expression("CAST({{ column('events', 'ts') }} AS TIMESTAMP)")
+        assert result is not None
+        assert result["sql_expression"] == "CAST(TS AS TIMESTAMP)"
+
+    def test_upper_resolved_detected(self):
+        result = detect_expression("UPPER(USERS.EMAIL)")
+        assert result is not None
+        assert result["table"] == "USERS"
+        assert result["column"] == "EMAIL"
+        assert result["sql_expression"] == "UPPER(EMAIL)"
+
+    def test_to_timestamp_resolved_detected(self):
+        result = detect_expression("TO_TIMESTAMP(EVENTS.DATE_STR)")
+        assert result is not None
+        assert result["sql_expression"] == "TO_TIMESTAMP(DATE_STR)"
+
+
+class TestExpressionEdgeCasesReturnNone:
+    """Edge cases that should NOT be detected as expressions."""
+
+    def test_plain_column_template_not_detected(self):
+        assert detect_expression("{{ column('events', 'user_id') }}") is None
+
+    def test_plain_ref_template_not_detected(self):
+        assert detect_expression("{{ ref('events', 'user_id') }}") is None
+
+    def test_empty_string_not_detected(self):
+        assert detect_expression("") is None
+
+    def test_arbitrary_text_not_detected(self):
+        assert detect_expression("some random text") is None
+
+    def test_plain_resolved_column_not_detected(self):
+        assert detect_expression("ORDERS.CUSTOMER_ID") is None
+
+    def test_plain_column_name_not_detected(self):
+        assert detect_expression("CUSTOMER_ID") is None
+
+    def test_date_literal_not_detected(self):
+        assert detect_expression("DATE('2024-01-01')") is None
+
+    def test_multi_column_template_not_detected(self):
+        expr = "{{ column('a', 'col1') }} + {{ column('a', 'col2') }}"
+        assert detect_expression(expr) is None
+
+    def test_multi_resolved_column_not_detected(self):
+        expr = "A.COL1 + A.COL2"
+        assert detect_expression(expr) is None
+
+    def test_coalesce_with_literal_multi_arg_detected_as_single_col(self):
+        result = detect_expression("COALESCE({{ column('orders', 'user_id') }}, 0)")
+        assert result is not None
+        assert result["column"] == "USER_ID"
+        assert result["sql_expression"] == "COALESCE(USER_ID, 0)"
+
+    def test_nvl_with_literal_detected(self):
+        result = detect_expression("NVL({{ column('orders', 'user_id') }}, 0)")
+        assert result is not None
+        assert result["sql_expression"] == "NVL(USER_ID, 0)"
+
+    def test_arithmetic_with_literal_detected(self):
+        result = detect_expression("{{ column('orders', 'amount') }} + 1")
+        assert result is not None
+        assert result["sql_expression"] == "AMOUNT + 1"
+
+    def test_substring_with_literal_args_detected(self):
+        result = detect_expression("SUBSTRING({{ column('users', 'name') }}, 1, 3)")
+        assert result is not None
+        assert result["sql_expression"] == "SUBSTRING(NAME, 1, 3)"
+
+    def test_nested_expression_with_two_templates_not_detected(self):
+        expr = "COALESCE({{ column('a', 'col1') }}, {{ column('a', 'col2') }})"
+        assert detect_expression(expr) is None

--- a/tests/unit/core/generation/test_join_key_generator.py
+++ b/tests/unit/core/generation/test_join_key_generator.py
@@ -10,7 +10,12 @@ Tests cover:
 
 import pytest
 
-from snowflake_semantic_tools.core.generation.join_key_generator import JoinKeyDimensionGenerator, detect_expression
+from snowflake_semantic_tools.core.generation.join_key_generator import (
+    JoinKeyDimensionGenerator,
+    _normalize_sql_expression,
+    detect_expression,
+    has_wrapping_text,
+)
 
 
 class TestDetectExpression:
@@ -141,10 +146,11 @@ class TestJoinKeyDimensionGenerator:
 
     def test_different_tables_same_expression(self):
         gen = JoinKeyDimensionGenerator()
-        name1 = gen.register_join_key("EVENTS", "TS", "DATE(TS)")
-        name2 = gen.register_join_key("ORDERS", "TS", "DATE(TS)")
-        assert name1 == name2 or name1 != name2
+        gen.register_join_key("EVENTS", "TS", "DATE(TS)")
+        gen.register_join_key("ORDERS", "TS", "DATE(TS)")
         assert len(gen.get_all_dimensions()) == 2
+        tables = {d["table"] for d in gen.get_all_dimensions()}
+        assert tables == {"EVENTS", "ORDERS"}
 
     def test_get_dimensions_for_table(self):
         gen = JoinKeyDimensionGenerator()
@@ -356,3 +362,53 @@ class TestExpressionEdgeCasesReturnNone:
     def test_nested_expression_with_two_templates_not_detected(self):
         expr = "COALESCE({{ column('a', 'col1') }}, {{ column('a', 'col2') }})"
         assert detect_expression(expr) is None
+
+
+class TestHasWrappingText:
+    """Test has_wrapping_text() for detecting non-bare column references."""
+
+    def test_bare_template_no_wrapping(self):
+        assert has_wrapping_text("{{ column('events', 'user_id') }}") is False
+
+    def test_bare_ref_template_no_wrapping(self):
+        assert has_wrapping_text("{{ ref('events', 'user_id') }}") is False
+
+    def test_template_with_function_wrapping(self):
+        assert has_wrapping_text("DATE({{ column('events', 'ts') }})") is True
+
+    def test_template_with_cast_wrapping(self):
+        assert has_wrapping_text("{{ column('events', 'ts') }}::DATE") is True
+
+    def test_two_templates_has_wrapping(self):
+        assert has_wrapping_text("{{ column('a', 'c1') }} + {{ column('a', 'c2') }}") is True
+
+    def test_bare_resolved_no_wrapping(self):
+        assert has_wrapping_text("ORDERS.CUSTOMER_ID") is False
+
+    def test_resolved_with_function_wrapping(self):
+        assert has_wrapping_text("DATE(ORDERS.ORDERED_AT)") is True
+
+    def test_resolved_with_cast_wrapping(self):
+        assert has_wrapping_text("ORDERS.ORDERED_AT::DATE") is True
+
+    def test_two_resolved_has_wrapping(self):
+        assert has_wrapping_text("A.COL1 + A.COL2") is True
+
+    def test_empty_string(self):
+        assert has_wrapping_text("") is False
+
+    def test_plain_text_no_column(self):
+        assert has_wrapping_text("some text") is False
+
+
+class TestNormalizeSqlExpression:
+    """Test _normalize_sql_expression() whitespace handling."""
+
+    def test_strips_leading_trailing(self):
+        assert _normalize_sql_expression("  DATE(TS)  ") == "DATE(TS)"
+
+    def test_collapses_internal_whitespace(self):
+        assert _normalize_sql_expression("DATE(  TS  )") == "DATE( TS )"
+
+    def test_already_normalized(self):
+        assert _normalize_sql_expression("DATE(TS)") == "DATE(TS)"

--- a/tests/unit/core/parsing/test_join_condition_parser.py
+++ b/tests/unit/core/parsing/test_join_condition_parser.py
@@ -584,7 +584,40 @@ class TestResolvedFormatExpressionDetection:
         assert parsed.left_column == "CUSTOMER_ID"
 
 
-class TestExpressionWithAsof:
+class TestUnresolvedExpressionDetection:
+    """Test that multi-column expressions set the unresolved_expression fields."""
+
+    def test_coalesce_two_templates_sets_unresolved(self):
+        condition = "COALESCE({{ column('orders', 'customer_id') }}, {{ column('orders', 'order_id') }}) = {{ column('customers', 'customer_id') }}"
+        parsed = JoinConditionParser.parse(condition)
+
+        assert parsed.left_has_expression is False
+        assert parsed.left_unresolved_expression != ""
+        assert "COALESCE" in parsed.left_unresolved_expression
+        assert parsed.right_unresolved_expression == ""
+
+    def test_multi_col_right_side_sets_unresolved(self):
+        condition = "{{ column('orders', 'customer_id') }} = COALESCE({{ column('customers', 'customer_id') }}, {{ column('customers', 'customer_name') }})"
+        parsed = JoinConditionParser.parse(condition)
+
+        assert parsed.right_has_expression is False
+        assert parsed.right_unresolved_expression != ""
+        assert parsed.left_unresolved_expression == ""
+
+    def test_single_col_expression_does_not_set_unresolved(self):
+        condition = "DATE({{ column('events', 'ts') }}) = {{ column('calendar', 'date_day') }}"
+        parsed = JoinConditionParser.parse(condition)
+
+        assert parsed.left_has_expression is True
+        assert parsed.left_unresolved_expression == ""
+
+    def test_resolved_multi_col_sets_unresolved(self):
+        condition = "ORDERS.COL1 + ORDERS.COL2 = CUSTOMERS.CUSTOMER_ID"
+        parsed = JoinConditionParser.parse(condition)
+
+        assert parsed.left_has_expression is False
+        assert parsed.left_unresolved_expression != ""
+
     """Test expression detection combined with ASOF (>=) joins."""
 
     def test_expression_on_asof_left_side_template(self):

--- a/tests/unit/core/parsing/test_join_condition_parser.py
+++ b/tests/unit/core/parsing/test_join_condition_parser.py
@@ -404,3 +404,256 @@ class TestUnifiedRefSyntax:
         assert parsed.left_column == "CUSTOMER_ID"
         assert parsed.right_table == "CUSTOMERS"
         assert parsed.right_column == "ID"
+
+
+class TestExpressionDetectionInParse:
+    """Test that parse() correctly detects SQL expressions wrapping column templates."""
+
+    def test_date_expression_left_side(self):
+        condition = "DATE({{ column('events', 'event_timestamp') }}) = {{ column('calendar', 'calendar_date') }}"
+        parsed = JoinConditionParser.parse(condition)
+
+        assert parsed.left_table == "EVENTS"
+        assert parsed.left_column == "EVENT_TIMESTAMP"
+        assert parsed.left_has_expression is True
+        assert parsed.left_sql_expression == "DATE(EVENT_TIMESTAMP)"
+        assert parsed.right_table == "CALENDAR"
+        assert parsed.right_column == "CALENDAR_DATE"
+        assert parsed.right_has_expression is False
+        assert parsed.right_sql_expression == ""
+
+    def test_date_trunc_expression_left_side(self):
+        condition = (
+            "DATE_TRUNC('month', {{ column('events', 'event_timestamp') }}) = {{ column('calendar', 'month_date') }}"
+        )
+        parsed = JoinConditionParser.parse(condition)
+
+        assert parsed.left_table == "EVENTS"
+        assert parsed.left_column == "EVENT_TIMESTAMP"
+        assert parsed.left_has_expression is True
+        assert parsed.left_sql_expression == "DATE_TRUNC('month', EVENT_TIMESTAMP)"
+        assert parsed.right_has_expression is False
+
+    def test_type_cast_expression(self):
+        condition = "{{ column('events', 'event_timestamp') }}::DATE = {{ column('calendar', 'calendar_date') }}"
+        parsed = JoinConditionParser.parse(condition)
+
+        assert parsed.left_table == "EVENTS"
+        assert parsed.left_column == "EVENT_TIMESTAMP"
+        assert parsed.left_has_expression is True
+        assert parsed.left_sql_expression == "EVENT_TIMESTAMP::DATE"
+
+    def test_cast_as_date_expression(self):
+        condition = (
+            "CAST({{ column('events', 'event_timestamp') }} AS DATE) = {{ column('calendar', 'calendar_date') }}"
+        )
+        parsed = JoinConditionParser.parse(condition)
+
+        assert parsed.left_table == "EVENTS"
+        assert parsed.left_column == "EVENT_TIMESTAMP"
+        assert parsed.left_has_expression is True
+        assert parsed.left_sql_expression == "CAST(EVENT_TIMESTAMP AS DATE)"
+
+    def test_expression_on_right_side(self):
+        condition = "{{ column('calendar', 'calendar_date') }} = DATE({{ column('events', 'event_timestamp') }})"
+        parsed = JoinConditionParser.parse(condition)
+
+        assert parsed.left_table == "CALENDAR"
+        assert parsed.left_column == "CALENDAR_DATE"
+        assert parsed.left_has_expression is False
+        assert parsed.right_table == "EVENTS"
+        assert parsed.right_column == "EVENT_TIMESTAMP"
+        assert parsed.right_has_expression is True
+        assert parsed.right_sql_expression == "DATE(EVENT_TIMESTAMP)"
+
+    def test_expression_on_both_sides(self):
+        condition = "DATE({{ column('events', 'timestamp') }}) = DATE({{ column('orders', 'created_at') }})"
+        parsed = JoinConditionParser.parse(condition)
+
+        assert parsed.left_has_expression is True
+        assert parsed.left_sql_expression == "DATE(TIMESTAMP)"
+        assert parsed.right_has_expression is True
+        assert parsed.right_sql_expression == "DATE(CREATED_AT)"
+
+    def test_no_expression_backward_compatible(self):
+        condition = "{{ column('orders', 'customer_id') }} = {{ column('customers', 'id') }}"
+        parsed = JoinConditionParser.parse(condition)
+
+        assert parsed.left_table == "ORDERS"
+        assert parsed.left_column == "CUSTOMER_ID"
+        assert parsed.left_has_expression is False
+        assert parsed.left_sql_expression == ""
+        assert parsed.right_table == "CUSTOMERS"
+        assert parsed.right_column == "ID"
+        assert parsed.right_has_expression is False
+        assert parsed.right_sql_expression == ""
+
+    def test_ref_syntax_with_expression(self):
+        condition = "DATE({{ ref('events', 'event_timestamp') }}) = {{ ref('calendar', 'calendar_date') }}"
+        parsed = JoinConditionParser.parse(condition)
+
+        assert parsed.left_table == "EVENTS"
+        assert parsed.left_column == "EVENT_TIMESTAMP"
+        assert parsed.left_has_expression is True
+        assert parsed.left_sql_expression == "DATE(EVENT_TIMESTAMP)"
+
+    def test_condition_type_still_equality(self):
+        condition = "DATE({{ column('events', 'event_timestamp') }}) = {{ column('calendar', 'calendar_date') }}"
+        parsed = JoinConditionParser.parse(condition)
+        assert parsed.condition_type == JoinType.EQUALITY
+        assert parsed.operator == "="
+
+
+class TestGenerateSqlReferencesWithExpressions:
+    """Test generate_sql_references() with join key overrides for expression-based joins."""
+
+    def test_override_left_column(self):
+        condition = "DATE({{ column('events', 'event_timestamp') }}) = {{ column('calendar', 'calendar_date') }}"
+        parsed = JoinConditionParser.parse(condition)
+
+        overrides = {"EVENTS.EVENT_TIMESTAMP": "_JK_EVENT_TIMESTAMP_A1B2"}
+        sql = JoinConditionParser.generate_sql_references([parsed], "EVENTS", "CALENDAR", join_key_overrides=overrides)
+        assert sql == "EVENTS (_JK_EVENT_TIMESTAMP_A1B2) REFERENCES CALENDAR (CALENDAR_DATE)"
+
+    def test_override_right_column(self):
+        condition = "{{ column('calendar', 'calendar_date') }} = DATE({{ column('events', 'event_timestamp') }})"
+        parsed = JoinConditionParser.parse(condition)
+
+        overrides = {"EVENTS.EVENT_TIMESTAMP": "_JK_EVENT_TIMESTAMP_A1B2"}
+        sql = JoinConditionParser.generate_sql_references([parsed], "CALENDAR", "EVENTS", join_key_overrides=overrides)
+        assert sql == "CALENDAR (CALENDAR_DATE) REFERENCES EVENTS (_JK_EVENT_TIMESTAMP_A1B2)"
+
+    def test_no_overrides_uses_raw_columns(self):
+        condition = "{{ column('orders', 'customer_id') }} = {{ column('customers', 'id') }}"
+        parsed = JoinConditionParser.parse(condition)
+
+        sql = JoinConditionParser.generate_sql_references([parsed], "ORDERS", "CUSTOMERS")
+        assert sql == "ORDERS (CUSTOMER_ID) REFERENCES CUSTOMERS (ID)"
+
+    def test_mixed_expression_and_plain_conditions(self):
+        conditions = [
+            "{{ column('events', 'user_id') }} = {{ column('calendar', 'user_id') }}",
+            "DATE({{ column('events', 'event_timestamp') }}) = {{ column('calendar', 'calendar_date') }}",
+        ]
+        parsed_list = [JoinConditionParser.parse(c) for c in conditions]
+
+        overrides = {"EVENTS.EVENT_TIMESTAMP": "_JK_EVENT_TIMESTAMP_A1B2"}
+        sql = JoinConditionParser.generate_sql_references(
+            parsed_list, "EVENTS", "CALENDAR", join_key_overrides=overrides
+        )
+        assert sql == "EVENTS (USER_ID, _JK_EVENT_TIMESTAMP_A1B2) REFERENCES CALENDAR (USER_ID, CALENDAR_DATE)"
+
+
+class TestResolvedFormatExpressionDetection:
+    """Test that parse() detects expressions in resolved (post-template) format.
+
+    This is critical because the SemanticViewBuilder re-parses JOIN_CONDITION
+    from SM_RELATIONSHIP_COLUMNS at generation time, and by then the templates
+    have been resolved to TABLE.COLUMN format.
+    """
+
+    def test_resolved_date_expression(self):
+        condition = "DATE(ORDERS.ORDERED_AT) = METRICFLOW_TIME_SPINE.DATE_DAY"
+        parsed = JoinConditionParser.parse(condition)
+
+        assert parsed.left_table == "ORDERS"
+        assert parsed.left_column == "ORDERED_AT"
+        assert parsed.left_has_expression is True
+        assert parsed.left_sql_expression == "DATE(ORDERED_AT)"
+        assert parsed.right_table == "METRICFLOW_TIME_SPINE"
+        assert parsed.right_column == "DATE_DAY"
+        assert parsed.right_has_expression is False
+
+    def test_resolved_date_trunc_expression(self):
+        condition = "DATE_TRUNC('day', ORDER_ITEMS.ORDERED_AT) = METRICFLOW_TIME_SPINE.DATE_DAY"
+        parsed = JoinConditionParser.parse(condition)
+
+        assert parsed.left_table == "ORDER_ITEMS"
+        assert parsed.left_column == "ORDERED_AT"
+        assert parsed.left_has_expression is True
+        assert parsed.left_sql_expression == "DATE_TRUNC('day', ORDERED_AT)"
+        assert parsed.right_has_expression is False
+
+    def test_resolved_no_expression_backward_compatible(self):
+        condition = "ORDERS.CUSTOMER_ID = CUSTOMERS.CUSTOMER_ID"
+        parsed = JoinConditionParser.parse(condition)
+
+        assert parsed.left_has_expression is False
+        assert parsed.right_has_expression is False
+        assert parsed.left_table == "ORDERS"
+        assert parsed.left_column == "CUSTOMER_ID"
+
+
+class TestExpressionWithAsof:
+    """Test expression detection combined with ASOF (>=) joins."""
+
+    def test_expression_on_asof_left_side_template(self):
+        condition = "DATE({{ column('events', 'event_timestamp') }}) >= {{ column('sessions', 'start_time') }}"
+        parsed = JoinConditionParser.parse(condition)
+
+        assert parsed.condition_type == JoinType.ASOF
+        assert parsed.left_has_expression is True
+        assert parsed.left_sql_expression == "DATE(EVENT_TIMESTAMP)"
+        assert parsed.left_table == "EVENTS"
+        assert parsed.left_column == "EVENT_TIMESTAMP"
+        assert parsed.right_has_expression is False
+
+    def test_expression_on_asof_left_side_resolved(self):
+        condition = "DATE(EVENTS.EVENT_TIMESTAMP) >= SESSIONS.START_TIME"
+        parsed = JoinConditionParser.parse(condition)
+
+        assert parsed.condition_type == JoinType.ASOF
+        assert parsed.left_has_expression is True
+        assert parsed.left_sql_expression == "DATE(EVENT_TIMESTAMP)"
+
+    def test_asof_expression_with_composite_key(self):
+        conditions = [
+            "{{ column('events', 'user_id') }} = {{ column('sessions', 'user_id') }}",
+            "DATE({{ column('events', 'event_timestamp') }}) >= {{ column('sessions', 'start_time') }}",
+        ]
+        parsed_list = [JoinConditionParser.parse(c) for c in conditions]
+
+        assert parsed_list[0].left_has_expression is False
+        assert parsed_list[1].left_has_expression is True
+        assert parsed_list[1].condition_type == JoinType.ASOF
+
+    def test_generate_sql_asof_with_expression_override(self):
+        conditions = [
+            "{{ column('events', 'user_id') }} = {{ column('sessions', 'user_id') }}",
+            "DATE({{ column('events', 'event_timestamp') }}) >= {{ column('sessions', 'start_time') }}",
+        ]
+        parsed_list = [JoinConditionParser.parse(c) for c in conditions]
+
+        overrides = {"EVENTS.EVENT_TIMESTAMP": "_JK_EVENT_TIMESTAMP_A1B2"}
+        sql = JoinConditionParser.generate_sql_references(
+            parsed_list, "EVENTS", "SESSIONS", join_key_overrides=overrides
+        )
+        assert sql == "EVENTS (USER_ID, _JK_EVENT_TIMESTAMP_A1B2) REFERENCES SESSIONS (USER_ID, ASOF START_TIME)"
+
+
+class TestExpressionWithRange:
+    """Test expression detection with BETWEEN/range joins."""
+
+    def test_expression_on_range_left_side(self):
+        condition = (
+            "DATE({{ column('orders', 'ordered_at') }}) "
+            "BETWEEN {{ column('rates', 'start_date') }} AND {{ column('rates', 'end_date') }} EXCLUSIVE"
+        )
+        parsed = JoinConditionParser.parse(condition)
+
+        assert parsed.condition_type == JoinType.RANGE
+        assert parsed.left_has_expression is True
+        assert parsed.left_sql_expression == "DATE(ORDERED_AT)"
+        assert parsed.left_table == "ORDERS"
+        assert parsed.left_column == "ORDERED_AT"
+
+    def test_generate_sql_range_with_expression_override(self):
+        condition = (
+            "DATE({{ column('orders', 'ordered_at') }}) "
+            "BETWEEN {{ column('rates', 'start_date') }} AND {{ column('rates', 'end_date') }} EXCLUSIVE"
+        )
+        parsed = JoinConditionParser.parse(condition)
+
+        overrides = {"ORDERS.ORDERED_AT": "_JK_ORDERED_AT_XXXX"}
+        sql = JoinConditionParser.generate_sql_references([parsed], "ORDERS", "RATES", join_key_overrides=overrides)
+        assert sql == "ORDERS (_JK_ORDERED_AT_XXXX) REFERENCES RATES (BETWEEN START_DATE AND END_DATE EXCLUSIVE)"

--- a/tests/unit/core/parsing/test_sst_meta_extraction.py
+++ b/tests/unit/core/parsing/test_sst_meta_extraction.py
@@ -132,15 +132,11 @@ class TestGetSstMeta:
         """Test that deprecation warnings can be disabled."""
         node = {
             "name": "test_model",
-            "meta": {
-                "sst": {
-                }
-            },
+            "meta": {"sst": {}},
         }
 
         # Should not emit warning when emit_warning=False
         result = get_sst_meta(node, node_type="model", node_name="test_model", emit_warning=False)
-
 
     def test_invalid_meta_type_returns_empty_dict(self):
         """Test that invalid meta type (non-dict) returns empty dict."""
@@ -158,14 +154,10 @@ class TestGetSstMeta:
         node = {
             "name": "test_model",
             "config": "not a dict",  # Invalid type
-            "meta": {
-                "sst": {
-                }
-            },
+            "meta": {"sst": {}},
         }
 
         result = get_sst_meta(node, node_type="model", node_name="test_model")
-
 
     def test_invalid_sst_type_returns_empty_dict(self):
         """Test that invalid sst type (non-dict) returns empty dict."""

--- a/tests/unit/core/test_v030_features.py
+++ b/tests/unit/core/test_v030_features.py
@@ -8,15 +8,16 @@ Unit tests for features added in 0.3.0:
 - _check_constraints key fix (column_name -> name)
 """
 
+from pathlib import Path
+
 import pytest
 
+from snowflake_semantic_tools.core.generation.semantic_view_builder import SemanticViewBuilder
 from snowflake_semantic_tools.core.models import ValidationResult
 from snowflake_semantic_tools.core.parsing.parsers.semantic_parser import parse_snowflake_metrics
-from snowflake_semantic_tools.core.validation.rules.semantic_models import SemanticModelValidator
 from snowflake_semantic_tools.core.validation.rules.references import ReferenceValidator
-from snowflake_semantic_tools.core.generation.semantic_view_builder import SemanticViewBuilder
+from snowflake_semantic_tools.core.validation.rules.semantic_models import SemanticModelValidator
 from snowflake_semantic_tools.infrastructure.snowflake.config import SnowflakeConfig
-from pathlib import Path
 
 
 class TestDerivedMetricParsing:

--- a/tests/unit/core/validation/test_duplicate_detection.py
+++ b/tests/unit/core/validation/test_duplicate_detection.py
@@ -453,56 +453,72 @@ class TestV091MetricDuplicateDetection:
         return {"metrics": {"items": metrics}}
 
     def test_truly_duplicate_metrics_flagged(self, validator):
-        data = self._make_metrics_data([
-            {"name": "metric_a", "expr": "SUM(orders.total)"},
-            {"name": "metric_b", "expr": "SUM(orders.total)"},
-        ])
+        data = self._make_metrics_data(
+            [
+                {"name": "metric_a", "expr": "SUM(orders.total)"},
+                {"name": "metric_b", "expr": "SUM(orders.total)"},
+            ]
+        )
         result = validator.validate(data)
         warnings = [w for w in result.get_warnings() if w.rule_id == "SST-V091"]
         assert len(warnings) == 1
 
     def test_same_expr_different_window_not_duplicate(self, validator):
-        data = self._make_metrics_data([
-            {"name": "cumulative", "expr": "SUM(ORDERS.TOTAL_REVENUE)", "window": {"partition_by_excluding": ["ordered_at"]}},
-            {"name": "ranked", "expr": "SUM(ORDERS.TOTAL_REVENUE)", "window": {"partition_by": ["customer_id"]}},
-        ])
+        data = self._make_metrics_data(
+            [
+                {
+                    "name": "cumulative",
+                    "expr": "SUM(ORDERS.TOTAL_REVENUE)",
+                    "window": {"partition_by_excluding": ["ordered_at"]},
+                },
+                {"name": "ranked", "expr": "SUM(ORDERS.TOTAL_REVENUE)", "window": {"partition_by": ["customer_id"]}},
+            ]
+        )
         result = validator.validate(data)
         warnings = [w for w in result.get_warnings() if w.rule_id == "SST-V091"]
         assert len(warnings) == 0
 
     def test_same_expr_same_window_is_duplicate(self, validator):
         window_config = {"partition_by": ["customer_id"], "order_by": [{"column": "ordered_at"}]}
-        data = self._make_metrics_data([
-            {"name": "metric_a", "expr": "SUM(ORDERS.TOTAL)", "window": window_config},
-            {"name": "metric_b", "expr": "SUM(ORDERS.TOTAL)", "window": window_config},
-        ])
+        data = self._make_metrics_data(
+            [
+                {"name": "metric_a", "expr": "SUM(ORDERS.TOTAL)", "window": window_config},
+                {"name": "metric_b", "expr": "SUM(ORDERS.TOTAL)", "window": window_config},
+            ]
+        )
         result = validator.validate(data)
         warnings = [w for w in result.get_warnings() if w.rule_id == "SST-V091"]
         assert len(warnings) == 1
 
     def test_same_expr_different_using_relationships_not_duplicate(self, validator):
-        data = self._make_metrics_data([
-            {"name": "revenue", "expr": "SUM(orders.total)"},
-            {"name": "revenue_by_loc", "expr": "SUM(orders.total)", "using_relationships": ["orders_to_locations"]},
-        ])
+        data = self._make_metrics_data(
+            [
+                {"name": "revenue", "expr": "SUM(orders.total)"},
+                {"name": "revenue_by_loc", "expr": "SUM(orders.total)", "using_relationships": ["orders_to_locations"]},
+            ]
+        )
         result = validator.validate(data)
         warnings = [w for w in result.get_warnings() if w.rule_id == "SST-V091"]
         assert len(warnings) == 0
 
     def test_same_expr_different_non_additive_by_not_duplicate(self, validator):
-        data = self._make_metrics_data([
-            {"name": "max_total", "expr": "MAX(orders.total)"},
-            {"name": "latest_total", "expr": "MAX(orders.total)", "non_additive_by": [{"dimension": "ordered_at"}]},
-        ])
+        data = self._make_metrics_data(
+            [
+                {"name": "max_total", "expr": "MAX(orders.total)"},
+                {"name": "latest_total", "expr": "MAX(orders.total)", "non_additive_by": [{"dimension": "ordered_at"}]},
+            ]
+        )
         result = validator.validate(data)
         warnings = [w for w in result.get_warnings() if w.rule_id == "SST-V091"]
         assert len(warnings) == 0
 
     def test_same_expr_one_derived_not_duplicate(self, validator):
-        data = self._make_metrics_data([
-            {"name": "total", "expr": "SUM(orders.total)"},
-            {"name": "total_derived", "expr": "SUM(orders.total)", "derived": True},
-        ])
+        data = self._make_metrics_data(
+            [
+                {"name": "total", "expr": "SUM(orders.total)"},
+                {"name": "total_derived", "expr": "SUM(orders.total)", "derived": True},
+            ]
+        )
         result = validator.validate(data)
         warnings = [w for w in result.get_warnings() if w.rule_id == "SST-V091"]
         assert len(warnings) == 0

--- a/tests/unit/core/validation/test_relationship_validation.py
+++ b/tests/unit/core/validation/test_relationship_validation.py
@@ -1094,5 +1094,92 @@ class TestRelationshipReferenceValidation:
         assert len(circular_errors) >= 2
 
 
+class TestExpressionBasedJoinValidation:
+    """Test that expression-based joins pass validation when the parser extracts base columns.
+
+    When a user writes DATE({{ column('events', 'event_timestamp') }}), the parser extracts
+    the base column 'EVENT_TIMESTAMP'. The validator should see the clean column reference
+    and validate it against the dbt catalog successfully.
+    """
+
+    @pytest.fixture
+    def validator(self):
+        return ReferenceValidator()
+
+    @pytest.fixture
+    def catalog_with_timestamps(self):
+        return {
+            "events": {
+                "database": "analytics",
+                "schema": "public",
+                "primary_key": "event_id",
+                "columns": {
+                    "event_id": {"data_type": "NUMBER"},
+                    "user_id": {"data_type": "NUMBER"},
+                    "event_timestamp": {"data_type": "TIMESTAMP_NTZ"},
+                },
+            },
+            "calendar": {
+                "database": "analytics",
+                "schema": "public",
+                "primary_key": "calendar_date",
+                "columns": {
+                    "calendar_date": {"data_type": "DATE"},
+                    "user_id": {"data_type": "NUMBER"},
+                },
+            },
+        }
+
+    def test_base_column_from_expression_passes_validation(self, validator, catalog_with_timestamps):
+        """Parser extracts EVENT_TIMESTAMP (base col), not DATE(EVENT_TIMESTAMP). Validation should pass."""
+        semantic_data = {
+            "relationships": {
+                "items": [
+                    {
+                        "relationship_name": "EVENTS_TO_CALENDAR",
+                        "left_table_name": "EVENTS",
+                        "right_table_name": "CALENDAR",
+                    }
+                ],
+                "relationship_columns": [
+                    {
+                        "relationship_name": "EVENTS_TO_CALENDAR",
+                        "left_column": "EVENTS.EVENT_TIMESTAMP",
+                        "right_column": "CALENDAR.CALENDAR_DATE",
+                    }
+                ],
+            }
+        }
+
+        result = validator.validate(semantic_data, catalog_with_timestamps)
+        column_errors = [e for e in result.get_errors() if "SST-V043" in str(e) or "does not exist" in str(e).lower()]
+        assert len(column_errors) == 0, f"Unexpected column errors: {column_errors}"
+
+    def test_raw_expression_in_column_ref_still_caught(self, validator, catalog_with_timestamps):
+        """If someone directly puts an expression in the column ref (bypassing parser), it should still error."""
+        semantic_data = {
+            "relationships": {
+                "items": [
+                    {
+                        "relationship_name": "EVENTS_TO_CALENDAR",
+                        "left_table_name": "EVENTS",
+                        "right_table_name": "CALENDAR",
+                    }
+                ],
+                "relationship_columns": [
+                    {
+                        "relationship_name": "EVENTS_TO_CALENDAR",
+                        "left_column": "EVENTS.DATE(EVENT_TIMESTAMP)",
+                        "right_column": "CALENDAR.CALENDAR_DATE",
+                    }
+                ],
+            }
+        }
+
+        result = validator.validate(semantic_data, catalog_with_timestamps)
+        errors = result.get_errors()
+        assert any("sql transformation" in str(e).lower() or "SST-V043" in str(e) for e in errors)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/core/validation/test_relationship_validation.py
+++ b/tests/unit/core/validation/test_relationship_validation.py
@@ -1,7 +1,8 @@
 """
 Unit tests for relationship reference validation.
 
-Tests cover:
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])Tests cover:
 - SQL transformations in column references
 - Missing column references
 - Missing table references
@@ -1180,6 +1181,29 @@ class TestExpressionBasedJoinValidation:
         errors = result.get_errors()
         assert any("sql transformation" in str(e).lower() or "SST-V043" in str(e) for e in errors)
 
+    def test_multi_column_expression_triggers_v049(self, validator, catalog_with_timestamps):
+        """V049 fires when a condition has two column templates wrapped in one expression."""
+        semantic_data = {
+            "relationships": {
+                "items": [
+                    {
+                        "relationship_name": "EVENTS_TO_CALENDAR",
+                        "left_table_name": "EVENTS",
+                        "right_table_name": "CALENDAR",
+                    }
+                ],
+                "relationship_columns": [
+                    {
+                        "relationship_name": "EVENTS_TO_CALENDAR",
+                        "left_column": "EVENTS.EVENT_ID",
+                        "right_column": "CALENDAR.CALENDAR_DATE",
+                        "left_unresolved_expression": "COALESCE(EVENTS.EVENT_ID, EVENTS.USER_ID)",
+                    }
+                ],
+            }
+        }
 
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])
+        result = validator.validate(semantic_data, catalog_with_timestamps)
+        errors = result.get_errors()
+        assert any("SST-V049" in str(e) for e in errors)
+        assert any("multi-column" in str(e).lower() for e in errors)

--- a/tests/unit/interfaces/cli/test_drop.py
+++ b/tests/unit/interfaces/cli/test_drop.py
@@ -7,10 +7,7 @@ from unittest.mock import MagicMock, patch
 import pandas as pd
 import pytest
 
-from snowflake_semantic_tools.interfaces.cli.commands.drop import (
-    _drop_specific_view,
-    _prune_orphaned_views,
-)
+from snowflake_semantic_tools.interfaces.cli.commands.drop import _drop_specific_view, _prune_orphaned_views
 from snowflake_semantic_tools.interfaces.cli.output import CLIOutput
 
 

--- a/tests/unit/services/test_parallel_generation.py
+++ b/tests/unit/services/test_parallel_generation.py
@@ -98,9 +98,7 @@ class TestParallelExecution:
         config.user = "test_user"
         config.role = "test_role"
         config.connection_params = {}
-        with patch(
-            "snowflake_semantic_tools.services.generate_semantic_views.ConnectionManager"
-        ) as MockCM:
+        with patch("snowflake_semantic_tools.services.generate_semantic_views.ConnectionManager") as MockCM:
             mock_cm = MagicMock()
             MockCM.return_value = mock_cm
             service = SemanticViewGenerationService(config)
@@ -168,8 +166,7 @@ class TestParallelExecution:
         service = self._make_service()
 
         views = [
-            {"name": f"view_{i}", "tables": [f"T{i}"], "description": "", "custom_instructions": []}
-            for i in range(8)
+            {"name": f"view_{i}", "tables": [f"T{i}"], "description": "", "custom_instructions": []} for i in range(8)
         ]
 
         gen_config = GenerateConfig(


### PR DESCRIPTION
## Description

Auto-generate synthetic "join key dimensions" when SQL expressions are detected in relationship join conditions. This allows users to join tables on transformed columns without modifying their upstream dbt models.

**Supports any arbitrary single-column SQL expression** — not just date casts. The detection is generic: if a join condition side contains anything beyond a bare `{{ ref('table', 'column') }}` template, it is treated as an expression. Examples of what works:

- Date casts: `DATE({{ ref('orders', 'ordered_at') }})`, `{{ ref('orders', 'ordered_at') }}::DATE`
- Truncation: `DATE_TRUNC('month', {{ ref('orders', 'ordered_at') }})`
- String functions: `UPPER({{ ref('users', 'email') }})`, `TRIM({{ ref('users', 'name') }})`
- Type conversions: `CAST({{ ref('orders', 'ts') }} AS VARCHAR)`, `TO_TIMESTAMP({{ ref('events', 'date_str') }})`
- Arithmetic: `{{ ref('orders', 'amount') }} + 1`
- Nested: `DATE_TRUNC('month', DATE({{ ref('events', 'ts') }}))`
- Both sides: `TO_DATE({{ ref('orders', 'ordered_at') }}) = TO_DATE({{ ref('customers', 'first_ordered_at') }})`

The only restriction is that each side must reference **exactly one column**. Multi-column expressions like `COALESCE(col1, col2)` are caught with a new SST-V049 error. Snowflake validates the expression SQL at semantic view creation time.

## Related Issue

Closes #106

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [x] Test improvements
- [ ] Other (please describe):

## Changes Made

### Core Implementation
- **`core/generation/join_key_generator.py`** (NEW): Generic expression detection (`detect_expression`, `has_wrapping_text`) and `JoinKeyDimensionGenerator` class for synthetic dimension naming, registration, and deduplication
- **`core/parsing/join_condition_parser.py`**: Extended `ParsedCondition` with expression metadata fields. `parse()` detects expressions in both template and resolved formats. `generate_sql_references()` accepts `join_key_overrides` for dimension name substitution
- **`core/generation/semantic_view_builder.py`**: Wired generator through `_build_relationships_clause()` -> `_build_dimensions_clause()` pipeline
- **`core/parsing/parsers/semantic_parser.py`**: Passes expression flags through to `rel_col_record` for validation

### Validation
- **`core/validation/rules/references.py`**: New SST-V049 check for multi-column expressions (e.g., `COALESCE(col1, col2)`)
- **`core/diagnostics/error_codes.py`**: Registered SST-V049

### Documentation
- **`docs/concepts/semantic-models.md`**: New "Expression-Based Joins" section with syntax, examples, and supported patterns
- **`docs/concepts/validation-rules.md`**: Updated relationship validation rules
- **`docs/reference/error-codes.md`**: Added V049, updated V043 description

### How It Works

User writes:
```yaml
relationship_conditions:
  - "DATE({{ ref('orders', 'ordered_at') }}) = {{ ref('calendar', 'date_day') }}"
```

SST generates:
```sql
DIMENSIONS (
    ORDERS._JK_ORDERED_AT_032F AS DATE(ORDERED_AT)
      COMMENT = 'Auto-generated join key: DATE(ORDERED_AT)'
)
RELATIONSHIPS (
    ORDERS_TO_CALENDAR AS
      ORDERS (_JK_ORDERED_AT_032F) REFERENCES CALENDAR (DATE_DAY)
)
```

## Testing

- [x] Unit tests pass (`pytest tests/unit/`)
- [x] All existing tests pass
- [x] New tests added for new functionality
- [ ] Tested locally with Python 3.9-3.11
- [x] Manual testing completed (if applicable)
- [x] Test coverage maintained or improved (target: >90%)

### Test Results

```
1596 passed in 2.10s
```

### E2E Validation (against sst-jaffle-shop)
- Validated 9 expression patterns against Snowflake (DATE, DATE_TRUNC, ::DATE, CAST, TO_DATE, nested, both-sides)
- Confirmed all `_JK_` dimensions created correctly via `DESCRIBE SEMANTIC VIEW`
- Confirmed SST-V049 fires for multi-column expressions (COALESCE, NVL, arithmetic)
- Confirmed Snowflake catches invalid SQL at generate time
- All 3 semantic views generate successfully

### New Tests Added (83 tests across 4 files)
- `test_join_key_generator.py`: 56 tests (expression detection, generator, edge cases)
- `test_join_condition_parser.py`: 27 new tests (expression + ASOF, range, resolved format, SQL generation)
- `test_relationship_validation.py`: 2 new tests (expression passes, raw expression caught)
- `test_every_error_code.py`: 1 new test (SST-V049)

## Checklist

### Code Quality
- [x] Code follows the project's style guidelines (Black, line length 120)
- [x] Imports sorted with isort (black profile)
- [x] Type hints added for new code (`mypy snowflake_semantic_tools/` passes)
- [x] Docstrings added for public functions/classes
- [x] No linting errors
- [ ] Pre-commit hooks pass (if using pre-commit)

### Testing and Validation
- [x] All tests pass (`pytest tests/unit/`)
- [x] New functionality has test coverage
- [x] Test results included above

### Documentation and Compatibility
- [x] Documentation updated (if needed)
- [x] Backward compatibility maintained (if applicable)
- [ ] Breaking changes discussed with maintainer first (see CONTRIBUTING.md)

### Performance
- [x] Performance impact considered
- [x] No significant performance regressions

## Additional Notes

- **PRIVATE dimensions are not supported by Snowflake** so `_JK_` dimensions are publicly visible. Mitigated by naming convention and auto-generated comments.
- **Snowflake validates expressions at DDL execution time** so invalid SQL (e.g., non-existent functions) will fail at `sst generate`, not `sst validate`. This is by design for the generic approach.
- Companion changes needed in [sst-jaffle-shop](https://github.com/WhoopInc/sst-jaffle-shop) for e2e test fixtures (2 expression relationships + V049 error fixture).
