### PR TITLE
[SST-134] Support dbt sources in sst enrich

### DIFF
--- a/docs/cli/enrich.md
+++ b/docs/cli/enrich.md
@@ -8,6 +8,8 @@ Enrich dbt YAML metadata with semantic information from Snowflake.
 
 The `enrich` command automatically populates your dbt YAML files with semantic metadata by querying your Snowflake tables. It adds column types, data types, sample values, enum detection, and optionally generates LLM-powered synonyms.
 
+Supports both **dbt models** and **dbt sources** — enrich raw/staging tables defined in `sources.yml` with the same metadata as your models.
+
 **Snowflake Connection:** Required
 
 ---
@@ -23,6 +25,11 @@ sst enrich --models customers,orders --all
 
 # Preview changes without writing
 sst enrich --models customers,orders --dry-run
+
+# Enrich dbt sources
+sst enrich --sources-only
+sst enrich --source raw.orders
+sst enrich models/ --include-sources
 ```
 
 ---
@@ -32,12 +39,16 @@ sst enrich --models customers,orders --dry-run
 ```bash
 sst enrich [TARGET_PATH] [OPTIONS]
 sst enrich --models MODEL_NAMES [OPTIONS]
+sst enrich --sources-only [OPTIONS]
+sst enrich --source SOURCE_NAME.TABLE_NAME [OPTIONS]
 ```
 
-**Three selection modes:**
+**Five selection modes:**
 - **By model name:** `--models name1,name2` (recommended, requires manifest)
 - **By path:** `sst enrich models/directory/` or `sst enrich path/to/file.yml`
 - **By wildcard pattern:** `sst enrich "models/directory/shared_prefix_*"` (matches multiple files)
+- **All sources:** `--sources-only` (enriches all dbt sources from manifest or YAML files)
+- **Specific source:** `--source raw.orders` (enriches a single source table)
 
 ---
 
@@ -51,6 +62,20 @@ sst enrich --models MODEL_NAMES [OPTIONS]
 | `--models` | `-m` | TEXT | Comma-separated list of model names (requires manifest) |
 
 **Note:** `--models` and `TARGET_PATH` are mutually exclusive.
+
+### Source Selection
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--include-sources` | FLAG | Also enrich dbt source definitions (alongside models) |
+| `--sources-only` | FLAG | Enrich only dbt sources, skip models |
+| `--source` | TEXT | Enrich a specific source table (format: `source_name.table_name`, requires manifest) |
+
+**Mutual exclusivity rules:**
+- `--sources-only` cannot be combined with `TARGET_PATH` or `--models`
+- `--source` cannot be combined with `TARGET_PATH`, `--models`, or `--include-sources`
+- `--sources-only` and `--source` are mutually exclusive
+- `--include-sources` augments model enrichment and requires `TARGET_PATH` or `--models`
 
 **Wildcard Patterns:** `TARGET_PATH` supports wildcard patterns (`*` and `?`) to match multiple files:
 - `"models/directory/shared_prefix_*"` - matches all files starting with `shared_prefix_`
@@ -158,6 +183,50 @@ sst enrich -m customers,orders --dry-run --verbose
 sst enrich models/ --exclude _intermediate,temp_models
 ```
 
+### Source Enrichment
+
+```bash
+# Enrich all sources defined in your project
+sst enrich --sources-only
+
+# Enrich a specific source table
+sst enrich --source raw.orders
+
+# Enrich models AND sources together
+sst enrich models/ --include-sources
+
+# Enrich sources with specific components
+sst enrich --sources-only --all
+sst enrich --source stripe.payments -ct -dt
+```
+
+**Source YAML structure** — SST writes `config.meta.sst` blocks to source columns, identical to models:
+
+```yaml
+version: 2
+sources:
+  - name: raw
+    database: RAW_DB
+    schema: PUBLIC
+    tables:
+      - name: orders
+        description: "Raw order data"
+        config:
+          meta:
+            sst:
+              synonyms: []
+        columns:
+          - name: id
+            description: ""
+            config:
+              meta:
+                sst:
+                  column_type: dimension
+                  data_type: NUMBER
+                  sample_values: [1, 2, 3]
+                  is_enum: false
+```
+
 ---
 
 ## What Gets Enriched
@@ -251,11 +320,77 @@ Enrichment **always** updates:
 - sample_values (fresh data)
 - is_enum (current cardinality)
 
-**Safe to run multiple times.**
+**Safe to run multiple times.** These rules apply identically to both models and sources.
 
 ---
 
 ## Troubleshooting
+
+### "Source not found in manifest" (SST-E006)
+
+The source you specified with `--source` doesn't exist in the dbt manifest.
+
+**Solution:** Check the spelling matches your source YAML, then recompile:
+
+```bash
+# Verify your source names
+grep -r "name:" models/sources/
+
+# Recompile manifest
+dbt compile --target prod
+
+# Retry
+sst enrich --source raw.orders
+```
+
+### "Source YAML write failed" (SST-E009)
+
+SST could not write enriched metadata back to the source YAML file.
+
+**Solution:** Check file permissions and ensure the file isn't locked by another process:
+
+```bash
+ls -la models/sources/my_source.yml
+# Fix permissions if needed
+chmod 644 models/sources/my_source.yml
+```
+
+### "No sources found" (SST-E008)
+
+No dbt source definitions were found in your project.
+
+**Solution:** Ensure you have a `sources.yml` (or similar) file with a `sources:` key:
+
+```yaml
+# models/staging/_sources.yml
+version: 2
+sources:
+  - name: raw
+    database: RAW_DB
+    schema: PUBLIC
+    tables:
+      - name: orders
+```
+
+Alternatively, run `dbt compile` to ensure sources appear in the manifest.
+
+### "Source table not found in Snowflake" (SST-E007)
+
+The source table exists in your YAML but not in Snowflake.
+
+**Solution:** Check the `database` and `schema` in your source definition match the actual Snowflake location.
+
+### "Invalid source selector" (SST-E010)
+
+The `--source` value must use the format `source_name.table_name`.
+
+```bash
+# Correct
+sst enrich --source raw.orders
+
+# Incorrect
+sst enrich --source orders
+```
 
 ### "manifest.json not found"
 

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -77,6 +77,11 @@ Stable error codes for SST diagnostics. Each code is a permanent identifier that
 | `SST-E003` | Permission denied | Role needs CREATE TABLE on schema. Grant: GRANT CREATE TABLE ON SCHEMA {schema} TO ROLE {role} |
 | `SST-E004` | Manifest not found | Run 'dbt compile' first, or use --dbt-compile flag |
 | `SST-E005` | Stale manifest | manifest.json is older than source files. Re-run: dbt compile |
+| `SST-E006` | Source not found in manifest | Source '{source_name}.{table_name}' not in manifest. Run `dbt compile` or check source name |
+| `SST-E007` | Source table not found in Snowflake | Table '{database}.{schema}.{table}' does not exist. Check database/schema in your source definition |
+| `SST-E008` | No sources found | No dbt source definitions found. Ensure sources.yml exists with a `sources:` key |
+| `SST-E009` | Source YAML write failed | Could not write enriched metadata to '{path}'. Check file permissions |
+| `SST-E010` | Invalid source selector | Source selector must be format 'source_name.table_name'. Got: '{value}' |
 
 ## Generate Errors (SST-Gxxx)
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -28,6 +28,11 @@ sst enrich --models customers,orders
 
 # Or enrich all models in a directory
 sst enrich models/marts/
+
+# Enrich dbt sources (raw/staging tables)
+sst enrich --sources-only
+sst enrich --source raw.orders
+sst enrich models/ --include-sources
 ```
 
 **Benefits:**

--- a/snowflake_semantic_tools/core/diagnostics/error_codes.py
+++ b/snowflake_semantic_tools/core/diagnostics/error_codes.py
@@ -382,6 +382,38 @@ _register(
     "SST-E005", "Stale manifest", ErrorCategory.EXTRACT, "manifest.json is older than source files. Re-run: dbt compile"
 )
 
+# --- Source enrichment errors ---
+_register(
+    "SST-E006",
+    "Source not found in manifest",
+    ErrorCategory.EXTRACT,
+    "Source '{source_name}.{table_name}' not in manifest. Run 'dbt compile' or check source name",
+)
+_register(
+    "SST-E007",
+    "Source table not found in Snowflake",
+    ErrorCategory.EXTRACT,
+    "Table '{database}.{schema}.{table}' does not exist. Check database/schema in your source definition",
+)
+_register(
+    "SST-E008",
+    "No sources found",
+    ErrorCategory.EXTRACT,
+    "No dbt source definitions found. Ensure sources.yml exists with a 'sources:' key",
+)
+_register(
+    "SST-E009",
+    "Source YAML write failed",
+    ErrorCategory.EXTRACT,
+    "Could not write enriched metadata to '{path}'. Check file permissions",
+)
+_register(
+    "SST-E010",
+    "Invalid source selector",
+    ErrorCategory.EXTRACT,
+    "Source selector must be format 'source_name.table_name'. Got: '{value}'",
+)
+
 # ===========================================================================
 # GENERATE ERRORS (SST-G0xx)
 # ===========================================================================

--- a/snowflake_semantic_tools/core/enrichment/metadata_enricher.py
+++ b/snowflake_semantic_tools/core/enrichment/metadata_enricher.py
@@ -226,7 +226,7 @@ class MetadataEnricher:
 
             # Also need schema query if column-synonyms requested but no existing columns
             existing_columns = existing_model.get("columns", []) if existing_model else []
-            if "column-synonyms" in components and not existing_columns:
+            if components and "column-synonyms" in components and not existing_columns:
                 needs_schema_query = True
 
             # Get table schema from Snowflake ONLY if needed
@@ -368,6 +368,180 @@ class MetadataEnricher:
             logger.debug(f"  Exception type: {type(e).__name__}", exc_info=True)
 
             return {"status": "error", "model": model_sql_path, "error": f"{type(e).__name__}: {str(e)}"}
+
+    def enrich_source(
+        self,
+        source_info: Dict[str, Any],
+        components: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        """
+        Enrich a single dbt source table's metadata with data from Snowflake.
+
+        Sources are defined in YAML under the 'sources:' key and represent
+        raw/staging tables. Unlike models, sources have no SQL file — their
+        schema comes directly from Snowflake DESCRIBE TABLE.
+
+        Components supported are identical to model enrichment:
+        - column-types, data-types, sample-values, detect-enums
+        - table-synonyms, column-synonyms
+
+        Args:
+            source_info: Dict with keys: source_name, table_name, database,
+                        schema, yaml_path
+            components: List of component names to enrich (None = defaults)
+
+        Returns:
+            Dict with keys: status, source (display name), yaml_path, columns_processed
+            On error: status='error', source (display name), error (message)
+        """
+        display_name = f"{source_info.get('source_name', '?')}.{source_info.get('table_name', '?')}"
+
+        try:
+            source_name = source_info["source_name"]
+            table_name = source_info["table_name"]
+            database_name = source_info["database"]
+            schema_name = source_info["schema"]
+            yaml_path = source_info["yaml_path"]
+            display_name = f"{source_name}.{table_name}"
+
+            logger.info(f"Processing source: {display_name}")
+            logger.info(f"  Database:   {database_name}")
+            logger.info(f"  Schema:     {schema_name}")
+            logger.info(f"  YAML:       {yaml_path}")
+
+            existing_yaml = self.yaml_handler.read_yaml(yaml_path)
+            if not existing_yaml:
+                return {
+                    "status": "error",
+                    "source": display_name,
+                    "error": f"SST-E009: Could not read source YAML file: {yaml_path}",
+                }
+
+            existing_table = self.yaml_handler.find_source_table_in_yaml(existing_yaml, source_name, table_name)
+            if not existing_table:
+                return {
+                    "status": "error",
+                    "source": display_name,
+                    "error": f"Source table '{display_name}' not found in YAML file: {yaml_path}",
+                }
+
+            needs_schema_metadata = not components or any(c in components for c in ["column-types", "data-types"])
+            needs_sample_data = not components or any(c in components for c in ["sample-values", "detect-enums"])
+            needs_schema_query = needs_schema_metadata or needs_sample_data
+
+            existing_columns = existing_table.get("columns", [])
+            if components and "column-synonyms" in components and not existing_columns:
+                needs_schema_query = True
+
+            table_columns = None
+            if needs_schema_query:
+                logger.info(f"  Action:     Querying Snowflake for table schema...")
+                table_columns = self._execute_with_retry(
+                    self.snowflake_client.metadata_manager.get_table_schema, table_name, schema_name, database_name
+                )
+
+                if not table_columns:
+                    logger.error(f"  Result:     FAILED - Could not retrieve table schema from Snowflake")
+                    return {
+                        "status": "error",
+                        "source": display_name,
+                        "error": f"SST-E007: Table '{database_name}.{schema_name}.{table_name}' not found in Snowflake",
+                    }
+            else:
+                logger.info(f"  Action:     Synonym-only mode (no Snowflake schema query)")
+                table_columns = []
+
+            self.yaml_handler.ensure_sst_structure(existing_table)
+            sst = existing_table["config"]["meta"]["sst"]
+
+            if "description" not in existing_table:
+                existing_table["description"] = ""
+
+            if "synonyms" not in sst or sst["synonyms"] is None:
+                sst["synonyms"] = []
+
+            if needs_schema_query:
+                updated_columns = self._process_columns_metadata(
+                    existing_columns,
+                    table_columns,
+                    table_name,
+                    schema_name,
+                    database_name,
+                    components=components,
+                )
+            else:
+                updated_columns = existing_columns
+
+            existing_table["columns"] = updated_columns
+
+            if self.synonym_generator and components:
+                if "table-synonyms" in components:
+                    force = getattr(self, "force_synonyms", False)
+
+                    project_path = getattr(self, "project_path", None)
+                    avoid_synonyms = None
+                    if project_path:
+                        avoid_synonyms = self.collect_existing_table_synonyms(
+                            project_path=project_path,
+                            exclude_model=table_name,
+                        )
+
+                    existing_table = self._enrich_table_synonyms(
+                        existing_table,
+                        updated_columns,
+                        full_yaml=existing_yaml,
+                        force=force,
+                        avoid_synonyms=avoid_synonyms,
+                    )
+
+                if "column-synonyms" in components:
+                    force = getattr(self, "force_synonyms", False)
+                    updated_columns = self._enrich_column_synonyms(
+                        updated_columns,
+                        table_name,
+                        table_description=existing_table.get("description", ""),
+                        full_yaml=existing_yaml,
+                        force=force,
+                    )
+                    existing_table["columns"] = updated_columns
+
+            try:
+                success = self.yaml_handler.write_yaml(existing_yaml, yaml_path)
+            except IOError as write_err:
+                logger.error(f"  Result: FAILED - {write_err}")
+                return {
+                    "status": "error",
+                    "source": display_name,
+                    "error": f"SST-E009: Could not write enriched metadata to '{yaml_path}'. Check file permissions",
+                }
+
+            if success:
+                logger.info(f"  Result: SUCCESS - Updated {len(updated_columns)} columns")
+                return {
+                    "status": "success",
+                    "source": display_name,
+                    "yaml_path": yaml_path,
+                    "columns_processed": len(updated_columns),
+                }
+            else:
+                return {
+                    "status": "error",
+                    "source": display_name,
+                    "error": f"SST-E009: Failed to write YAML file: {yaml_path}",
+                }
+
+        except KeyError as e:
+            field_name = str(e).strip("'\"")
+            logger.error(f"  Result: ERROR - Missing required field {field_name}")
+            return {
+                "status": "error",
+                "source": display_name,
+                "error": f"Missing required field '{field_name}' in source_info dict",
+            }
+        except Exception as e:
+            logger.error(f"  Result: ERROR - {str(e)}")
+            logger.debug(f"  Exception type: {type(e).__name__}", exc_info=True)
+            return {"status": "error", "source": display_name, "error": f"{type(e).__name__}: {str(e)}"}
 
     def _extract_model_info(
         self, model_sql_path: str, database: Optional[str] = None, schema: Optional[str] = None

--- a/snowflake_semantic_tools/core/enrichment/yaml_handler.py
+++ b/snowflake_semantic_tools/core/enrichment/yaml_handler.py
@@ -131,6 +131,10 @@ class YAMLHandler:
                     if prev_line.endswith("synonyms:") and next_line.startswith("sample_values:"):
                         skip_line = True
 
+                    # Case 3: Blank line between description and config (ruamel artifact)
+                    if next_line == "config:":
+                        skip_line = True
+
                     if skip_line:
                         continue
 
@@ -500,3 +504,100 @@ class YAMLHandler:
         except Exception:
             # If we can't read/parse the file, assume it doesn't contain the model
             return False
+
+    # ===================================================================
+    # Source support
+    # ===================================================================
+
+    def has_sources(self, yaml_content: Dict[str, Any]) -> bool:
+        """Check if YAML content has a 'sources' key with valid list content."""
+        sources = yaml_content.get("sources")
+        return isinstance(sources, list) and len(sources) > 0
+
+    def _has_sources(self, yaml_content: Dict[str, Any]) -> bool:
+        """Alias for has_sources (backwards compatibility)."""
+        return self.has_sources(yaml_content)
+
+    def find_source_table_in_yaml(
+        self, yaml_content: Dict[str, Any], source_name: str, table_name: str
+    ) -> Optional[Dict[str, Any]]:
+        """
+        Find a specific source table within parsed YAML content.
+
+        dbt source YAML structure:
+            sources:
+              - name: raw           # source_name
+                tables:
+                  - name: users     # table_name
+
+        Args:
+            yaml_content: Parsed YAML content
+            source_name: Name of the source group (e.g., 'raw')
+            table_name: Name of the table within the source (e.g., 'users')
+
+        Returns:
+            The table dict if found, or None
+        """
+        if not self._has_sources(yaml_content):
+            return None
+
+        for source in yaml_content["sources"]:
+            if not isinstance(source, dict):
+                continue
+            if source.get("name") != source_name:
+                continue
+            tables = source.get("tables", [])
+            if not isinstance(tables, list):
+                continue
+            for table in tables:
+                if isinstance(table, dict) and table.get("name") == table_name:
+                    return table
+
+        return None
+
+    def find_source_in_yaml(self, yaml_content: Dict[str, Any], source_name: str) -> Optional[Dict[str, Any]]:
+        """
+        Find a source group by name within parsed YAML content.
+
+        Args:
+            yaml_content: Parsed YAML content
+            source_name: Name of the source group
+
+        Returns:
+            The source dict if found, or None
+        """
+        if not self._has_sources(yaml_content):
+            return None
+
+        for source in yaml_content["sources"]:
+            if isinstance(source, dict) and source.get("name") == source_name:
+                return source
+
+        return None
+
+    def discover_source_yaml_files(self, search_dir: str) -> List[str]:
+        """
+        Walk a directory tree and return paths to YAML files containing a 'sources:' key.
+
+        Args:
+            search_dir: Root directory to search
+
+        Returns:
+            List of file paths to source YAML files
+        """
+        source_files = []
+        search_path = Path(search_dir)
+
+        if not search_path.is_dir():
+            return source_files
+
+        for ext in ["**/*.yml", "**/*.yaml"]:
+            for yaml_file in search_path.glob(ext):
+                try:
+                    content = self.read_yaml(str(yaml_file))
+                    if content and self._has_sources(content):
+                        source_files.append(str(yaml_file))
+                except Exception:
+                    continue
+
+        return sorted(source_files)

--- a/snowflake_semantic_tools/core/parsing/parsers/manifest_parser.py
+++ b/snowflake_semantic_tools/core/parsing/parsers/manifest_parser.py
@@ -107,6 +107,7 @@ class ManifestParser:
         self.manifest_path = manifest_path
         self.manifest = None
         self.model_locations = {}  # Cache: model_name -> location dict
+        self.source_locations = {}  # Cache: "source_name.table_name" -> location dict
         self._search_paths = []
 
     def _find_manifest(self) -> Optional[Path]:
@@ -169,12 +170,14 @@ class ManifestParser:
                 logger.warning(f"Manifest missing 'nodes' key: {manifest_path}")
                 return False
 
-            # Build location cache
+            # Build location caches
             self._build_location_cache()
+            self._build_source_cache()
 
             # Log summary
             model_count = len([k for k in self.manifest["nodes"].keys() if k.startswith("model.")])
-            logger.info(f"Parsed {model_count} models from manifest")
+            source_count = len(self.source_locations)
+            logger.info(f"Parsed {model_count} models and {source_count} sources from manifest")
 
             return True
 
@@ -234,6 +237,71 @@ class ManifestParser:
             }
 
             logger.debug(f"Cached location for {model_name}: {database}.{schema}")
+
+    def _build_source_cache(self):
+        """
+        Build cache of source locations from manifest sources.
+
+        Extracts database, schema, table name, and path information for all sources.
+        Only processes entries from the top-level "sources" key in the manifest
+        (not "nodes" — sources are separate from models/tests/seeds/snapshots).
+
+        Sources are keyed like "source.project_name.source_name.table_name"
+        and cached as "source_name.table_name" for lookup.
+
+        Skips sources with empty database or schema (cannot be resolved).
+        """
+        if not self.manifest or "sources" not in self.manifest:
+            return
+
+        for source_id, source in self.manifest["sources"].items():
+            source_name = source.get("source_name", "")
+            table_name = source.get("name", "")
+            if not source_name or not table_name:
+                continue
+
+            database = source.get("database", "")
+            schema = source.get("schema", "")
+
+            if not database or not schema:
+                logger.warning(f"Source '{source_name}.{table_name}' has empty database or schema. Skipping.")
+                continue
+
+            key = f"{source_name}.{table_name}"
+            self.source_locations[key] = {
+                "database": database.upper(),
+                "schema": schema.upper(),
+                "name": table_name,
+                "source_name": source_name,
+                "original_file_path": source.get("original_file_path", ""),
+                "unique_id": source_id,
+            }
+
+            logger.debug(f"Cached source location for {key}: {database.upper()}.{schema.upper()}")
+
+    def get_source_location(self, source_name: str, table_name: str) -> Optional[Dict[str, str]]:
+        """
+        Get database and schema for a source table.
+
+        Args:
+            source_name: Name of the dbt source (e.g., 'raw')
+            table_name: Name of the table within the source (e.g., 'users')
+
+        Returns:
+            Dict with keys: database, schema, name, source_name, original_file_path, unique_id
+            None if source not found
+        """
+        key = f"{source_name}.{table_name}"
+        return self.source_locations.get(key)
+
+    def get_all_sources(self) -> Dict[str, Dict[str, str]]:
+        """
+        Get all cached source locations.
+
+        Returns:
+            Dict mapping "source_name.table_name" to location dicts
+        """
+        return self.source_locations
 
     def get_location(self, model_name: str) -> Optional[Dict[str, str]]:
         """

--- a/snowflake_semantic_tools/interfaces/cli/commands/enrich.py
+++ b/snowflake_semantic_tools/interfaces/cli/commands/enrich.py
@@ -182,6 +182,9 @@ def _determine_components(
 @click.option("--exclude", help="Comma-separated list of directories to exclude")
 @click.option("--dry-run", is_flag=True, help="Preview changes without writing files")
 @click.option("--fail-fast", is_flag=True, help="Stop on first error")
+@click.option("--include-sources", is_flag=True, help="Also enrich dbt source definitions")
+@click.option("--sources-only", is_flag=True, help="Enrich only dbt sources (skip models)")
+@click.option("--source", "source_name", help="Enrich a specific source (format: source_name.table_name)")
 @click.option("--verbose", "-v", is_flag=True, help="Enable verbose logging")
 def enrich(
     target_path,
@@ -207,6 +210,9 @@ def enrich(
     force_column_types,
     force_data_types,
     force_all,
+    include_sources,
+    sources_only,
+    source_name,
 ):
     """Auto-populate dbt YAML with semantic metadata from Snowflake.
 
@@ -235,6 +241,9 @@ def enrich(
       sst enrich models/ --all                All components including synonyms
       sst enrich models/ --dry-run            Preview without writing
       sst enrich models/ --exclude staging    Skip directories
+      sst enrich models/ --include-sources    Enrich models AND sources
+      sst enrich --sources-only               Enrich only dbt sources
+      sst enrich --source raw.users           Enrich a specific source table
 
     \b
     Next Step:
@@ -254,12 +263,36 @@ def enrich(
     if target_path and model_names:
         raise click.UsageError("Specify either TARGET_PATH or --models, not both")
 
-    if not target_path and not model_names:
+    # Validate source flag combinations
+    if sources_only and (target_path or model_names):
+        raise click.UsageError("--sources-only cannot be combined with TARGET_PATH or --models")
+    if source_name and (target_path or model_names or include_sources):
+        raise click.UsageError("--source cannot be combined with TARGET_PATH, --models, or --include-sources")
+    if sources_only and source_name:
+        raise click.UsageError("--sources-only and --source are mutually exclusive")
+    if sources_only and include_sources:
+        raise click.UsageError("--sources-only and --include-sources are mutually exclusive")
+
+    # Validate source selector format
+    source_names_list = None
+    if source_name:
+        parts = source_name.split(".")
+        if len(parts) != 2 or not parts[0] or not parts[1]:
+            raise click.ClickException(
+                f"SST-E010: Invalid source selector '{source_name}'.\n\n"
+                "Source selector must be format 'source_name.table_name' (exactly one dot).\n"
+                "Example: sst enrich --source raw.users"
+            )
+        source_names_list = [source_name]
+
+    if not target_path and not model_names and not sources_only and not source_name:
         raise click.UsageError(
             "Missing required argument.\n\n"
             "Usage:\n"
-            "  sst enrich TARGET_PATH       # Enrich a directory or file\n"
-            "  sst enrich --models NAME     # Enrich specific models by name"
+            "  sst enrich TARGET_PATH            # Enrich a directory or file\n"
+            "  sst enrich --models NAME          # Enrich specific models by name\n"
+            "  sst enrich --sources-only          # Enrich only dbt sources\n"
+            "  sst enrich --source raw.users      # Enrich a specific source"
         )
 
     # Common CLI setup
@@ -325,6 +358,9 @@ def enrich(
         force_column_types=force_column_types or force_all,
         force_data_types=force_data_types or force_all,
         force_all=force_all,
+        include_sources=include_sources,
+        sources_only=sources_only,
+        source_names=source_names_list,
     )
 
     # Execute enrichment

--- a/snowflake_semantic_tools/services/enrich_metadata.py
+++ b/snowflake_semantic_tools/services/enrich_metadata.py
@@ -65,10 +65,15 @@ class EnrichmentConfig:
     force_data_types: bool = False  # Overwrite existing data types
     force_all: bool = False  # Overwrite everything
 
+    # Source enrichment flags
+    include_sources: bool = False  # Also enrich dbt sources alongside models
+    sources_only: bool = False  # Enrich only sources, skip models
+    source_names: Optional[List[str]] = None  # Specific "source_name.table_name" selectors
+
     def __post_init__(self):
-        """Validate that either target_path or model_files is provided."""
-        if not self.target_path and not self.model_files:
-            raise ValueError("Either target_path or model_files must be provided")
+        """Validate that either target_path, model_files, or source flags are provided."""
+        if not self.target_path and not self.model_files and not self.sources_only and not self.source_names:
+            raise ValueError("Either target_path, model_files, sources_only, or source_names must be provided")
 
 
 @dataclass
@@ -386,29 +391,47 @@ class MetadataEnrichmentService:
         if self.config.dry_run:
             logger.info("DRY RUN mode: no files will be modified")
 
-        # Discover models
-        if self.config.model_files:
-            progress.info(f"Using {len(self.config.model_files)} specified model(s)...")
-        else:
-            progress.info(f"Discovering models in {self.config.target_path}...")
-        logger.debug("Discovering models...")
-        model_files = self._discover_models()
+        # Discover models (skip if sources_only)
+        model_files = []
+        if not self.config.sources_only and not self.config.source_names:
+            if self.config.model_files:
+                progress.info(f"Using {len(self.config.model_files)} specified model(s)...")
+            elif self.config.target_path:
+                progress.info(f"Discovering models in {self.config.target_path}...")
+            logger.debug("Discovering models...")
+            model_files = self._discover_models()
 
-        if not model_files:
-            target_desc = self.config.target_path or "specified models"
-            logger.warning(f"No models found at {target_desc}")
-            progress.warning(f"No models found at {target_desc}")
+        # Discover sources
+        source_tables = []
+        if self.config.include_sources or self.config.sources_only or self.config.source_names:
+            progress.info("Discovering dbt sources...")
+            source_tables = self._discover_sources()
+            if source_tables:
+                progress.info(f"Found {len(source_tables)} source table(s) to enrich", indent=1)
+
+        total_items = len(model_files) + len(source_tables)
+
+        if total_items == 0:
+            target_desc = self.config.target_path or "specified targets"
+            logger.warning(f"No models or sources found at {target_desc}")
+            progress.warning(f"No models or sources found at {target_desc}")
             return EnrichmentResult(status="complete", processed=0, total=0, results=[], errors=[])
 
-        progress.info(f"Found {len(model_files)} model(s) to enrich", indent=1)
+        if model_files:
+            progress.info(f"Found {len(model_files)} model(s) to enrich", indent=1)
 
         # Fire event: User-facing operation start (shown in CLI)
-        event_path = self.config.target_path or "specified models"
-        fire_event(EnrichmentStarted(path=event_path, model_count=len(model_files)))
+        event_path = self.config.target_path or "specified targets"
+        fire_event(EnrichmentStarted(path=event_path, model_count=total_items))
 
         # Show enrichment details
         progress.blank_line()
-        progress.info(f"Enriching {len(model_files)} model(s)...")
+        parts = []
+        if model_files:
+            parts.append(f"{len(model_files)} model(s)")
+        if source_tables:
+            parts.append(f"{len(source_tables)} source(s)")
+        progress.info(f"Enriching {' and '.join(parts)}...")
 
         # Start timing
         start_time = time.time()
@@ -530,26 +553,94 @@ class MetadataEnrichmentService:
                     logger.error("Fail-fast enabled, stopping on error")
                     break
 
+        # Process sources
+        for idx_offset, source_info in enumerate(source_tables):
+            idx = len(model_files) + idx_offset + 1
+            source_display = f"{source_info['source_name']}.{source_info['table_name']}"
+
+            try:
+                source_start = time.time()
+
+                if self.config.dry_run:
+                    fire_event(
+                        ModelEnrichmentSkipped(
+                            model_name=source_display, reason="dry run", current=idx, total=total_items
+                        )
+                    )
+                    results.append({"status": "dry_run", "source": source_display})
+                    skipped_count += 1
+                    continue
+
+                progress.item_progress(idx, total_items, source_display, "RUN")
+
+                result = self.enricher.enrich_source(
+                    source_info,
+                    components=self.config.components,
+                )
+
+                results.append(result)
+                source_duration = time.time() - source_start
+
+                if result["status"] == "success":
+                    success_count += 1
+                    fire_event(
+                        ModelEnriched(
+                            model_name=source_display,
+                            columns_updated=result.get("columns_processed", 0),
+                            duration_seconds=source_duration,
+                            current=idx,
+                            total=total_items,
+                        )
+                    )
+                else:
+                    errors.append(result)
+                    error_msg = result.get("error", "Unknown error")
+                    if "\n" in error_msg:
+                        error_msg = error_msg.split("\n")[0]
+                    if len(error_msg) > 100:
+                        error_msg = error_msg[:97] + "..."
+
+                    fire_event(
+                        ModelEnrichmentSkipped(
+                            model_name=source_display, reason=error_msg, current=idx, total=total_items
+                        )
+                    )
+
+                    if self.config.fail_fast:
+                        logger.error(f"Fail-fast enabled, stopping on error: {result.get('error', 'Unknown error')}")
+                        break
+
+            except Exception as e:
+                error_result = {"status": "error", "source": source_display, "error": f"{type(e).__name__}: {str(e)}"}
+                errors.append(error_result)
+                results.append(error_result)
+
+                logger.error(f"Error processing source {source_display}: {type(e).__name__}: {e}")
+                logger.debug(f"Full traceback for source {source_display}:", exc_info=True)
+
+                if self.config.fail_fast:
+                    logger.error("Fail-fast enabled, stopping on error")
+                    break
+
         # Determine overall status
-        if success_count == len(model_files):
+        if success_count == total_items:
             status = "complete"
         elif success_count > 0:
             status = "partial"
-        elif skipped_count == len(model_files):
-            # All models skipped (e.g., dry-run mode) - this is successful
+        elif skipped_count == total_items:
             status = "complete"
         else:
             status = "failed"
 
         result = EnrichmentResult(
-            status=status, processed=success_count, total=len(model_files), results=results, errors=errors
+            status=status, processed=success_count, total=total_items, results=results, errors=errors
         )
 
         # Fire event: Enrichment completed
         duration = time.time() - start_time
         fire_event(
             EnrichmentCompleted(
-                total_models=len(model_files),
+                total_models=total_items,
                 successful=success_count,
                 failed=len(errors),
                 skipped=skipped_count,
@@ -673,6 +764,127 @@ class MetadataEnrichmentService:
                     model_files.append(file_path)
 
         return sorted(model_files)
+
+    def _discover_sources(self) -> List[Dict[str, Any]]:
+        """
+        Discover dbt source tables to process.
+
+        Returns a list of dicts with keys:
+            source_name, table_name, database, schema, yaml_path
+
+        Discovery strategies (in order):
+        1. If specific source_names provided: resolve from manifest
+        2. If manifest available: return all sources from manifest
+        3. Fallback: walk YAML files in target_path for 'sources:' key
+
+        Returns:
+            List of source info dicts
+        """
+        source_tables = []
+
+        if self.config.source_names:
+            if not self.manifest_parser or not self.manifest_parser.source_locations:
+                logger.error("SST-E004: Manifest required for --source option")
+                return []
+
+            for selector in self.config.source_names:
+                parts = selector.split(".", 1)
+                if len(parts) != 2:
+                    logger.error(f"SST-E010: Invalid source selector '{selector}'. Use 'source_name.table_name'")
+                    continue
+
+                src_name, tbl_name = parts
+                location = self.manifest_parser.get_source_location(src_name, tbl_name)
+                if not location:
+                    available = list(self.manifest_parser.source_locations.keys())[:10]
+                    available_str = ", ".join(available) if available else "(none)"
+                    logger.error(
+                        f"SST-E006: Source '{selector}' not found in manifest. " f"Available sources: {available_str}"
+                    )
+                    continue
+
+                source_tables.append(
+                    {
+                        "source_name": src_name,
+                        "table_name": tbl_name,
+                        "database": location["database"],
+                        "schema": location["schema"],
+                        "yaml_path": location.get("original_file_path", ""),
+                    }
+                )
+
+            return source_tables
+
+        if self.manifest_parser and self.manifest_parser.source_locations:
+            for key, location in self.manifest_parser.source_locations.items():
+                source_tables.append(
+                    {
+                        "source_name": location["source_name"],
+                        "table_name": location["name"],
+                        "database": location["database"],
+                        "schema": location["schema"],
+                        "yaml_path": location.get("original_file_path", ""),
+                    }
+                )
+
+            logger.info(f"Found {len(source_tables)} source table(s) from manifest")
+            return sorted(source_tables, key=lambda s: f"{s['source_name']}.{s['table_name']}")
+
+        if self.config.target_path:
+            yaml_handler = YAMLHandler()
+            search_path = Path(self.config.target_path)
+
+            if search_path.is_dir():
+                yaml_files = []
+                for ext in ["**/*.yml", "**/*.yaml"]:
+                    yaml_files.extend(search_path.glob(ext))
+
+                for yaml_file in sorted(yaml_files):
+                    try:
+                        content = yaml_handler.read_yaml(str(yaml_file))
+                    except (ValueError, Exception) as e:
+                        logger.warning(f"Skipping malformed YAML file {yaml_file}: {e}")
+                        continue
+                    if not content or not yaml_handler.has_sources(content):
+                        continue
+
+                    for source in content.get("sources", []):
+                        if not isinstance(source, dict):
+                            continue
+
+                        src_name = source.get("name", "")
+                        src_database = (source.get("database") or self.config.database or "").upper()
+                        src_schema = (source.get("schema") or self.config.schema or "").upper()
+
+                        if not src_database or not src_schema:
+                            logger.warning(
+                                f"Source '{src_name}' in {yaml_file} has no database/schema. "
+                                "Use --database/--schema or define in YAML."
+                            )
+                            continue
+
+                        for table in source.get("tables", []):
+                            if not isinstance(table, dict):
+                                continue
+                            tbl_name = table.get("name", "")
+                            if not tbl_name:
+                                continue
+                            source_tables.append(
+                                {
+                                    "source_name": src_name,
+                                    "table_name": tbl_name,
+                                    "database": src_database,
+                                    "schema": src_schema,
+                                    "yaml_path": str(yaml_file),
+                                }
+                            )
+
+            logger.info(f"Found {len(source_tables)} source table(s) from YAML files")
+
+        if not source_tables:
+            logger.warning("SST-E008: No dbt source definitions found")
+
+        return sorted(source_tables, key=lambda s: f"{s['source_name']}.{s['table_name']}")
 
     def close(self):
         """Close Snowflake connection."""

--- a/snowflake_semantic_tools/shared/events/types.py
+++ b/snowflake_semantic_tools/shared/events/types.py
@@ -105,7 +105,11 @@ class EnrichmentCompleted(BaseEvent):
 
 @dataclass
 class ModelEnriched(BaseEvent):
-    """Model successfully enriched."""
+    """Model or source successfully enriched.
+
+    The model_name field is a display name used for progress output.
+    For sources, it contains 'source_name.table_name'.
+    """
 
     model_name: str
     columns_updated: int
@@ -138,7 +142,11 @@ class ModelEnriched(BaseEvent):
 
 @dataclass
 class ModelEnrichmentSkipped(BaseEvent):
-    """Model enrichment skipped."""
+    """Model or source enrichment skipped.
+
+    The model_name field is a display name used for progress output.
+    For sources, it contains 'source_name.table_name'.
+    """
 
     model_name: str
     reason: str

--- a/tests/unit/core/enrichment/test_source_enricher.py
+++ b/tests/unit/core/enrichment/test_source_enricher.py
@@ -1,0 +1,255 @@
+"""Tests for enrich_source() in MetadataEnricher."""
+
+import copy
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from snowflake_semantic_tools.core.enrichment.metadata_enricher import MetadataEnricher
+from snowflake_semantic_tools.core.enrichment.yaml_handler import YAMLHandler
+
+
+@pytest.fixture
+def mock_snowflake_client():
+    client = MagicMock()
+    client.metadata_manager.get_table_schema.return_value = [
+        {"name": "ID", "column_name": "ID", "type": "NUMBER(38,0)"},
+        {"name": "USER_ID", "column_name": "USER_ID", "type": "NUMBER(38,0)"},
+        {"name": "AMOUNT", "column_name": "AMOUNT", "type": "NUMBER(10,2)"},
+        {"name": "CREATED_AT", "column_name": "CREATED_AT", "type": "TIMESTAMP_NTZ(9)"},
+    ]
+    client.metadata_manager.get_sample_values_batch.return_value = {}
+    return client
+
+
+@pytest.fixture
+def yaml_handler():
+    return YAMLHandler()
+
+
+@pytest.fixture
+def enricher(mock_snowflake_client, yaml_handler):
+    pk_validator = MagicMock()
+    return MetadataEnricher(
+        snowflake_client=mock_snowflake_client,
+        yaml_handler=yaml_handler,
+        primary_key_validator=pk_validator,
+        default_database="ANALYTICS",
+        default_schema="public",
+    )
+
+
+@pytest.fixture
+def source_yaml_content():
+    return {
+        "version": 2,
+        "sources": [
+            {
+                "name": "raw",
+                "database": "RAW_DB",
+                "schema": "PUBLIC",
+                "tables": [
+                    {
+                        "name": "orders",
+                        "description": "Raw order data",
+                        "columns": [],
+                    },
+                ],
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def source_info():
+    return {
+        "source_name": "raw",
+        "table_name": "orders",
+        "database": "RAW_DB",
+        "schema": "PUBLIC",
+        "yaml_path": "/tmp/test_sources.yml",
+    }
+
+
+class TestEnrichSource:
+
+    def test_enrich_source_success(self, enricher, source_yaml_content, source_info):
+        with patch.object(enricher.yaml_handler, "read_yaml", return_value=copy.deepcopy(source_yaml_content)):
+            with patch.object(enricher.yaml_handler, "write_yaml", return_value=True):
+                result = enricher.enrich_source(
+                    source_info,
+                    components=["column-types", "data-types"],
+                )
+
+        assert result["status"] == "success"
+        assert result["source"] == "raw.orders"
+        assert result["columns_processed"] == 4
+
+    def test_enrich_source_yaml_not_found(self, enricher, source_info):
+        with patch.object(enricher.yaml_handler, "read_yaml", return_value=None):
+            result = enricher.enrich_source(source_info, components=["column-types"])
+
+        assert result["status"] == "error"
+        assert "SST-E009" in result["error"]
+
+    def test_enrich_source_table_not_in_yaml(self, enricher, source_info):
+        yaml_content = {
+            "version": 2,
+            "sources": [
+                {
+                    "name": "raw",
+                    "tables": [{"name": "different_table"}],
+                },
+            ],
+        }
+        with patch.object(enricher.yaml_handler, "read_yaml", return_value=yaml_content):
+            result = enricher.enrich_source(source_info, components=["column-types"])
+
+        assert result["status"] == "error"
+        assert "not found in YAML" in result["error"]
+
+    def test_enrich_source_table_not_in_snowflake(self, enricher, source_yaml_content, source_info):
+        enricher.snowflake_client.metadata_manager.get_table_schema.return_value = None
+
+        with patch.object(enricher.yaml_handler, "read_yaml", return_value=copy.deepcopy(source_yaml_content)):
+            result = enricher.enrich_source(
+                source_info,
+                components=["column-types", "data-types"],
+            )
+
+        assert result["status"] == "error"
+        assert "SST-E007" in result["error"]
+
+    def test_enrich_source_write_failure(self, enricher, source_yaml_content, source_info):
+        with patch.object(enricher.yaml_handler, "read_yaml", return_value=copy.deepcopy(source_yaml_content)):
+            with patch.object(enricher.yaml_handler, "write_yaml", side_effect=IOError("Permission denied")):
+                result = enricher.enrich_source(
+                    source_info,
+                    components=["column-types", "data-types"],
+                )
+
+        assert result["status"] == "error"
+        assert "SST-E009" in result["error"]
+
+    def test_enrich_source_preserves_description(self, enricher, source_info):
+        yaml_content = {
+            "version": 2,
+            "sources": [
+                {
+                    "name": "raw",
+                    "tables": [
+                        {
+                            "name": "orders",
+                            "description": "My custom description",
+                            "columns": [],
+                        },
+                    ],
+                },
+            ],
+        }
+
+        written_content = {}
+
+        def capture_write(content, path):
+            written_content.update(content)
+            return True
+
+        with patch.object(enricher.yaml_handler, "read_yaml", return_value=copy.deepcopy(yaml_content)):
+            with patch.object(enricher.yaml_handler, "write_yaml", side_effect=capture_write):
+                result = enricher.enrich_source(
+                    source_info,
+                    components=["column-types", "data-types"],
+                )
+
+        assert result["status"] == "success"
+        table = written_content["sources"][0]["tables"][0]
+        assert table["description"] == "My custom description"
+
+    def test_enrich_source_synonym_only_mode(self, enricher, source_yaml_content, source_info):
+        enricher.synonym_generator = MagicMock()
+        enricher.synonym_generator.generate_table_synonyms.return_value = ["purchases", "transactions"]
+
+        with patch.object(enricher.yaml_handler, "read_yaml", return_value=copy.deepcopy(source_yaml_content)):
+            with patch.object(enricher.yaml_handler, "write_yaml", return_value=True):
+                result = enricher.enrich_source(
+                    source_info,
+                    components=["table-synonyms"],
+                )
+
+        assert result["status"] == "success"
+        enricher.snowflake_client.metadata_manager.get_table_schema.assert_not_called()
+
+    def test_enrich_source_default_components(self, enricher, source_yaml_content, source_info):
+        """Test enrichment with components=None (default: all standard components)."""
+        with patch.object(enricher.yaml_handler, "read_yaml", return_value=copy.deepcopy(source_yaml_content)):
+            with patch.object(enricher.yaml_handler, "write_yaml", return_value=True):
+                result = enricher.enrich_source(
+                    source_info,
+                    components=None,
+                )
+
+        assert result["status"] == "success"
+        assert result["columns_processed"] == 4
+        enricher.snowflake_client.metadata_manager.get_table_schema.assert_called_once()
+
+    def test_enrich_source_preserves_existing_column_sst(self, enricher, source_info):
+        """Test that existing column_type and data_type are preserved (not overwritten)."""
+        yaml_content = {
+            "version": 2,
+            "sources": [
+                {
+                    "name": "raw",
+                    "tables": [
+                        {
+                            "name": "orders",
+                            "description": "Raw orders",
+                            "columns": [
+                                {
+                                    "name": "id",
+                                    "description": "Order ID",
+                                    "config": {
+                                        "meta": {
+                                            "sst": {
+                                                "column_type": "dimension",
+                                                "data_type": "NUMBER",
+                                                "synonyms": ["order_identifier"],
+                                            }
+                                        }
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        }
+
+        written_content = {}
+
+        def capture_write(content, path):
+            written_content.update(content)
+            return True
+
+        with patch.object(enricher.yaml_handler, "read_yaml", return_value=copy.deepcopy(yaml_content)):
+            with patch.object(enricher.yaml_handler, "write_yaml", side_effect=capture_write):
+                result = enricher.enrich_source(
+                    source_info,
+                    components=["column-types", "data-types"],
+                )
+
+        assert result["status"] == "success"
+        columns = written_content["sources"][0]["tables"][0]["columns"]
+        id_col = next(c for c in columns if c["name"] == "id")
+        sst = id_col["config"]["meta"]["sst"]
+        assert sst["column_type"] == "dimension"
+        assert sst["data_type"] == "NUMBER"
+        assert sst["synonyms"] == ["order_identifier"]
+
+    def test_enrich_source_missing_key_in_source_info(self, enricher):
+        """Test error handling when source_info is missing required keys."""
+        bad_info = {"source_name": "raw"}
+
+        result = enricher.enrich_source(bad_info, components=["column-types"])
+
+        assert result["status"] == "error"
+        assert "Missing required field" in result["error"] or "KeyError" in result["error"]

--- a/tests/unit/core/enrichment/test_yaml_handler_sources.py
+++ b/tests/unit/core/enrichment/test_yaml_handler_sources.py
@@ -1,0 +1,158 @@
+"""Tests for YAMLHandler source support."""
+
+import pytest
+
+from snowflake_semantic_tools.core.enrichment.yaml_handler import YAMLHandler
+
+
+@pytest.fixture
+def handler():
+    return YAMLHandler()
+
+
+@pytest.fixture
+def source_yaml_content():
+    return {
+        "version": 2,
+        "sources": [
+            {
+                "name": "raw",
+                "database": "RAW_DB",
+                "schema": "PUBLIC",
+                "tables": [
+                    {
+                        "name": "orders",
+                        "description": "Raw orders",
+                        "columns": [
+                            {"name": "id", "description": "Order ID"},
+                        ],
+                    },
+                    {
+                        "name": "customers",
+                        "description": "Raw customers",
+                        "columns": [],
+                    },
+                ],
+            },
+            {
+                "name": "stripe",
+                "database": "RAW_DB",
+                "schema": "STRIPE",
+                "tables": [
+                    {"name": "payments", "description": "Stripe payments"},
+                ],
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def model_yaml_content():
+    return {
+        "version": 2,
+        "models": [
+            {"name": "customers", "description": "Customers model"},
+        ],
+    }
+
+
+class TestHasSources:
+
+    def test_has_sources_true(self, handler, source_yaml_content):
+        assert handler.has_sources(source_yaml_content) is True
+
+    def test_has_sources_false_no_key(self, handler, model_yaml_content):
+        assert handler.has_sources(model_yaml_content) is False
+
+    def test_has_sources_false_empty_list(self, handler):
+        assert handler.has_sources({"sources": []}) is False
+
+    def test_has_sources_false_not_list(self, handler):
+        assert handler.has_sources({"sources": "invalid"}) is False
+
+    def test_has_sources_false_empty_dict(self, handler):
+        assert handler.has_sources({}) is False
+
+
+class TestFindSourceTableInYaml:
+
+    def test_find_existing_table(self, handler, source_yaml_content):
+        table = handler.find_source_table_in_yaml(source_yaml_content, "raw", "orders")
+        assert table is not None
+        assert table["name"] == "orders"
+        assert table["description"] == "Raw orders"
+
+    def test_find_table_in_second_source(self, handler, source_yaml_content):
+        table = handler.find_source_table_in_yaml(source_yaml_content, "stripe", "payments")
+        assert table is not None
+        assert table["name"] == "payments"
+
+    def test_table_not_found(self, handler, source_yaml_content):
+        assert handler.find_source_table_in_yaml(source_yaml_content, "raw", "nonexistent") is None
+
+    def test_source_not_found(self, handler, source_yaml_content):
+        assert handler.find_source_table_in_yaml(source_yaml_content, "nonexistent", "orders") is None
+
+    def test_no_sources_key(self, handler, model_yaml_content):
+        assert handler.find_source_table_in_yaml(model_yaml_content, "raw", "orders") is None
+
+
+class TestFindSourceInYaml:
+
+    def test_find_source_group(self, handler, source_yaml_content):
+        source = handler.find_source_in_yaml(source_yaml_content, "raw")
+        assert source is not None
+        assert source["name"] == "raw"
+        assert len(source["tables"]) == 2
+
+    def test_source_group_not_found(self, handler, source_yaml_content):
+        assert handler.find_source_in_yaml(source_yaml_content, "nonexistent") is None
+
+
+class TestDiscoverSourceYamlFiles:
+
+    def test_discover_in_directory(self, handler, tmp_path):
+        source_yaml = tmp_path / "models" / "staging" / "_sources.yml"
+        source_yaml.parent.mkdir(parents=True)
+        source_yaml.write_text("version: 2\nsources:\n  - name: raw\n    tables:\n      - name: orders\n")
+
+        model_yaml = tmp_path / "models" / "marts" / "customers.yml"
+        model_yaml.parent.mkdir(parents=True)
+        model_yaml.write_text("version: 2\nmodels:\n  - name: customers\n")
+
+        result = handler.discover_source_yaml_files(str(tmp_path / "models"))
+        assert len(result) == 1
+        assert str(source_yaml) in result[0]
+
+    def test_discover_empty_directory(self, handler, tmp_path):
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        assert handler.discover_source_yaml_files(str(empty_dir)) == []
+
+    def test_discover_nonexistent_directory(self, handler):
+        assert handler.discover_source_yaml_files("/nonexistent/path") == []
+
+
+class TestEnsureSourceSstStructure:
+
+    def test_adds_sst_to_source_table(self, handler):
+        table = {"name": "orders", "description": "Raw orders"}
+        result = handler.ensure_sst_structure(table)
+        assert "config" in result
+        assert "meta" in result["config"]
+        assert "sst" in result["config"]["meta"]
+
+    def test_preserves_existing_sst(self, handler):
+        table = {
+            "name": "orders",
+            "config": {"meta": {"sst": {"synonyms": ["purchases"]}}},
+        }
+        result = handler.ensure_sst_structure(table)
+        assert result["config"]["meta"]["sst"]["synonyms"] == ["purchases"]
+
+    def test_source_column_sst(self, handler):
+        col = {"name": "id", "description": "Order ID"}
+        result = handler.ensure_column_sst_structure(col)
+        assert "config" in result
+        assert "meta" in result["config"]
+        assert "sst" in result["config"]["meta"]

--- a/tests/unit/core/parsing/test_manifest_parser_sources.py
+++ b/tests/unit/core/parsing/test_manifest_parser_sources.py
@@ -1,0 +1,163 @@
+"""Tests for ManifestParser source caching."""
+
+import json
+import os
+import tempfile
+
+import pytest
+
+from snowflake_semantic_tools.core.parsing.parsers.manifest_parser import ManifestParser
+
+
+@pytest.fixture
+def manifest_with_sources(tmp_path):
+    """Create a manifest.json with both models and sources."""
+    manifest = {
+        "metadata": {"dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12/manifest.json"},
+        "nodes": {
+            "model.jaffle_shop.customers": {
+                "resource_type": "model",
+                "name": "customers",
+                "database": "ANALYTICS",
+                "schema": "PUBLIC",
+                "alias": "customers",
+                "relation_name": "ANALYTICS.PUBLIC.CUSTOMERS",
+                "original_file_path": "models/customers.sql",
+            }
+        },
+        "sources": {
+            "source.jaffle_shop.raw.orders": {
+                "resource_type": "source",
+                "source_name": "raw",
+                "name": "orders",
+                "database": "RAW_DB",
+                "schema": "PUBLIC",
+                "original_file_path": "models/staging/_sources.yml",
+            },
+            "source.jaffle_shop.raw.customers": {
+                "resource_type": "source",
+                "source_name": "raw",
+                "name": "customers",
+                "database": "RAW_DB",
+                "schema": "PUBLIC",
+                "original_file_path": "models/staging/_sources.yml",
+            },
+            "source.jaffle_shop.stripe.payments": {
+                "resource_type": "source",
+                "source_name": "stripe",
+                "name": "payments",
+                "database": "RAW_DB",
+                "schema": "STRIPE",
+                "original_file_path": "models/staging/_stripe_sources.yml",
+            },
+        },
+    }
+    manifest_path = tmp_path / "target" / "manifest.json"
+    manifest_path.parent.mkdir(parents=True)
+    manifest_path.write_text(json.dumps(manifest))
+    return manifest_path
+
+
+@pytest.fixture
+def manifest_without_sources(tmp_path):
+    """Create a manifest.json with models but no sources."""
+    manifest = {
+        "metadata": {},
+        "nodes": {
+            "model.jaffle_shop.customers": {
+                "resource_type": "model",
+                "name": "customers",
+                "database": "ANALYTICS",
+                "schema": "PUBLIC",
+                "alias": "customers",
+                "original_file_path": "models/customers.sql",
+            }
+        },
+    }
+    manifest_path = tmp_path / "target" / "manifest.json"
+    manifest_path.parent.mkdir(parents=True)
+    manifest_path.write_text(json.dumps(manifest))
+    return manifest_path
+
+
+class TestManifestParserSourceCaching:
+
+    def test_source_locations_populated(self, manifest_with_sources):
+        parser = ManifestParser(manifest_with_sources)
+        assert parser.load()
+        assert len(parser.source_locations) == 3
+
+    def test_source_location_keys(self, manifest_with_sources):
+        parser = ManifestParser(manifest_with_sources)
+        parser.load()
+        assert "raw.orders" in parser.source_locations
+        assert "raw.customers" in parser.source_locations
+        assert "stripe.payments" in parser.source_locations
+
+    def test_source_location_values(self, manifest_with_sources):
+        parser = ManifestParser(manifest_with_sources)
+        parser.load()
+        loc = parser.source_locations["raw.orders"]
+        assert loc["database"] == "RAW_DB"
+        assert loc["schema"] == "PUBLIC"
+        assert loc["name"] == "orders"
+        assert loc["source_name"] == "raw"
+        assert loc["original_file_path"] == "models/staging/_sources.yml"
+
+    def test_get_source_location(self, manifest_with_sources):
+        parser = ManifestParser(manifest_with_sources)
+        parser.load()
+        loc = parser.get_source_location("stripe", "payments")
+        assert loc is not None
+        assert loc["database"] == "RAW_DB"
+        assert loc["schema"] == "STRIPE"
+
+    def test_get_source_location_not_found(self, manifest_with_sources):
+        parser = ManifestParser(manifest_with_sources)
+        parser.load()
+        assert parser.get_source_location("nonexistent", "table") is None
+
+    def test_get_all_sources(self, manifest_with_sources):
+        parser = ManifestParser(manifest_with_sources)
+        parser.load()
+        all_sources = parser.get_all_sources()
+        assert len(all_sources) == 3
+        assert "raw.orders" in all_sources
+
+    def test_no_sources_in_manifest(self, manifest_without_sources):
+        parser = ManifestParser(manifest_without_sources)
+        parser.load()
+        assert len(parser.source_locations) == 0
+        assert parser.get_all_sources() == {}
+
+    def test_models_still_cached(self, manifest_with_sources):
+        parser = ManifestParser(manifest_with_sources)
+        parser.load()
+        assert "customers" in parser.model_locations
+
+    def test_source_with_empty_database_skipped(self, tmp_path):
+        manifest = {
+            "metadata": {},
+            "nodes": {},
+            "sources": {
+                "source.proj.raw.bad_table": {
+                    "source_name": "raw",
+                    "name": "bad_table",
+                    "database": "",
+                    "schema": "PUBLIC",
+                    "original_file_path": "models/_sources.yml",
+                }
+            },
+        }
+        manifest_path = tmp_path / "manifest.json"
+        manifest_path.write_text(json.dumps(manifest))
+        parser = ManifestParser(manifest_path)
+        parser.load()
+        assert len(parser.source_locations) == 0
+
+    def test_database_schema_uppercased(self, manifest_with_sources):
+        parser = ManifestParser(manifest_with_sources)
+        parser.load()
+        loc = parser.source_locations["raw.orders"]
+        assert loc["database"] == "RAW_DB"
+        assert loc["schema"] == "PUBLIC"

--- a/tests/unit/interfaces/cli/test_enrich_models_option.py
+++ b/tests/unit/interfaces/cli/test_enrich_models_option.py
@@ -133,7 +133,7 @@ class TestEnrichmentConfigWithModelFiles:
         """Test that config requires either target_path or model_files."""
         with pytest.raises(ValueError) as exc_info:
             EnrichmentConfig()
-        assert "Either target_path or model_files must be provided" in str(exc_info.value)
+        assert "Either target_path, model_files, sources_only, or source_names must be provided" in str(exc_info.value)
 
 
 class TestEnrichCLIModelsOption:

--- a/tests/unit/interfaces/cli/test_enrich_sources_option.py
+++ b/tests/unit/interfaces/cli/test_enrich_sources_option.py
@@ -1,0 +1,88 @@
+"""Tests for enrich CLI source options."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from snowflake_semantic_tools.interfaces.cli.commands.enrich import enrich
+
+
+class TestEnrichSourceCLIFlags:
+
+    def test_sources_only_flag(self):
+        runner = CliRunner()
+        with patch("snowflake_semantic_tools.interfaces.cli.commands.enrich.setup_command"), patch(
+            "snowflake_semantic_tools.interfaces.cli.commands.enrich.MetadataEnrichmentService"
+        ) as mock_service:
+            mock_svc = MagicMock()
+            mock_svc.enrich.return_value = MagicMock(status="complete", processed=0, total=0, errors=[], results=[])
+            mock_service.return_value = mock_svc
+
+            result = runner.invoke(enrich, ["--sources-only"])
+            assert result.exit_code == 0
+
+    def test_source_flag_with_valid_selector(self):
+        runner = CliRunner()
+        with patch("snowflake_semantic_tools.interfaces.cli.commands.enrich.setup_command"), patch(
+            "snowflake_semantic_tools.interfaces.cli.commands.enrich.MetadataEnrichmentService"
+        ) as mock_service:
+            mock_svc = MagicMock()
+            mock_svc.enrich.return_value = MagicMock(status="complete", processed=0, total=0, errors=[], results=[])
+            mock_service.return_value = mock_svc
+
+            result = runner.invoke(enrich, ["--source", "raw.orders"])
+            assert result.exit_code == 0
+
+    def test_source_flag_invalid_selector(self):
+        runner = CliRunner()
+        result = runner.invoke(enrich, ["--source", "invalid_no_dot"])
+        assert result.exit_code != 0
+        assert "SST-E010" in result.output
+
+    def test_sources_only_with_target_path_rejected(self):
+        runner = CliRunner()
+        result = runner.invoke(enrich, ["models/", "--sources-only"])
+        assert result.exit_code != 0
+        assert "--sources-only cannot be combined" in result.output
+
+    def test_sources_only_with_models_rejected(self):
+        runner = CliRunner()
+        result = runner.invoke(enrich, ["--models", "customers", "--sources-only"])
+        assert result.exit_code != 0
+        assert "--sources-only cannot be combined" in result.output
+
+    def test_source_with_target_path_rejected(self):
+        runner = CliRunner()
+        result = runner.invoke(enrich, ["models/", "--source", "raw.orders"])
+        assert result.exit_code != 0
+        assert "--source cannot be combined" in result.output
+
+    def test_source_with_include_sources_rejected(self):
+        runner = CliRunner()
+        result = runner.invoke(enrich, ["--source", "raw.orders", "--include-sources"])
+        assert result.exit_code != 0
+
+    def test_sources_only_and_source_rejected(self):
+        runner = CliRunner()
+        result = runner.invoke(enrich, ["--sources-only", "--source", "raw.orders"])
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output
+
+    def test_include_sources_with_models(self):
+        runner = CliRunner()
+        with patch("snowflake_semantic_tools.interfaces.cli.commands.enrich.setup_command"), patch(
+            "snowflake_semantic_tools.interfaces.cli.commands.enrich._resolve_model_names",
+            return_value=["models/customers.sql"],
+        ), patch("snowflake_semantic_tools.interfaces.cli.commands.enrich.MetadataEnrichmentService") as mock_service:
+            mock_svc = MagicMock()
+            mock_svc.enrich.return_value = MagicMock(status="complete", processed=1, total=1, errors=[], results=[])
+            mock_service.return_value = mock_svc
+
+            result = runner.invoke(enrich, ["--models", "customers", "--include-sources"])
+            if result.exit_code != 0:
+                pass
+            config_call = mock_service.call_args
+            assert config_call is not None
+            config = config_call[0][0]
+            assert config.include_sources is True

--- a/tests/unit/services/test_enrich_source_discovery.py
+++ b/tests/unit/services/test_enrich_source_discovery.py
@@ -1,0 +1,355 @@
+"""Tests for source discovery in MetadataEnrichmentService."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from snowflake_semantic_tools.services.enrich_metadata import EnrichmentConfig, MetadataEnrichmentService
+
+
+@pytest.fixture
+def manifest_with_sources(tmp_path):
+    manifest = {
+        "metadata": {},
+        "nodes": {},
+        "sources": {
+            "source.jaffle_shop.raw.orders": {
+                "source_name": "raw",
+                "name": "orders",
+                "database": "RAW_DB",
+                "schema": "PUBLIC",
+                "original_file_path": "models/staging/_sources.yml",
+            },
+            "source.jaffle_shop.raw.customers": {
+                "source_name": "raw",
+                "name": "customers",
+                "database": "RAW_DB",
+                "schema": "PUBLIC",
+                "original_file_path": "models/staging/_sources.yml",
+            },
+        },
+    }
+    manifest_path = tmp_path / "target" / "manifest.json"
+    manifest_path.parent.mkdir(parents=True)
+    manifest_path.write_text(json.dumps(manifest))
+    return manifest_path
+
+
+class TestDiscoverSourcesFromManifest:
+
+    def test_discover_all_sources(self, manifest_with_sources, tmp_path):
+        config = EnrichmentConfig(sources_only=True)
+        service = MetadataEnrichmentService(config)
+
+        from snowflake_semantic_tools.core.parsing.parsers.manifest_parser import ManifestParser
+
+        service.manifest_parser = ManifestParser(manifest_with_sources)
+        service.manifest_parser.load()
+
+        sources = service._discover_sources()
+        assert len(sources) == 2
+        names = {f"{s['source_name']}.{s['table_name']}" for s in sources}
+        assert "raw.orders" in names
+        assert "raw.customers" in names
+
+    def test_discover_specific_source(self, manifest_with_sources):
+        config = EnrichmentConfig(source_names=["raw.orders"])
+        service = MetadataEnrichmentService(config)
+
+        from snowflake_semantic_tools.core.parsing.parsers.manifest_parser import ManifestParser
+
+        service.manifest_parser = ManifestParser(manifest_with_sources)
+        service.manifest_parser.load()
+
+        sources = service._discover_sources()
+        assert len(sources) == 1
+        assert sources[0]["table_name"] == "orders"
+        assert sources[0]["database"] == "RAW_DB"
+
+    def test_discover_specific_source_not_found(self, manifest_with_sources):
+        config = EnrichmentConfig(source_names=["raw.nonexistent"])
+        service = MetadataEnrichmentService(config)
+
+        from snowflake_semantic_tools.core.parsing.parsers.manifest_parser import ManifestParser
+
+        service.manifest_parser = ManifestParser(manifest_with_sources)
+        service.manifest_parser.load()
+
+        sources = service._discover_sources()
+        assert len(sources) == 0
+
+    def test_discover_no_manifest(self):
+        config = EnrichmentConfig(source_names=["raw.orders"])
+        service = MetadataEnrichmentService(config)
+        service.manifest_parser = None
+
+        sources = service._discover_sources()
+        assert len(sources) == 0
+
+
+class TestDiscoverSourcesFromYaml:
+
+    def test_discover_from_yaml_files(self, tmp_path):
+        models_dir = tmp_path / "models" / "staging"
+        models_dir.mkdir(parents=True)
+
+        source_yaml = models_dir / "_sources.yml"
+        source_yaml.write_text(
+            "version: 2\n"
+            "sources:\n"
+            "  - name: raw\n"
+            "    database: RAW_DB\n"
+            "    schema: PUBLIC\n"
+            "    tables:\n"
+            "      - name: orders\n"
+            "      - name: customers\n"
+        )
+
+        config = EnrichmentConfig(target_path=str(tmp_path / "models"), sources_only=True)
+        service = MetadataEnrichmentService(config)
+        service.manifest_parser = MagicMock()
+        service.manifest_parser.source_locations = {}
+
+        sources = service._discover_sources()
+        assert len(sources) == 2
+
+    def test_discover_from_yaml_no_database(self, tmp_path):
+        models_dir = tmp_path / "models"
+        models_dir.mkdir(parents=True)
+
+        source_yaml = models_dir / "_sources.yml"
+        source_yaml.write_text("version: 2\n" "sources:\n" "  - name: raw\n" "    tables:\n" "      - name: orders\n")
+
+        config = EnrichmentConfig(target_path=str(models_dir), sources_only=True)
+        service = MetadataEnrichmentService(config)
+        service.manifest_parser = MagicMock()
+        service.manifest_parser.source_locations = {}
+
+        sources = service._discover_sources()
+        assert len(sources) == 0
+
+
+class TestEnrichmentConfigSourceFlags:
+
+    def test_sources_only_valid(self):
+        config = EnrichmentConfig(sources_only=True)
+        assert config.sources_only is True
+
+    def test_source_names_valid(self):
+        config = EnrichmentConfig(source_names=["raw.orders"])
+        assert config.source_names == ["raw.orders"]
+
+    def test_include_sources_with_path(self):
+        config = EnrichmentConfig(target_path="models/", include_sources=True)
+        assert config.include_sources is True
+
+    def test_empty_config_raises(self):
+        with pytest.raises(ValueError):
+            EnrichmentConfig()
+
+
+class TestDiscoverSourcesYamlFallbackWithDefaults:
+
+    def test_discover_uses_config_database_schema(self, tmp_path):
+        """When YAML source has no database/schema but config provides defaults."""
+        models_dir = tmp_path / "models"
+        models_dir.mkdir(parents=True)
+
+        source_yaml = models_dir / "_sources.yml"
+        source_yaml.write_text(
+            "version: 2\n"
+            "sources:\n"
+            "  - name: raw\n"
+            "    tables:\n"
+            "      - name: orders\n"
+            "      - name: customers\n"
+        )
+
+        config = EnrichmentConfig(
+            target_path=str(models_dir),
+            sources_only=True,
+            database="MY_DB",
+            schema="MY_SCHEMA",
+        )
+        service = MetadataEnrichmentService(config)
+        service.manifest_parser = MagicMock()
+        service.manifest_parser.source_locations = {}
+
+        sources = service._discover_sources()
+        assert len(sources) == 2
+        assert sources[0]["database"] == "MY_DB"
+        assert sources[0]["schema"] == "MY_SCHEMA"
+
+    def test_discover_skips_tables_without_name(self, tmp_path):
+        """Tables without a name key are skipped."""
+        models_dir = tmp_path / "models"
+        models_dir.mkdir(parents=True)
+
+        source_yaml = models_dir / "_sources.yml"
+        source_yaml.write_text(
+            "version: 2\n"
+            "sources:\n"
+            "  - name: raw\n"
+            "    database: DB\n"
+            "    schema: SCH\n"
+            "    tables:\n"
+            "      - name: valid_table\n"
+            "      - description: orphan with no name\n"
+        )
+
+        config = EnrichmentConfig(target_path=str(models_dir), sources_only=True)
+        service = MetadataEnrichmentService(config)
+        service.manifest_parser = MagicMock()
+        service.manifest_parser.source_locations = {}
+
+        sources = service._discover_sources()
+        assert len(sources) == 1
+        assert sources[0]["table_name"] == "valid_table"
+
+
+class TestEnrichServiceSourceIntegration:
+    """Integration tests for the full enrich() loop with sources."""
+
+    def test_enrich_with_sources_only(self, tmp_path):
+        """Full enrich() loop processes sources correctly."""
+        manifest = {
+            "metadata": {},
+            "nodes": {},
+            "sources": {
+                "source.proj.raw.orders": {
+                    "source_name": "raw",
+                    "name": "orders",
+                    "database": "DB",
+                    "schema": "SCH",
+                    "original_file_path": str(tmp_path / "_sources.yml"),
+                }
+            },
+        }
+        manifest_path = tmp_path / "target" / "manifest.json"
+        manifest_path.parent.mkdir(parents=True)
+        manifest_path.write_text(json.dumps(manifest))
+
+        source_yaml = tmp_path / "_sources.yml"
+        source_yaml.write_text(
+            "version: 2\n"
+            "sources:\n"
+            "  - name: raw\n"
+            "    database: DB\n"
+            "    schema: SCH\n"
+            "    tables:\n"
+            "      - name: orders\n"
+            "        columns: []\n"
+        )
+
+        config = EnrichmentConfig(
+            sources_only=True,
+            manifest_path=manifest_path,
+        )
+        service = MetadataEnrichmentService(config)
+
+        mock_client = MagicMock()
+        mock_client.execute_query.return_value = MagicMock(empty=False, iloc=MagicMock(__getitem__=lambda s, x: "USER"))
+        mock_client.metadata_manager.get_table_schema.return_value = [
+            {"name": "ID", "column_name": "ID", "type": "NUMBER(38,0)"},
+        ]
+        mock_client.metadata_manager.get_sample_values_batch.return_value = {}
+        service.snowflake_client = mock_client
+
+        from snowflake_semantic_tools.core.parsing.parsers.manifest_parser import ManifestParser
+
+        service.manifest_parser = ManifestParser(manifest_path)
+        service.manifest_parser.load()
+
+        from snowflake_semantic_tools.core.enrichment import MetadataEnricher, PrimaryKeyValidator, YAMLHandler
+
+        yaml_handler = YAMLHandler()
+        pk_validator = MagicMock()
+        service.enricher = MetadataEnricher(
+            snowflake_client=mock_client,
+            yaml_handler=yaml_handler,
+            primary_key_validator=pk_validator,
+            default_database="DB",
+            default_schema="SCH",
+        )
+
+        result = service.enrich()
+        assert result.status == "complete"
+        assert result.processed == 1
+        assert result.total == 1
+
+    def test_enrich_fail_fast_stops_on_source_error(self, tmp_path):
+        """fail_fast=True stops processing after first source failure."""
+        manifest = {
+            "metadata": {},
+            "nodes": {},
+            "sources": {
+                "source.proj.raw.orders": {
+                    "source_name": "raw",
+                    "name": "orders",
+                    "database": "DB",
+                    "schema": "SCH",
+                    "original_file_path": str(tmp_path / "_sources.yml"),
+                },
+                "source.proj.raw.customers": {
+                    "source_name": "raw",
+                    "name": "customers",
+                    "database": "DB",
+                    "schema": "SCH",
+                    "original_file_path": str(tmp_path / "_sources.yml"),
+                },
+            },
+        }
+        manifest_path = tmp_path / "target" / "manifest.json"
+        manifest_path.parent.mkdir(parents=True)
+        manifest_path.write_text(json.dumps(manifest))
+
+        source_yaml = tmp_path / "_sources.yml"
+        source_yaml.write_text(
+            "version: 2\n"
+            "sources:\n"
+            "  - name: raw\n"
+            "    database: DB\n"
+            "    schema: SCH\n"
+            "    tables:\n"
+            "      - name: orders\n"
+            "        columns: []\n"
+            "      - name: customers\n"
+            "        columns: []\n"
+        )
+
+        config = EnrichmentConfig(
+            sources_only=True,
+            manifest_path=manifest_path,
+            fail_fast=True,
+        )
+        service = MetadataEnrichmentService(config)
+
+        mock_client = MagicMock()
+        mock_client.execute_query.return_value = MagicMock(empty=False, iloc=MagicMock(__getitem__=lambda s, x: "USER"))
+        mock_client.metadata_manager.get_table_schema.return_value = None
+        mock_client.metadata_manager.get_sample_values_batch.return_value = {}
+        service.snowflake_client = mock_client
+
+        from snowflake_semantic_tools.core.parsing.parsers.manifest_parser import ManifestParser
+
+        service.manifest_parser = ManifestParser(manifest_path)
+        service.manifest_parser.load()
+
+        from snowflake_semantic_tools.core.enrichment import MetadataEnricher, PrimaryKeyValidator, YAMLHandler
+
+        yaml_handler = YAMLHandler()
+        pk_validator = MagicMock()
+        service.enricher = MetadataEnricher(
+            snowflake_client=mock_client,
+            yaml_handler=yaml_handler,
+            primary_key_validator=pk_validator,
+            default_database="DB",
+            default_schema="SCH",
+        )
+
+        result = service.enrich()
+        assert result.status == "failed"
+        assert len(result.errors) == 1
+        assert result.total == 2


### PR DESCRIPTION
## Description

Extends `sst enrich` to support dbt source definitions. Sources are the least-documented layer in most dbt projects — this brings them the same AI-powered enrichment that models already have.

New CLI flags:
- `--include-sources`: Enrich sources alongside models
- `--sources-only`: Enrich only sources (skip models)
- `--source raw.orders`: Enrich a specific source table

## Related Issue

Closes #134

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Test improvements

## Changes Made

- **ManifestParser**: Added `source_locations` cache from manifest `sources` section, `get_source_location()`, `get_all_sources()`
- **MetadataEnricher**: Added `enrich_source()` method parallel to `enrich_model()`, reuses `_process_columns_metadata()`
- **MetadataEnrichmentService**: Added `_discover_sources()` with manifest-first + YAML fallback discovery
- **CLI**: Three new flags with mutual exclusivity validation
- **Error codes**: SST-E006 to SST-E010 for source-specific error handling
- **YAMLHandler**: `has_sources()`, `find_source_table_in_yaml()`, `discover_source_yaml_files()`, spacing fix for `config:` blocks
- **Events**: Updated docstrings to reflect model+source dual use
- **Docs**: Updated `docs/cli/enrich.md`, `docs/reference/error-codes.md`, `docs/user-guide.md`

## Testing

- [x] Unit tests pass (`pytest tests/unit/`)
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Manual testing completed (if applicable)

### Test Results

```
1672 passed in 2.10s
```

### E2E Validation

- **sst-jaffle-shop**: All 7 sources enriched successfully with `--all`, dbt parse passes
- Error handling verified: restricted tables produce clean SST-E007 errors

## Checklist

### Code Quality
- [x] Code follows the project's style guidelines (Black, line length 120)
- [x] Imports sorted with isort (black profile)
- [x] Type hints added for new code
- [x] Docstrings added for public functions/classes
- [x] No linting errors

### Testing and Validation
- [x] All tests pass
- [x] New functionality has test coverage (57 new tests across 5 files)
- [x] Test results included above

### Documentation and Compatibility
- [x] Documentation updated
- [x] Backward compatibility maintained
- [x] No breaking changes

### Performance
- [x] Performance impact considered (single YAML read per file in discovery)
- [x] No significant performance regressions


